### PR TITLE
pipeline: adjust for repo move and rename

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -160,7 +160,7 @@ If working on your own repo, you will want to override the
 
 ```
 oc new-app --file=manifests/pipeline.yaml \
-    --param=REPO_URL=https://github.com/jlebon/fedora-coreos-ci \
+    --param=REPO_URL=https://github.com/jlebon/fedora-coreos-pipeline \
     --param=REPO_REF=my-feature-branch
 ```
 

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -9,15 +9,15 @@ metadata:
       Jenkins pipeline for Fedora CoreOS.
     iconClass: icon-jenkins
     openshift.io/display-name: Fedora CoreOS Pipeline
-    openshift.io/documentation-url: https://github.com/dustymabe/fedora-coreos-ci
-    openshift.io/support-url: https://github.com/dustymabe/fedora-coreos-ci
+    openshift.io/documentation-url: https://github.com/coreos/fedora-coreos-pipeline
+    openshift.io/support-url: https://github.com/coreos/fedora-coreos-pipeline
     openshift.io/provider-display-name: Fedora CoreOS
     tags: fcos,jenkins,fedora
   name: fedora-coreos
 parameters:
   - description: Git source URI for Jenkinsfile
     name: REPO_URL
-    value: https://github.com/dustymabe/fedora-coreos-ci
+    value: https://github.com/coreos/fedora-coreos-pipeline
   - description: Git branch/tag reference for Jenkinsfile
     name: REPO_REF
     value: master


### PR DESCRIPTION
The only thing that really changes is the default `REPO_URL` parameter.