### PR TITLE
pipeline: minor logic fixes with fileExists

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
         }
 
         def prevBuildID = null
-        if (utils.shwrap_rc("test -f builds/latest")) {
+        if (utils.path_exists("builds/latest")) {
             prevBuildID = utils.shwrap_capture("readlink builds/latest")
         }
 

--- a/utils.groovy
+++ b/utils.groovy
@@ -22,10 +22,15 @@ def shwrap_rc(cmds) {
     """)
 }
 
+// This is like fileExists, but actually works inside the Kubernetes container.
+def path_exists(path) {
+    return shwrap_rc("test -e ${path}") == 0
+}
+
 def rsync(from, to) {
 
     def rsync_keypath = "/var/run/secrets/kubernetes.io/duffy-key/duffy.key"
-    if (!fileExists(rsync_keypath)) {
+    if (!path_exists(rsync_keypath)) {
         echo "No ${rsync_keypath} file with rsync key."
         echo "Must be operating in dev environment"
         echo "Skipping rsync...."


### PR DESCRIPTION
Three fixes:

- First, `test -f builds/latest` will always fail because either it
  doesn't exist, or it does but it's a symlink, whereas `test -f` checks
  that it's a file.
- Second, `shwrap_rc()` returns the exit code. But in shell semantics, 0
  means successful, so the if-statement actually had an opposite logic.
  Of course taken together those two issues meant two negatives became a
  positive and it *seemed* like it worked when testing locally... So
  evil.
- Third, when checking for the SSH key, we were still using
  `fileExists()` which is broken inside Kubernetes containers.

So let's create a dedicated `path_exists()` which fixes all of this and
lowers the chances of getting this wrong again in the future. Note we
use `test -e` here to more closely match `fileExists()` (which really
doesn't actually care if it's a file or a directory or a link).