### PR TITLE
pipeline: fix rsync for prod

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -37,12 +37,12 @@ def rsync(from, to) {
         return
     }
 
-    def rsync_key = readFile(file: rsync_keypath)
-    rsync_key = rsync_key[0..12]
-
     shwrap("""
     # so we don't echo password to the jenkins logs
-    set +x; export RSYNC_PASSWORD=${rsync_key}; set -x
+    set +x
+    RSYNC_PASSWORD=\$(cat ${rsync_keypath})
+    export RSYNC_PASSWORD=\${RSYNC_PASSWORD:0:13}
+    set -x
     # always add trailing slash for consistent semantics
     rsync -avh --delete ${from}/ ${to}
     """)


### PR DESCRIPTION
Of course, just like `fileExists()` doesn't work well inside Kube
containers, neither does `readFile()`. Fix this by reverting back to
just reading and trimming in shell.

The larger issue here is that it's not easy to test the rsync bits
locally. Maybe we can fix this by replacing the simple-httpd stuff with
an artifact server deployment for local dev? Will look into it.