### PR TITLE
utils: don't use rsync -v, just use --stats

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -44,7 +44,7 @@ def rsync(from, to) {
     # so we don't echo password to the jenkins logs
     set +x; export RSYNC_PASSWORD=${rsync_key}; set -x
     # always add trailing slash for consistent semantics
-    rsync -avh --delete ${from}/ ${to}
+    rsync -ah --stats --delete ${from}/ ${to}
     """)
 }
 


### PR DESCRIPTION
We don't need every OSTree object synced in or out printed. That makes
the build logs a bit too spammy. Let's just settle for `--stats`, which
prints all the interesting info (e.g.  number of files created, total
sizes, total bytes sent, etc...