### PR TITLE
[WIP]: Fix tag for output of jenkins master bc

### DIFF
--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -68,7 +68,7 @@ objects:
       output:
         to:
           kind: ImageStreamTag
-          name: jenkins:2
+          name: jenkins:latest
           namespace: fedora-coreos
       successfulBuildsHistoryLimit: 2
       failedBuildsHistoryLimit: 2


### PR DESCRIPTION
The deployment is looking for `jenkins:latest`, not `jenkins:2`.