### PR TITLE
pipeline: run every 30 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,11 @@ node {
     }
 }
 
+properties([
+    disableConcurrentBuilds(),
+    pipelineTriggers(devel ? [] : [cron("H/30 * * * *")])
+])
+
 podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultContainer: 'jnlp') {
     node('coreos-assembler') { container('coreos-assembler') {
 


### PR DESCRIPTION
Right now, the pipeline is only ever triggered manually. Let's fire up
the engine here and start churning out builds at a regular interval. We
can reconsider turning this off down the line if we have sufficient
"push triggers" to safely disable the timer.

This makes use of the new devel flag that was added in the previous
patch.