### PR TITLE
pipeline: compress artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,9 +62,9 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
         }
 
         stage('Archive') {
+            // Change perms to allow reading on webserver side.
+            // Don't touch symlinks (https://github.com/CentOS/sig-atomic-buildscripts/pull/355)
             utils.shwrap("""
-            # Change perms to allow reading on webserver side.
-            # Don't touch symlinks (https://github.com/CentOS/sig-atomic-buildscripts/pull/355)
             find builds/ ! -type l -exec chmod a+rX {} +
             find repo/   ! -type l -exec chmod a+rX {} +
             """)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,6 +62,12 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
         }
 
         stage('Archive') {
+
+            // First, compress image artifacts
+            utils.shwrap("""
+            coreos-assembler compress
+            """)
+
             // Change perms to allow reading on webserver side.
             // Don't touch symlinks (https://github.com/CentOS/sig-atomic-buildscripts/pull/355)
             utils.shwrap("""


### PR DESCRIPTION
Make use of the new `compress` command in coreos-assembler to compress
the artifacts before syncing out.

Closes: #14