### PR TITLE
pipeline: prune less aggressively

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
 
         stage('Build') {
             utils.shwrap("""
-            coreos-assembler build
+            coreos-assembler build --skip-prune
             """)
         }
 
@@ -59,6 +59,12 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
             return
         } else {
             currentBuild.description = "⚡ ${newBuildID}"
+        }
+
+        stage('Prune') {
+            utils.shwrap("""
+            coreos-assembler prune --keep-last-n=10
+            """)
         }
 
         stage('Archive') {


### PR DESCRIPTION
Let's not keep only the last 3 builds here. That default is really to
appeal for the local dev case. I'm working towards adding a
`prune --keep-younger-than` switch to make it time based instead but for
now let's keep say... 15 builds so there's some semblance of permanence.