### PR TITLE
pipeline: fix `prune` invocation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
 
         stage('Prune') {
             utils.shwrap("""
-            coreos-assembler prune --keep-last-n=10
+            coreos-assembler prune --keep=10
             """)
         }
 


### PR DESCRIPTION
It's `--keep`, not `--keep-last-n`. (Though the underlying script that
does the work uses `--keep-last-n`.)