### PR TITLE
pipeline: nuke cache.qcow2 once it grows past 8G

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,6 +65,14 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
             utils.shwrap("""
             coreos-assembler prune --keep=10
             """)
+
+            // If the cache img is larger than e.g. 8G, then nuke it. Otherwise
+            // it'll just keep growing and we'll hit ENOSPC.
+            utils.shwrap("""
+            if [ \$(du cache/cache.qcow2 | cut -f1) -gt \$((1024*1024*8)) ]; then
+                rm -vf cache/cache.qcow2
+            fi
+            """)
         }
 
         stage('Archive') {


### PR DESCRIPTION
Otherwise, we'll just hit ENOSPC eventually. rpm-ostree doesn't/can't
know what it should delete since (not surprisingly) the cache is meant
to cache packages that may be used in the next compose.

We could try to be smart and e.g. only keep the latest NEVRA of all
packages, etc... but for now let's just let rpm-ostree re-download and
import it all once in a while. It's good to exercise the import code too
since it can subtly change between rpm-ostree versions.