### PR TITLE
pipeline: re-create cache.qcow2 after nuking it

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,6 +71,8 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
             utils.shwrap("""
             if [ \$(du cache/cache.qcow2 | cut -f1) -gt \$((1024*1024*8)) ]; then
                 rm -vf cache/cache.qcow2
+                qemu-img create -f qcow2 cache/cache.qcow2 10G
+                LIBGUESTFS_BACKEND=direct virt-format --filesystem=xfs -a cache/cache.qcow2
             fi
             """)
         }


### PR DESCRIPTION
When testing #39, I had only tested that the qcow2 gets nuked. The
issue is that the *next* build will error out since it expects the qcow2
to already be created.

Simply switch to always running `coreos-assembler init --force` since
it's idempotent anyway so it'll only recreate the qcow2 if it was nuked
in the previous run.