### PR TITLE
pipeline: start building installer ISOs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,12 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
             currentBuild.description = "⚡ ${newBuildID}"
         }
 
+        stage('Build Installer') {
+            utils.shwrap("""
+            coreos-assembler buildextend-installer
+            """)
+        }
+
         stage('Prune') {
             utils.shwrap("""
             coreos-assembler prune --keep=10


### PR DESCRIPTION
Start using the new `buildextend-installer` command from:
https://github.com/coreos/coreos-assembler/pull/306