### PR TITLE
pvc: use coreos-assembler-claim2 in centos CI

### DIFF
--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -123,7 +123,7 @@ objects:
   - apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
-      name: coreos-assembler-claim
+      name: coreos-assembler-claim2
       namespace: fedora-coreos
     spec:
       accessModes:

--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -27,7 +27,7 @@ spec:
   volumes:
   - name: data
     persistentVolumeClaim:
-      claimName: coreos-assembler-claim
+      claimName: coreos-assembler-claim2
   - name: duffy-key
     secret:
       secretName: duffy.key

--- a/manifests/sleep.yaml
+++ b/manifests/sleep.yaml
@@ -23,7 +23,7 @@ spec:
   volumes:
   - name: data
     persistentVolumeClaim:
-      claimName: coreos-assembler-claim
+      claimName: coreos-assembler-claim2
   - name: duffy-key
     secret:
       secretName: duffy.key


### PR DESCRIPTION
Brian created us a new PVC and the claim has a new name because
we needed the other one around while we copied it over.