### PR TITLE
pipeline: make PVC_SIZE a template parameter

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -176,6 +176,10 @@ This template creates:
 4. the `PersistentVolumeClaim` in which we'll cache and compose, and
 5. the Jenkins pipeline build.
 
+The default size of the PVC is 100Gi. There is a `PVC_SIZE`
+parameter one can use to make this smaller if you do not
+have enough space. E.g. `--param=PVC_SIZE=30Gi`.
+
 We can now start a build of the Jenkins master:
 
 ```

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -21,6 +21,9 @@ parameters:
   - description: Git branch/tag reference for Jenkinsfile
     name: REPO_REF
     value: master
+  - description: Size of the PVC to create
+    name: PVC_SIZE
+    value: 100Gi
 objects:
 
   ### JENKINS MASTER ###
@@ -130,7 +133,7 @@ objects:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 100Gi
+          storage: ${PVC_SIZE}
 
   ### FEDORA COREOS BUILD PIPELINE ###
 


### PR DESCRIPTION
Allow developers to easily customize it if they don't have 100Gi to
spare.