### PR TITLE
Add support for developer pipelines

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -6,6 +6,21 @@ These instructions will cover both local developer workflows, as well as
 interacting with the production pipeline in CentOS CI. A section header
 may indicate that the section only applies to one of the two workflows.
 
+Another option if one simply wants to test a different COSA image or
+FCOS config or pipeline code (but otherwise maintain the manifest the
+same) is to create a developer pipeline alongside the production one. To
+do this, you *must* use the `devel-up` script. For example:
+
+```
+./devel-up --update \
+        --pipeline https://github.com/jlebon/fedora-coreos-pipeline \
+        --config https://github.com/jlebon/fedora-coreos-config@feature \
+        --cosa-img quay.io/jlebon/coreos-assembler:random-tag
+```
+
+Now carrying on with the instructions for setting up the environment
+from scratch...
+
 ### [LOCAL] Set up an OpenShift cluster
 
 First, make sure to install `oci-kvm-hook` on your host system (not in a
@@ -151,18 +166,23 @@ the Jenkins pipeline).
 
 ### Create the pipeline from the template
 
-If working on the production pipeline, or you're not
-planning any modifications, you may simply do:
+If working on the production pipeline, you may simply do:
 
 ```
 oc new-app --file=manifests/pipeline.yaml
 ```
 
-If working on your own repo, you will want to override the
+If working on a local cluster you will want to define the `DEVEL_PREFIX`
+parameter to be e.g. `$USER-`. The pipeline will simply not run without
+a `DEVEL_PREFIX` set if it is not running in prod mode.
+
+There are additional useful parameters for the devel case. For example,
+to use a custom pipeline repo, you'll want to override the
 `PIPELINE_REPO_URL` and `PIPELINE_REPO_REF` parameters:
 
 ```
 oc new-app --file=manifests/pipeline.yaml \
+    --param=DEVEL_PREFIX=$(whoami)- \
     --param=PIPELINE_REPO_URL=https://github.com/jlebon/fedora-coreos-pipeline \
     --param=PIPELINE_REPO_REF=my-feature-branch
 ```

--- a/devel-up
+++ b/devel-up
@@ -1,0 +1,149 @@
+#!/usr/bin/python3
+
+'''
+    Tiny convenient and *safe* wrapper around `oc process/apply` for devel
+    pipelines. Can be run multiple times; subsequent runs will replace existing
+    resources.
+
+    Example usage:
+        ./devel-up --update \
+            --pipeline https://github.com/jlebon/fedora-coreos-pipeline \
+            --config https://github.com/jlebon/fedora-coreos-config@wip \
+            --cosa-img quay.io/jlebon/coreos-assembler:master
+            # OR
+            --cosa https://github.com/jlebon/coreos-assembler
+
+    Deleting devel pipeline:
+        ./devel-up --delete
+'''
+
+import os
+import sys
+import json
+import argparse
+import subprocess
+
+
+def main():
+    args = parse_args()
+    resources = process_template(args)
+
+    if args.update:
+        update_resources(args, resources)
+
+        if args.start:
+            print("Starting:")
+            out = subprocess.run(['oc', 'start-build',
+                                  # hack the name; should extract from manifest
+                                  f'{args.prefix}fedora-coreos-pipeline'],
+                                 check=True, stdout=subprocess.PIPE,
+                                 encoding='utf-8')
+            print(f"  {out.stdout.strip()}")
+            print()
+        else:
+            print("You may start your devel pipeline with:")
+            print(f"  oc start-build {args.prefix}fedora-coreos-pipeline")
+            print()
+    else:
+        assert args.delete
+
+        delete_resources(args, resources)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument("--update", action='store_true',
+                        help="Create or update devel pipeline")
+    action.add_argument("--delete", action='store_true',
+                        help="Delete devel pipeline")
+    parser.add_argument("--start", action='store_true',
+                        help="Start build after updating it")
+    parser.add_argument("--prefix", help="Devel prefix to use for resources",
+                        default=get_username())
+    parser.add_argument("--pipeline", metavar='<URL>[@REF]',
+                        help="Repo and ref to use for pipeline code")
+    parser.add_argument("--config", metavar='<URL>[@REF]',
+                        help="Repo and ref to use for FCOS config")
+    parser.add_argument("--cosa-img", metavar='FQIN',
+                        help="Pullspec to use for COSA image")
+    # XXX: to add as a mutually exclusive option with above
+    # parser.add_argument("--cosa", metavar='<URL>[@REF]',
+    #                     help="Repo and ref to use for COSA image",
+    #                     default=DEFAULT_COSA_IMG)
+
+    args = parser.parse_args()
+
+    # just sanity check we have a prefix
+    assert len(args.prefix)
+    assert not args.prefix.endswith('-'), "Prefix must not end with dash"
+
+    # e.g. jlebon --> jlebon-fedora-coreos-pipeline
+    args.prefix += '-'
+
+    return args
+
+
+def get_username():
+    import pwd
+    return pwd.getpwuid(os.getuid()).pw_name
+
+
+def process_template(args):
+    params = [f'DEVEL_PREFIX={args.prefix}']
+    if args.pipeline:
+        params += params_from_git_refspec(args.pipeline, 'PIPELINE_REPO')
+    if args.config:
+        params += params_from_git_refspec(args.config, 'PIPELINE_FCOS_CONFIG')
+    if args.cosa_img:
+        params += [f'COREOS_ASSEMBLER_IMAGE={args.cosa_img}']
+
+    print("Parameters:")
+    for param in params:
+        print(f"  {param}")
+    params = [q for p in params for q in ['--param', p]]
+    print()
+
+    resources = subprocess.check_output(
+        ['oc', 'process', '--filename', 'manifests/pipeline.yaml'] + params)
+    return json.loads(resources)
+
+
+def update_resources(args, resources):
+    # final safety check: only actually create/update prefixed resources
+    print("Updating:")
+    for resource in resources['items']:
+        if resource['metadata']['name'].startswith(args.prefix):
+            out = subprocess.run(['oc', 'apply', '--filename', '-'],
+                                 input=json.dumps(resource), encoding='utf-8',
+                                 check=True, stdout=subprocess.PIPE)
+            print(f"  {out.stdout.strip()}")
+    print()
+
+
+def delete_resources(args, resources):
+    # only delete prefixed resources
+    print("Deleting:")
+    for resource in resources['items']:
+        if resource['metadata']['name'].startswith(args.prefix):
+            out = subprocess.run(['oc', 'delete', '--filename', '-'],
+                                 input=json.dumps(resource), encoding='utf-8',
+                                 check=True, stdout=subprocess.PIPE)
+            print(f"  {out.stdout.strip()}")
+    print()
+
+
+def params_from_git_refspec(refspec, param_prefix):
+    url, ref = parse_git_refspec(refspec)
+    return [f'{param_prefix}_URL={url}',
+            f'{param_prefix}_REF={ref}']
+
+
+def parse_git_refspec(refspec):
+    if '@' not in refspec:
+        return (refspec, 'master')
+    return tuple(refspec.split('@'))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/devel-up
+++ b/devel-up
@@ -65,6 +65,8 @@ def parse_args():
                         help="Repo and ref to use for pipeline code")
     parser.add_argument("--config", metavar='<URL>[@REF]',
                         help="Repo and ref to use for FCOS config")
+    parser.add_argument("--bucket", metavar='BUCKET',
+                        help="AWS S3 bucket to use")
     parser.add_argument("--cosa-img", metavar='FQIN',
                         help="Pullspec to use for COSA image")
     # XXX: to add as a mutually exclusive option with above
@@ -95,6 +97,8 @@ def process_template(args):
         params += params_from_git_refspec(args.pipeline, 'PIPELINE_REPO')
     if args.config:
         params += params_from_git_refspec(args.config, 'PIPELINE_FCOS_CONFIG')
+    if args.bucket:
+        params += [f'S3_BUCKET={args.bucket}']
     if args.cosa_img:
         params += [f'COREOS_ASSEMBLER_IMAGE={args.cosa_img}']
 

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -21,9 +21,24 @@ parameters:
   - description: Git branch/tag reference for pipeline Jenkinsfile
     name: PIPELINE_REPO_REF
     value: master
+  - description: Prefix to prepend to resources
+    name: DEVEL_PREFIX
+    value:
+  - description: Git source URI for FCOS config
+    name: PIPELINE_FCOS_CONFIG_URL
+    value: https://github.com/coreos/fedora-coreos-config
+  - description: Git branch/tag reference for FCOS config
+    name: PIPELINE_FCOS_CONFIG_REF
+    value: master
   - description: Size of the PVC to create
     name: PVC_SIZE
     value: 100Gi
+  - description: Image of coreos-assembler to use
+    name: COREOS_ASSEMBLER_IMAGE
+    # for now we just follow :master, but we may start freezing if things become
+    # too unstable
+    value: quay.io/coreos-assembler/coreos-assembler:master
+
 objects:
 
   ### JENKINS MASTER ###
@@ -105,7 +120,7 @@ objects:
   - apiVersion: v1
     kind: ImageStream
     metadata:
-      name: coreos-assembler
+      name: ${DEVEL_PREFIX}coreos-assembler
       namespace: fedora-coreos
     spec:
       lookupPolicy:
@@ -115,9 +130,7 @@ objects:
         - name: master
           from:
             kind: DockerImage
-            # for now we just follow :master, but we may start freezing if
-            # things become too unstable
-            name: quay.io/coreos-assembler/coreos-assembler:master
+            name: ${COREOS_ASSEMBLER_IMAGE}
           importPolicy:
             scheduled: true
 
@@ -140,7 +153,14 @@ objects:
   - kind: BuildConfig
     apiVersion: "build.openshift.io/v1"
     metadata:
-      name: "fedora-coreos-pipeline"
+      name: ${DEVEL_PREFIX}fedora-coreos-pipeline
+      # We use annotations as a way to pass information from the bc (and thus
+      # from `oc new-app/process` time) to the Groovy code. This allows us to
+      # centralize all the major knobs in this file for easier management.
+      annotations:
+        coreos.com/source-config-url: ${PIPELINE_FCOS_CONFIG_URL}
+        coreos.com/source-config-ref: ${PIPELINE_FCOS_CONFIG_REF}
+        coreos.com/devel-prefix: ${DEVEL_PREFIX}
     spec:
       # Define triggers.
       #   - trigger on buildconfig change
@@ -161,7 +181,7 @@ objects:
         imageChange:
           from:
             kind: ImageStreamTag
-            name: coreos-assembler:master
+            name: ${DEVEL_PREFIX}coreos-assembler:master
       source:
         type: Git
         git:

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -38,6 +38,9 @@ parameters:
     # for now we just follow :master, but we may start freezing if things become
     # too unstable
     value: quay.io/coreos-assembler/coreos-assembler:master
+  - description: AWS S3 bucket in which to store builds (or blank for none)
+    name: S3_BUCKET
+    value: fcos-builds
 
 objects:
 
@@ -161,6 +164,7 @@ objects:
         coreos.com/source-config-url: ${PIPELINE_FCOS_CONFIG_URL}
         coreos.com/source-config-ref: ${PIPELINE_FCOS_CONFIG_REF}
         coreos.com/devel-prefix: ${DEVEL_PREFIX}
+        coreos.com/s3-bucket: ${S3_BUCKET}
     spec:
       # Define triggers.
       #   - trigger on buildconfig change

--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -11,7 +11,7 @@ spec:
      image: jenkins-slave-base-centos7:latest
      args: ['$(JENKINS_SECRET)', '$(JENKINS_NAME)']
    - name: coreos-assembler
-     image: coreos-assembler:master
+     image: COREOS_ASSEMBLER_IMAGE
      imagePullPolicy: Always
      command: ['/usr/bin/dumb-init']
      args: ['sleep', 'infinity']


### PR DESCRIPTION
So, a lot happening in this patch, but essentially the idea is:

1. add some more parameters to the template to support "devel" resources
2. add annotations to the pipeline buildconfig to allow us to pass data
   to the pipeline code; update the pipeline to pick this up
3. allow uploading to S3 in devel mode using the provided devel prefix
4. add a new `devel-up` utility to make it easier and safer to create
   and update devel pipelines; no way to delete them yet, will do that
   in a follow up

The reason for the `devel-up` utility is that I wanted more "semantic"
control over the way devel resources are created than through directly
using parameters, especially around ensuring that they absolutely do not
modify prod resources. But also, it's much more convenient to use than
overriding each param one by one.