### PR TITLE
manifests/pipeline: remove namespace params from template

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -140,7 +140,6 @@ like `fedora-coreos-devel` if you'd like.
 
 ```
 oc new-project fedora-coreos
-oc delete project myproject
 ```
 
 And you're all set!

--- a/HACKING.md
+++ b/HACKING.md
@@ -134,7 +134,9 @@ oc login -u developer https://127.0.0.1:8443
 (Any password will work). The IP address to log in here may differ
 according to the output from `oc cluster up`.
 
-We'll want to match the project name used in CentOS CI:
+Ideally you will match the project name used for prod in CentOS CI
+(`fedora-coreos`), but feel free to use a different project name
+like `fedora-coreos-devel` if you'd like.
 
 ```
 oc new-project fedora-coreos

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -52,7 +52,6 @@ objects:
     kind: ImageStream
     metadata:
       name: jenkins-s2i
-      namespace: fedora-coreos
     spec:
       tags:
         - name: stable
@@ -64,7 +63,6 @@ objects:
     kind: ImageStream
     metadata:
       name: jenkins
-      namespace: fedora-coreos
   - kind: BuildConfig
     apiVersion: v1
     metadata:
@@ -90,7 +88,6 @@ objects:
         to:
           kind: ImageStreamTag
           name: jenkins:latest
-          namespace: fedora-coreos
       successfulBuildsHistoryLimit: 2
       failedBuildsHistoryLimit: 2
 
@@ -102,7 +99,6 @@ objects:
     kind: ImageStream
     metadata:
       name: jenkins-slave-base-centos7
-      namespace: fedora-coreos
     spec:
       lookupPolicy:
         # this allows e.g. the pipeline to directly reference the imagestream
@@ -124,7 +120,6 @@ objects:
     kind: ImageStream
     metadata:
       name: ${DEVEL_PREFIX}coreos-assembler
-      namespace: fedora-coreos
     spec:
       lookupPolicy:
         # this allows e.g. the pipeline to directly reference the imagestream
@@ -143,7 +138,6 @@ objects:
     kind: PersistentVolumeClaim
     metadata:
       name: coreos-assembler-claim2
-      namespace: fedora-coreos
     spec:
       accessModes:
       - ReadWriteOnce


### PR DESCRIPTION
This allows for someone running in a different namespace/project
than `fedora-coreos`.