### PR TITLE
pipeline: stop using /srv as workdir

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -238,7 +238,7 @@ This template creates:
 1. the Jenkins master imagestream,
 2. the Jenkins slave imagestream,
 3. the coreos-assembler imagestream,
-4. the `PersistentVolumeClaim` in which we'll cache and compose, and
+4. the `PersistentVolumeClaim` in which we'll cache, and
 5. the Jenkins pipeline build.
 
 The default size of the PVC is 100Gi. There is a `PVC_SIZE`

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,8 +158,6 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
             utils.shwrap("""
             if [ \$(du cache/cache.qcow2 | cut -f1) -gt \$((1024*1024*8)) ]; then
                 rm -vf \$(realpath cache/cache.qcow2)
-                qemu-img create -f qcow2 cache/cache.qcow2 10G
-                LIBGUESTFS_BACKEND=direct virt-format --filesystem=xfs -a cache/cache.qcow2
             fi
             """)
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,6 +76,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
 
             def ref = params.STREAM
             if (src_config_ref != "") {
+                assert !prod : "Asked to override ref in prod mode"
                 ref = src_config_ref
             }
 

--- a/utils.groovy
+++ b/utils.groovy
@@ -1,9 +1,6 @@
-workdir = env.WORKSPACE
-
 def shwrap(cmds) {
     sh """
         set -xeuo pipefail
-        cd ${workdir}
         ${cmds}
     """
 }
@@ -11,7 +8,6 @@ def shwrap(cmds) {
 def shwrap_capture(cmds) {
     return sh(returnStdout: true, script: """
         set -euo pipefail
-        cd ${workdir}
         ${cmds}
     """).trim()
 }
@@ -19,7 +15,6 @@ def shwrap_capture(cmds) {
 def shwrap_rc(cmds) {
     return sh(returnStatus: true, script: """
         set -euo pipefail
-        cd ${workdir}
         ${cmds}
     """)
 }


### PR DESCRIPTION
I think we should stop using `/srv` as a workdir entirely and just
always build in the workspace. The core issue here is that (1) we want
to be able to have concurrent builds, and (2) a cosa workdir can't be
easily shared today. This also simplifies the devel vs prod logic quite
a bit since it had some funky conditionals around this.

So then, how can developers without S3 creds actually *access* built
artifacts? We simply archive them as part of the build. This is in line
also with #31, where we'll probably be archiving things anyway.

Finally, how *can* we use the PVC as cache in a safe way shareable
across all the streams? I see two options offhand:
1. as a local RPM mirror: add flags and logic to `cosa fetch` to read &
   write RPMs in `/srv`, hold a lock to regen metadata
2. as a pkgcache repo: similarly to the above, but also doing the
   import, so it's just a pkgcache repo; this would probably require
   teaching rpm-ostree about this, or `cosa fetch` could just blindly
   import every ref