### PR TITLE
deploy: fix referenced before assignment bug

### DIFF
--- a/deploy
+++ b/deploy
@@ -128,8 +128,9 @@ def get_username():
 
 
 def process_template(args):
+    params = []
     if not args.official:
-        params = [f'DEVELOPER_PREFIX={args.prefix}']
+        params += [f'DEVELOPER_PREFIX={args.prefix}']
     if args.pipeline:
         params += params_from_git_refspec(args.pipeline, 'PIPELINE_REPO')
     if args.config:


### PR DESCRIPTION
otherwise in `--official` mode you see:

```
Traceback (most recent call last):
  File "./deploy", line 235, in <module>
    sys.exit(main())
  File "./deploy", line 35, in main
    resources = process_template(args)
  File "./deploy", line 134, in process_template
    params += params_from_git_refspec(args.pipeline, 'PIPELINE_REPO')
UnboundLocalError: local variable 'params' referenced before assignment
```