### PR TITLE
deploy: use `oc replace` instead of `oc apply`

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -8,7 +8,7 @@ a separate cluster entirely.
 
 The main tool to deploy and update these resource is `./deploy`, which
 is located in this repo. It is a simple wrapper around
-`oc process/create/apply` to make deploying and updating the various
+`oc process/create/replace` to make deploying and updating the various
 resources located in the `manifests/pipeline.yaml` OpenShift template
 easier. It will set up a Jenkins pipeline job which uses the
 [Kubernetes Jenkins plugin](https://github.com/jenkinsci/kubernetes-plugin).

--- a/deploy
+++ b/deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 '''
-    Convenient wrapper around `oc process/create/apply`. Can be run multiple
+    Convenient wrapper around `oc process/create/replace`. Can be run multiple
     times; subsequent runs will replace existing resources.
 
     Example usage:
@@ -180,7 +180,7 @@ def resource_action(resource):
         if kind in ['persistentvolumeclaim']:
             print(f"  {kind} \"{resource['metadata']['name']}\" skipped")
             return 'skip'
-        return 'apply'
+        return 'replace'
     return 'create'
 
 


### PR DESCRIPTION
I now understand better the difference between `oc apply` and `oc
replace`. The former accepts partial specs and is capable of updating
just parts of the objects, similar to a patch.  Whereas `oc replace`
will completely replace the object.

Here we want the latter. E.g. if we drop out a field from a list, we
also want it to drop out of the object on the next `./deploy`. Our
manifest should be canonical.