### PR TITLE
streams: use `--wait` so we wait and report errors if downstream fails

### DIFF
--- a/streams.groovy
+++ b/streams.groovy
@@ -36,9 +36,10 @@ def triggered_by_push() {
 
 // Starts a stream build.
 def build_stream(stream) {
-    // use `oc start-build` instead of the build step
+    // Use `oc start-build` instead of the build step:
     // https://bugzilla.redhat.com/show_bug.cgi?id=1580468
-    sh "oc start-build fedora-coreos-pipeline -e STREAM=${stream}"
+    // With `--wait`, we'll error out if the build actually failed.
+    sh "oc start-build --wait fedora-coreos-pipeline -e STREAM=${stream}"
 }
 
 return this


### PR DESCRIPTION
I actually wanted to have "blocking" semantics from the beginning, but
abandoned on that when switching away from the `build` step. And I
didn't think to try `oc start-build --wait`. There's `--follow` too, but
it doesn't work with Jenkins pipelines.

We can probably improve on this in the future by capturing the build
name, and printing a link to the Jenkins console for that build.