### PR TITLE
pipeline: stop rsync'ing to artifact server completely

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -317,9 +317,9 @@ Repeat these steps for the `fedora-coreos-pipeline` repo.
 ### [OPTIONAL] Set up simple-httpd
 
 When hacking locally, it might be useful to look at the contents of the
-PV to see the builds since one isn't rsync'ing to an artifact server.
-One alternative to creating a "sleeper" pod with the PV mounted is to
-expose a simple httpd server:
+PV to see the builds if one isn't uploading to S3. One alternative to
+creating a "sleeper" pod with the PV mounted is to expose a simple httpd
+server:
 
 ```
 oc create -f manifests/simple-httpd.yaml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -178,8 +178,6 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
         }
 
         stage('Archive') {
-
-            // First, compress image artifacts
             utils.shwrap("""
             coreos-assembler compress
             """)
@@ -199,24 +197,6 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
               mkdir -p ${developer_builddir}
               cp -aT builds ${developer_builddir}
               """)
-            }
-
-            // XXX: For now, we keep uploading the latest build to the artifact
-            // server to make it easier for folks to access since we don't have
-            // a stream metadata frontend/website set up yet. The key part here
-            // is that it is *not* the canonical storage for builds.
-
-            // Change perms to allow reading on webserver side.
-            // Don't touch symlinks (https://github.com/CentOS/sig-atomic-buildscripts/pull/355)
-            utils.shwrap("""
-            find builds/ ! -type l -exec chmod a+rX {} +
-            """)
-
-            // Note that if the prod directory doesn't exist on the remote this
-            // will fail. We can possibly hack around this in the future:
-            // https://stackoverflow.com/questions/1636889
-            if (official) {
-                utils.rsync_out("builds", "builds")
             }
         }
     }}

--- a/utils.groovy
+++ b/utils.groovy
@@ -35,33 +35,4 @@ def path_exists(path) {
     return shwrap_rc("test -e ${path}") == 0
 }
 
-def rsync(from, to) {
-
-    def rsync_keypath = "/var/run/secrets/kubernetes.io/duffy-key/duffy.key"
-    if (!path_exists(rsync_keypath)) {
-        echo "No ${rsync_keypath} file with rsync key."
-        echo "Must be operating in dev environment"
-        echo "Skipping rsync...."
-        return
-    }
-
-    shwrap("""
-    # so we don't echo password to the jenkins logs
-    set +x
-    RSYNC_PASSWORD=\$(cat ${rsync_keypath})
-    export RSYNC_PASSWORD=\${RSYNC_PASSWORD:0:13}
-    set -x
-    # always add trailing slash for consistent semantics
-    rsync -ah --stats --delete ${from}/ ${to}
-    """)
-}
-
-def rsync_in(from, to) {
-    rsync("fedora-coreos@artifacts.ci.centos.org::fedora-coreos/prod/${from}", "${to}")
-}
-
-def rsync_out(from, to) {
-    rsync("${from}", "fedora-coreos@artifacts.ci.centos.org::fedora-coreos/prod/${to}")
-}
-
 return this


### PR DESCRIPTION
Now that we have S3 uploads set up, let's stop the "compat" rsync'ing to
the artifact server. Instead, I propose we leave a single file there
which points people to https://builds.coreos.fedoraproject.org/browser.

Once we're officially in preview mode, we can evaluate whether we should
make the above less accessible, or perhaps simply dropping the prod
streams from the dropdown.