### PR TITLE
Jenkinsfile: add step for building release metadata

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,7 +171,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
             // which will generate a release.json from the meta.json files
             utils.shwrap("""
             git clone https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng
-            /var/tmp/fcos-releng/coreos-meta-translator/trans.py --workdir .
+            /var/tmp/fcos-releng/coreos-meta-translator/trans.py --workdir . || true
             """)
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,6 +166,15 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
             }
         }
 
+        stage('Build Release Metadata') {
+            // Run the coreos-meta-translator against the most recent build,
+            // which will generate a release.json from the meta.json files
+            utils.shwrap("""
+            git clone https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng
+            /var/tmp/fcos-releng/coreos-meta-translator/trans.py --workdir .
+            """)
+        }
+
         stage('Prune Cache') {
             // If the cache img is larger than e.g. 8G, then nuke it. Otherwise
             // it'll just keep growing and we'll hit ENOSPC. Use realpath since


### PR DESCRIPTION
Adds a step which downloads the `fedora-coreos-releng-automation` repo
and runs the `coreos-meta-translator` against the current build to
produce `release.json` files.