### PR TITLE
Jenkinsfile: add Publish step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -199,5 +199,15 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
               """)
             }
         }
+
+        if (official) {
+            stage('Publish') {
+                // Run plume to publish official builds; This will handle modifying
+                // object ACLs and creating/modifying the releases.json metadata index
+                utils.shwrap("""
+                coreos-assembler shell plume release --distro fcos --version ${newBuildID} --channel ${params.STREAM} --bucket ${s3_bucket}
+                """)
+            }
+        }
     }}
 }


### PR DESCRIPTION
Adds a publish step for official builds that runs plume against the
version/stream. This will modify all object ACLs for the given build to
be public-read and create or modify the releases.json metadata index.

Requires coreos/coreos-assembler#606