### PR TITLE
production: disable all triggers for now

### DIFF
--- a/Jenkinsfile.production
+++ b/Jenkinsfile.production
@@ -6,7 +6,8 @@ node {
 }
 
 properties([
-    pipelineTriggers(streams.get_push_trigger())
+    // no triggers; we'll drive production releases manually in the short-term
+    pipelineTriggers([])
 ])
 
 node {


### PR DESCRIPTION
In the short-term, we'll be triggering production (i.e. `testing`)
builds manually. Other streams are unaffected (`testing-devel` and
`bodhi-updates`).

This is so that we can manually drive versioning for the time being
until we have something automated in place.