### PR TITLE
doc: document getting access to Jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,20 @@ The production instance is running in
 [CentOS CI](https://jenkins-fedora-coreos.apps.ci.centos.org)
 (though note anonymous view is blocked by default).
 
-To have access to Jenkins (or more generally to the
-production namespace), you must open a bug request at
+To operate Jenkins (or more generally to access the
+production namespace), you must have access to the cluster
+at https://console.apps.ci.centos.org:8443 and to the projects
+"fedora-coreos" and "fedora-coreos-devel".
+
+If you need access, you can open a bug request at
 https://bugs.centos.org/ against the `Buildsys` project and
-`Ci.centos.org Ecosystem Testing` category and ask to be
-added to the `fedora-coreos` and `fedora-coreos-devel`
-projects. After one of the project admins sponsors you,
-you'll be given access.
+`Ci.centos.org Ecosystem Testing` category.
+Do note that the bug-tracker and OpenShift use different
+authentication backends, so you will have separate credentials
+for each.
+
+Please specify the requested username, RBAC for projects
+`fedora-coreos` and `fedora-coreos-devel`, and your GPG key
+fingerprint.
+You also need one of the project admins as a sponsor, please
+reach out on Freenode `#fedora-coreos` channel.


### PR DESCRIPTION
Align instructions with the actual process, and make them more explicit.