### PR TITLE
Jenkinsfile: drop `|| true` hack

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,7 +171,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
             // which will generate a release.json from the meta.json files
             utils.shwrap("""
             git clone https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng
-            /var/tmp/fcos-releng/coreos-meta-translator/trans.py --workdir . || true
+            /var/tmp/fcos-releng/coreos-meta-translator/trans.py --workdir .
             """)
         }
 


### PR DESCRIPTION
We shouldn't need this anymore. All streams have now migrated to the new
layout.