### PR TITLE
Jenkinsfile: call plume directly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,7 +223,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
                 // Run plume to publish official builds; This will handle modifying
                 // object ACLs and creating/modifying the releases.json metadata index
                 utils.shwrap("""
-                coreos-assembler shell plume release --distro fcos --version ${newBuildID} --channel ${params.STREAM} --bucket ${s3_bucket}
+                plume release --distro fcos --version ${newBuildID} --channel ${params.STREAM} --bucket ${s3_bucket}
                 """)
             }
         }


### PR DESCRIPTION
We're already running inside the container, where `plume` is already in
the path, so we don't need to go through `cosa shell` for it.

I don't think that's the root cause of
https://github.com/coreos/mantle/issues/1023, but worth doing
regardless.