### PR TITLE
Jenkinsfile: directly reference aws creds location

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,7 +223,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
                 // Run plume to publish official builds; This will handle modifying
                 // object ACLs and creating/modifying the releases.json metadata index
                 utils.shwrap("""
-                plume release --distro fcos --version ${newBuildID} --channel ${params.STREAM} --bucket ${s3_bucket} --aws-credentials ${env.AWS_CONFIG_FILE}
+                plume release --distro fcos --version ${newBuildID} --channel ${params.STREAM} --bucket ${s3_bucket} --aws-credentials /.aws/config
                 """)
             }
         }


### PR DESCRIPTION
We already run `test -e` against this hard-coded path, switch the plume
call to using it directly as well.