### PR TITLE
Jenkinsfile: start uploading AMIs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -183,6 +183,8 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
                     // also publish vmdks, we could make this more efficient by
                     // uploading first, and then pointing ore at our uploaded vmdk
                     utils.shwrap("""
+                    # https://github.com/coreos/mantle/issues/1023
+                    export AWS_SDK_LOAD_CONFIG=1
                     coreos-assembler buildextend-aws ${suffix} \
                         --build=${newBuildID} \
                         --region=us-east-1 \
@@ -242,11 +244,12 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
                 // Run plume to publish official builds; This will handle modifying
                 // object ACLs and creating/modifying the releases.json metadata index
                 utils.shwrap("""
+                # https://github.com/coreos/mantle/issues/1023
+                export AWS_SDK_LOAD_CONFIG=1
                 plume release --distro fcos \
                     --version ${newBuildID} \
                     --channel ${params.STREAM} \
-                    --bucket ${s3_bucket} \
-                    --aws-credentials /.aws/config
+                    --bucket ${s3_bucket}
                 """)
 
                 if (!params.MINIMAL) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -221,7 +221,11 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
                 // Run plume to publish official builds; This will handle modifying
                 // object ACLs and creating/modifying the releases.json metadata index
                 utils.shwrap("""
-                plume release --distro fcos --version ${newBuildID} --channel ${params.STREAM} --bucket ${s3_bucket} --aws-credentials /.aws/config
+                plume release --distro fcos \
+                    --version ${newBuildID} \
+                    --channel ${params.STREAM} \
+                    --bucket ${s3_bucket} \
+                    --aws-credentials /.aws/config
                 """)
             }
         }


### PR DESCRIPTION
There are a few undesirable things in here, but it will do for now. E.g.
we're not replicating across multiple regions, nor are we uploading
separate vmdks.

There's a lot of stuff around this that the RHCOS team has internally.
We should look to upstreaming it into cosa (or replacing it with
existing functionality in mantle and extending as necessary), so that it
can be shared with FCOS.

For now, we're just patching things together so we at least have
`us-east-1` for preview.