### PR TITLE
Jenkinsfile: add CHECKSUMS file in uploads

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,6 +223,11 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
               // just upload as public-read for now, but see discussions in
               // https://github.com/coreos/fedora-coreos-tracker/issues/189
               utils.shwrap("""
+              # XXX: until we have e.g. `cosa sign` in place:
+              # https://github.com/coreos/coreos-assembler/issues/268
+              find builds/${newBuildID} -type f | xargs sha256sum | tee CHECKSUMS
+              sha256sum CHECKSUMS
+              mv CHECKSUMS builds/${newBuildID}
               coreos-assembler buildupload s3 --acl=public-read ${s3_builddir}
               """)
             } else if (!official) {


### PR DESCRIPTION
There's no way to verify right now either that the artifacts were
corrupted during uploads or tampered with. The right solution for this
is signing (see [1]), but until then, let's at least upload a CHECKSUMS
file for the former, and display it in the Jenkins logs as a temporary
hack for the latter (I mean, the logs are rotated out eventually, so
it's definitely not ideal).

[1] https://github.com/coreos/coreos-assembler/issues/268