### PR TITLE
Jenkinsfile: go back to always compressing with xz

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,10 +206,8 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
         }
 
         stage('Archive') {
-            // XXX: temporarily use gzip on non-production streams as we iterate on stuff
-            def compressor = params.STREAM in streams.production ? "xz" : "gzip"
             utils.shwrap("""
-            coreos-assembler compress --compressor ${compressor}
+            coreos-assembler compress --compressor xz
             """)
 
             // Run the coreos-meta-translator against the most recent build,


### PR DESCRIPTION
xz compression should be much faster now with:
[1] https://github.com/coreos/coreos-assembler/pull/632

So let's drop the hack and always use xz. For the developer use case,
the MINIMAL parameter means there's only really the `qcow2` to compress.