### PR TITLE
Jenkinsfile: use latest release on stream as parent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,6 +85,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
         }
 
         def developer_builddir = "/srv/devel/${developer_prefix}/build"
+        def basearch = utils.shwrap_capture("coreos-assembler basearch")
 
         stage('Init') {
 
@@ -260,7 +261,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
                 if (!params.MINIMAL) {
                     // And make AMIs launchable by all; XXX: should probably integrate this into
                     // `plume release --distro fcos` along with copying into other regions.
-                    def hvm = utils.shwrap_capture("jq -r '.amis[0].hvm' builds/${newBuildID}/x86_64/meta.json")
+                    def hvm = utils.shwrap_capture("jq -r '.amis[0].hvm' builds/${newBuildID}/${basearch}/meta.json")
                     utils.shwrap("""
                     aws ec2 --region us-east-1 modify-image-attribute \
                         --image-id ${hvm} \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,6 +115,8 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
                 utils.shwrap("""
                 coreos-assembler buildprep s3://${s3_stream_dir}/builds
                 """)
+                // also fetch releases.json to get the latest build, but don't error if it doesn't exist
+                utils.aws_s3_cp_allow_noent("s3://${s3_stream_dir}/releases.json", "tmp/releases.json")
             } else if (!official && utils.path_exists(developer_builddir)) {
                 utils.shwrap("""
                 coreos-assembler buildprep ${developer_builddir}
@@ -131,11 +133,22 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
             prevBuildID = utils.shwrap_capture("readlink builds/latest")
         }
 
+        def parent_version = ""
+        def parent_commit = ""
         stage('Build') {
+            def parent_arg = ""
+            if (utils.path_exists("tmp/releases.json")) {
+                def releases = readJSON file: "tmp/releases.json"
+                def commit_obj = releases["releases"][-1]["commits"].find{ commit -> commit["architecture"] == basearch }
+                parent_commit = commit_obj["checksum"]
+                parent_arg = "--parent ${parent_commit}"
+                parent_version = releases["releases"][-1]["version"]
+            }
+
             def force = params.FORCE ? "--force" : ""
             def version = params.VERSION ? "--version ${params.VERSION}" : ""
             utils.shwrap("""
-            coreos-assembler build --skip-prune ${force} ${version}
+            coreos-assembler build --skip-prune ${force} ${version} ${parent_arg}
             """)
         }
 
@@ -146,6 +159,16 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
             return
         } else {
             currentBuild.description = "[${params.STREAM}] ⚡ ${newBuildID}"
+
+            // and insert the parent info into meta.json so we can display it in
+            // the release browser and for sanity checking
+            if (parent_commit && parent_version) {
+                def meta_json = "builds/${newBuildID}/${basearch}/meta.json"
+                def meta = readJSON file: meta_json
+                meta["fedora-coreos.parent-version"] = parent_version
+                meta["fedora-coreos.parent-commit"] = parent_commit
+                writeJSON file: meta_json, json: meta
+            }
         }
 
         if (!params.MINIMAL) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,19 +68,19 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
     node('coreos-assembler') { container('coreos-assembler') {
 
         // this is defined IFF we *should* and we *can* upload to S3
-        def s3_builddir
+        def s3_stream_dir
 
         if (s3_bucket && utils.path_exists("/.aws/config")) {
           if (official) {
             // see bucket layout in https://github.com/coreos/fedora-coreos-tracker/issues/189
-            s3_builddir = "${s3_bucket}/prod/streams/${params.STREAM}/builds"
+            s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
           } else {
             // One prefix = one pipeline = one stream; the devel-up script is geared
             // towards testing a specific combination of (cosa, pipeline, fcos config),
             // not a full duplication of all the prod streams. One can always instantiate
             // a second prefix to test a separate combination if more than 1 concurrent
             // devel pipeline is needed.
-            s3_builddir = "${s3_bucket}/devel/streams/${developer_prefix}/builds"
+            s3_stream_dir = "${s3_bucket}/devel/streams/${developer_prefix}"
           }
         }
 
@@ -110,9 +110,9 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
         }
 
         stage('Fetch') {
-            if (s3_builddir) {
+            if (s3_stream_dir) {
                 utils.shwrap("""
-                coreos-assembler buildprep s3://${s3_builddir}
+                coreos-assembler buildprep s3://${s3_stream_dir}/builds
                 """)
             } else if (!official && utils.path_exists(developer_builddir)) {
                 utils.shwrap("""
@@ -172,10 +172,10 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
                 """)
             }
 
-            // Key off of s3_builddir: i.e. if we're configured to upload artifacts
+            // Key off of s3_stream_dir: i.e. if we're configured to upload artifacts
             // to S3, we also take that to mean we should upload an AMI. We could
             // split this into two separate developer knobs in the future.
-            if (s3_builddir) {
+            if (s3_stream_dir) {
                 stage('Upload AWS') {
                     def suffix = official ? "" : "--name-suffix ${developer_prefix}"
                     // XXX: hardcode us-east-1 for now
@@ -219,7 +219,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
             /var/tmp/fcos-releng/coreos-meta-translator/trans.py --workdir .
             """)
 
-            if (s3_builddir) {
+            if (s3_stream_dir) {
               // just upload as public-read for now, but see discussions in
               // https://github.com/coreos/fedora-coreos-tracker/issues/189
               utils.shwrap("""
@@ -228,7 +228,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
               find builds/${newBuildID} -type f | xargs sha256sum | tee CHECKSUMS
               sha256sum CHECKSUMS
               mv CHECKSUMS builds/${newBuildID}
-              coreos-assembler buildupload s3 --acl=public-read ${s3_builddir}
+              coreos-assembler buildupload s3 --acl=public-read ${s3_stream_dir}/builds
               """)
             } else if (!official) {
               // In devel mode without an S3 server, just archive into the PVC


### PR DESCRIPTION
We want to maintain OSTree history between our releases. To do this, we
fetch the latest release from the release index, and pass it to cosa
through the `--parent` switch.

For more information, see:
https://github.com/coreos/coreos-assembler/issues/159#issuecomment-512594688