### PR TITLE
Jenkinsfile: rely on plume to modify image attributes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -278,17 +278,6 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
                     --channel ${params.STREAM} \
                     --bucket ${s3_bucket}
                 """)
-
-                if (!params.MINIMAL) {
-                    // And make AMIs launchable by all; XXX: should probably integrate this into
-                    // `plume release --distro fcos` along with copying into other regions.
-                    def hvm = utils.shwrap_capture("jq -r '.amis[0].hvm' builds/${newBuildID}/${basearch}/meta.json")
-                    utils.shwrap("""
-                    aws ec2 --region us-east-1 modify-image-attribute \
-                        --image-id ${hvm} \
-                        --launch-permission '{"Add": [{"Group":"all"}]}'
-                    """)
-                }
             }
         }
     }}


### PR DESCRIPTION
`plume release --distro fcos` now has the ability to modify image
attributes including launch permission; switch to that over manually
setting them.