### PR TITLE
Jenkinsfile: compress qcow2 before archiving on failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,7 +182,8 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
         // archive the image if the tests failed
         def report = readJSON file: "tmp/kola/reports/report.json"
         if (report["result"] != "PASS") {
-            archiveArtifacts "builds/latest/**/*.qcow2"
+            utils.shwrap("coreos-assembler compress --compressor xz")
+            archiveArtifacts "builds/latest/**/*.qcow2.xz"
             currentBuild.result = 'FAILURE'
             return
         }


### PR DESCRIPTION
Use cosa to compress the qcow2, so we get multi-threading, before
archiving. Otherwise, we risk overloading the Jenkins master PVC before
too long.

Another strategy eventually would be to still upload to S3 (see [1]
which is related to this). But even then, we'd still want to compress
first.

[1] https://github.com/coreos/coreos-assembler/issues/668