### PR TITLE
manifests: drop duffy credentials

### DIFF
--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -22,9 +22,6 @@ spec:
      volumeMounts:
      - name: data
        mountPath: /srv/
-     - name: duffy-key
-       mountPath: /var/run/secrets/kubernetes.io/duffy-key
-       readOnly: true
      - name: aws-creds
        mountPath: /.aws
        readOnly: true
@@ -36,10 +33,6 @@ spec:
   - name: data
     persistentVolumeClaim:
       claimName: coreos-assembler-claim2
-  - name: duffy-key
-    secret:
-      secretName: duffy.key
-      optional: true
   - name: aws-creds
     secret:
       secretName: fcos-builds-bot-aws-config

--- a/manifests/sleep.yaml
+++ b/manifests/sleep.yaml
@@ -19,9 +19,6 @@ spec:
      volumeMounts:
      - name: data
        mountPath: /srv/
-     - name: duffy-key
-       mountPath: /var/run/secrets/kubernetes.io/duffy-key
-       readOnly: true
      - name: aws-creds
        mountPath: /.aws
        readOnly: true
@@ -31,10 +28,6 @@ spec:
   - name: data
     persistentVolumeClaim:
       claimName: coreos-assembler-claim2
-  - name: duffy-key
-    secret:
-      secretName: duffy.key
-      optional: true
   - name: aws-creds
     secret:
       secretName: fcos-builds-bot-aws-config


### PR DESCRIPTION
We don't use the CentOS artifact server anymore. So just drop the secret
mount in the interest of only mounting those we really need.