### PR TITLE
Jenkinsfile: add stage to replicate AWS AMI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -244,6 +244,15 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
                         --bucket s3://${s3_bucket}/ami-import
                     """)
                 }
+
+                // Replicate the newly uploaded AMI to other regions. Intentionally
+                // split out from the 'Upload AWS' stage to allow for tests to be added
+                // at a later date before replicating said image.
+                stage('Replicate AWS AMI') {
+                    utils.shwrap("""
+                    coreos-assembler aws-replicate --build=${newBuildID}
+                    """)
+                }
             }
         }
 


### PR DESCRIPTION
Adds a new stage after the `Upload AWS` stage that replicates the newly
created AMI to other regions. Currently the command will attempt to
replicate it to the following regions:

 - `us-east-1`
 - `us-east-2`
 - `us-west-1`
 - `us-west-2`
 - `eu-west-1`
 - `eu-west-2`
 - `eu-west-3`
 - `eu-central-1`
 - `eu-north-1`
 - `ap-south-1`
 - `ap-southeast-1`
 - `ap-southeast-2`
 - `ap-northeast-1`
 - `ap-northeast-2`
 - `sa-east-1`
 - `ca-central-1`