### PR TITLE
Jenkinsfile: share AMI with Fedora testing account

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,9 @@ node {
     }
 }
 
+// Share with the Fedora testing account so we can test it afterwards
+FEDORA_AWS_TESTING_USER_ID = "013116697141"
+
 properties([
     pipelineTriggers([]),
     parameters([
@@ -241,7 +244,8 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
                     coreos-assembler buildextend-aws ${suffix} \
                         --build=${newBuildID} \
                         --region=us-east-1 \
-                        --bucket s3://${s3_bucket}/ami-import
+                        --bucket s3://${s3_bucket}/ami-import \
+                        --grant-user ${FEDORA_AWS_TESTING_USER_ID}
                     """)
                 }
             }


### PR DESCRIPTION
Prep for actually being able to run tests in AWS.
See discussions in https://pagure.io/fedora-infrastructure/issue/8064.