### PR TITLE
Jenkinsfiles: Add STREAM into description for Jenkins UI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -267,6 +267,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
                         # We consider the AWS kola tests to be a followup job
                         # so we aren't adding a `--wait` here.
                         oc start-build fedora-coreos-pipeline-kola-aws \
+                            -e STREAM=${params.STREAM} \
                             -e VERSION=${newBuildID} \
                             -e S3_STREAM_DIR=${s3_stream_dir}
                     """)

--- a/Jenkinsfile.kola.aws
+++ b/Jenkinsfile.kola.aws
@@ -9,6 +9,10 @@ node {
 properties([
     pipelineTriggers([]),
     parameters([
+      string(name: 'STREAM',
+             description: 'The Stream we are testing against',
+             defaultValue: '',
+             trim: true),
       string(name: 'VERSION',
              description: 'Fedora CoreOS Build ID to test',
              defaultValue: '',
@@ -20,7 +24,7 @@ properties([
     ])
 ])
 
-currentBuild.description = "[${params.VERSION}] Running"
+currentBuild.description = "[${params.STREAM}] - ${params.VERSION}"
 
 // substitute the right COSA image into the pod definition before spawning it
 pod = pod.replace("COREOS_ASSEMBLER_IMAGE", "coreos-assembler:master")

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -34,7 +34,7 @@ properties([
     ])
 ])
 
-currentBuild.description = "[${params.STREAM}] Running"
+currentBuild.description = "[${params.STREAM}] - ${params.VERSION}"
 
 // substitute the right COSA image into the pod definition before spawning it
 pod = pod.replace("COREOS_ASSEMBLER_IMAGE", "coreos-assembler:master")

--- a/Jenkinsfile.stream.metadata.generator
+++ b/Jenkinsfile.stream.metadata.generator
@@ -21,7 +21,7 @@ properties([
     ])
 ])
 
-currentBuild.description = "[${params.STREAM}] Running"
+currentBuild.description = "[${params.STREAM}] - ${params.VERSION}"
 
 pod = pod.replace("COREOS_ASSEMBLER_IMAGE", "coreos-assembler:master")
 


### PR DESCRIPTION
Add the stream to the description of the job so we can find
related jobs in the UI without having to look at logs.