### PR TITLE
Jenkinsfiles: don't ignore errors from kola command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,7 +195,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
 
         stage('Kola:QEMU') {
             utils.shwrap("""
-            coreos-assembler kola run || :
+            coreos-assembler kola run
             tar -cf - tmp/kola/ | xz -c9 > _kola_temp.tar.xz
             """)
             archiveArtifacts "_kola_temp.tar.xz"

--- a/Jenkinsfile.kola.aws
+++ b/Jenkinsfile.kola.aws
@@ -56,7 +56,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
         stage('AWS Kola Run') {
           utils.shwrap("""
           export AWS_CONFIG_FILE=\${AWS_FCOS_KOLA_BOT_CONFIG}
-          kola run -p aws --aws-ami ${ami} --aws-region ${ami_region} -b fcos -j 10 || :
+          kola run -p aws --aws-ami ${ami} --aws-region ${ami_region} -b fcos -j 10
           tar -cf - _kola_temp/ | xz -c9 > _kola_temp.tar.xz
           """)
           archiveArtifacts "_kola_temp.tar.xz"


### PR DESCRIPTION
If the kola command has trouble setting up for testing we should
make sure this get flagged up in the web UI.