### PR TITLE
Jenkinsfile.kola.aws: decrease parallelization to 5

### DIFF
--- a/Jenkinsfile.kola.aws
+++ b/Jenkinsfile.kola.aws
@@ -60,7 +60,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
         stage('AWS Kola Run') {
           utils.shwrap("""
           export AWS_CONFIG_FILE=\${AWS_FCOS_KOLA_BOT_CONFIG}
-          kola run -p aws --aws-ami ${ami} --aws-region ${ami_region} -b fcos -j 10 || :
+          kola run -p aws --aws-ami ${ami} --aws-region ${ami_region} -b fcos -j 5 || :
           tar -cf - _kola_temp/ | xz -c9 > _kola_temp.tar.xz
           """)
           archiveArtifacts "_kola_temp.tar.xz"


### PR DESCRIPTION
We are bumping up against instance limits in our test account so let's
drop the parallelization down.