### PR TITLE
Jenkinsfile: add --upload option to buildextend-aws

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -254,6 +254,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
                     utils.shwrap("""
                     export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
                     coreos-assembler buildextend-aws ${suffix} \
+                        --upload \
                         --build=${newBuildID} \
                         --region=us-east-1 \
                         --bucket s3://${s3_bucket}/ami-import \


### PR DESCRIPTION
Tells the command to upload AMIs to AWS. This was the default but
changed in https://github.com/coreos/coreos-assembler/pull/792.