### PR TITLE
manifest/pod: bump memory request to 6.5G

### DIFF
--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -25,7 +25,7 @@ spec:
          # used together with the request limit below to ensure xz doesn't
          # cause us to get evicted
        - name: XZ_DEFAULTS
-         value: "--memlimit=2150MiB"
+         value: "--memlimit=6144MiB"
      volumeMounts:
      - name: data
        mountPath: /srv/
@@ -42,10 +42,9 @@ spec:
        privileged: false
      resources:
        requests:
-         # This is really the bare minimum here for building a whole OS.
-         # Notably, the supermin VM uses 2G, and xz specifically is very hungry.
-         # Add a bit more for overhead.
-         memory: 2.5Gi
+         # Note the supermin VM just uses 2G. The really hungry part is xz,
+         # which without lots of memory takes lots of time.
+         memory: 6.5Gi
   nodeSelector:
     oci_kvm_hook: allowed
   volumes:


### PR DESCRIPTION
Otherwise, `xz` just scales down to 1 thread.

Nodes should have the memory for this since we used to run without any
limits before and only occasionally got evicted.