### PR TITLE
pipeline: add support for signing via RoboSignatory

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -322,6 +322,21 @@ currently as designed (see
 oc set triggers bc/fedora-coreos-pipeline-mechanical --from-webhook
 ```
 
+### [PROD] Create fedora-messaging configuration
+
+First create the configmap:
+
+```
+oc create configmap fedora-messaging-cfg --from-file=fedmsg.toml
+```
+
+Then add the client secrets:
+
+```
+oc create secret generic fedora-messaging-coreos-key \
+  --from-file=coreos.crt --from-file=coreos.key
+```
+
 ### [PROD] Set up webhooks/automation
 
 - From the GitHub Settings tab for `fedora-coreos-config`, go to the

--- a/configs/fedmsg.toml
+++ b/configs/fedmsg.toml
@@ -1,0 +1,18 @@
+# fedora-messaging config to send messages to RoboSignatory for signing
+amqp_url = "amqps://coreos:@rabbitmq.fedoraproject.org/%2Fpubsub"
+
+[tls]
+ca_cert = "/etc/fedora-messaging/cacert.pem"
+keyfile = "/run/fedora-messaging-coreos-key/coreos.key"
+certfile = "/run/fedora-messaging-coreos-key/coreos.crt"
+
+[client_properties]
+app = "Fedora CoreOS Pipeline"
+app_url = "https://github.com/coreos/fedora-coreos-pipeline"
+app_contacts_email = ["coreos@lists.fedoraproject.org"]
+
+[exchanges."amq.topic"]
+type = "topic"
+durable = true
+auto_delete = false
+arguments = {}

--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -34,6 +34,12 @@ spec:
      - name: github-token
        mountPath: /.github
        readOnly: true
+     - name: fedora-messaging-cfg
+       mountPath: /etc/fedora-messaging-cfg
+       readOnly: true
+     - name: fedora-messaging-coreos-key
+       mountPath: /run/fedora-messaging-coreos-key
+       readOnly: true
      securityContext:
        privileged: false
      resources:
@@ -58,4 +64,13 @@ spec:
   - name: github-token
     secret:
       secretName: coreosbot-github-token
+      optional: true
+  # These two here are used for signing with RoboSignatory
+  - name: fedora-messaging-cfg
+    configMap:
+      name: fedora-messaging-cfg
+      optional: true
+  - name: fedora-messaging-coreos-key
+    secret:
+      secretName: fedora-messaging-coreos-key
       optional: true


### PR DESCRIPTION
This makes use of the new `cosa sign robosignatory` command to sign both
the OSTree commit and final image artifacts.

Requires: https://github.com/coreos/coreos-assembler/pull/763