### PR TITLE
Jenkinsfile.*: consistently substitute COREOS_ASSEMBLER_MEMORY_REQUEST

### DIFF
--- a/Jenkinsfile.kola.aws
+++ b/Jenkinsfile.kola.aws
@@ -29,6 +29,9 @@ currentBuild.description = "[${params.STREAM}] - ${params.VERSION}"
 // substitute the right COSA image into the pod definition before spawning it
 pod = pod.replace("COREOS_ASSEMBLER_IMAGE", "coreos-assembler:master")
 
+// shouldn't need more than 256Mi for this job
+pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "256Mi")
+
 podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultContainer: 'jnlp') {
     node('coreos-assembler') { container('coreos-assembler') {
         def ami, ami_region

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -39,6 +39,9 @@ currentBuild.description = "[${params.STREAM}] - ${params.VERSION}"
 // substitute the right COSA image into the pod definition before spawning it
 pod = pod.replace("COREOS_ASSEMBLER_IMAGE", "coreos-assembler:master")
 
+// shouldn't need more than 256Mi for this job
+pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "256Mi")
+
 podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultContainer: 'jnlp') {
     node('coreos-assembler') { container('coreos-assembler') {
         if (params.AWS_REPLICATION == 'true') {

--- a/Jenkinsfile.stream.metadata.generator
+++ b/Jenkinsfile.stream.metadata.generator
@@ -25,6 +25,9 @@ currentBuild.description = "[${params.STREAM}] - ${params.VERSION}"
 
 pod = pod.replace("COREOS_ASSEMBLER_IMAGE", "coreos-assembler:master")
 
+// shouldn't need more than 256Mi for this job
+pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "256Mi")
+
 podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultContainer: 'jnlp') {
     node('coreos-assembler') { container('coreos-assembler') {
         stage('Stream Metadata' ) {


### PR DESCRIPTION
We were only doing it in the main Jenkinsfile, but many of the other
ones use the same `pod.yaml` definition so we need to sub out that
variable there too.

In the future, I'd like to switch all jobs over to
[coreos-ci-lib](https://github.com/coreos/coreos-ci-lib) instead to make
this less error-prone and only actually mount the secrets each job
needs.