### PR TITLE
Jenkinsfile.*: do `cosa init` before `buildprep`

### DIFF
--- a/Jenkinsfile.kola.aws
+++ b/Jenkinsfile.kola.aws
@@ -40,6 +40,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
         stage('Fetch Metadata') {
             utils.shwrap("""
             export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
+            coreos-assembler init https://github.com/coreos/fedora-coreos-config
             coreos-assembler buildprep s3://${params.S3_STREAM_DIR}/builds
             """)
 

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -58,6 +58,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
                 // recent build
                 utils.shwrap("""
                 export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
+                coreos-assembler init https://github.com/coreos/fedora-coreos-config
                 coreos-assembler buildprep s3://${s3_stream_dir}/builds
                 coreos-assembler aws-replicate --build=${params.VERSION}
                 git clone https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng


### PR DESCRIPTION
After [1], `buildprep` wants to write to `tmp/` but that directory
doesn't exist yet. Really, we should be nice to cosa and `init` the
workdir first so it doesn't get confused.

[1] https://github.com/coreos/coreos-assembler/pull/823