### PR TITLE
Add support for KVM device plugin

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -17,19 +17,32 @@ In the following sections, the section header may indicate whether the
 section applies to the local cluster case (`[LOCAL]`) or the official
 prod case (`[PROD]`).
 
+You'll want to be sure you have KVM available in your cluster.  See
+[this section of the coreos-assembler docs](https://github.com/coreos/coreos-assembler/blob/master/README.md#getting-started---prerequisites).
+
+### Using a production OpenShift cluster
+
+This is recommended for production pipelines, and also gives you
+a lot of flexibility.  The coreos-assembler document above has
+multiple options for this.  To be clear, we would also likely
+support running on "vanilla" Kubernetes if someone interested showed
+up wanting that.
+
 ### [LOCAL] Set up an OpenShift cluster
 
-First, make sure to install `oci-kvm-hook` on your host system (not in a
-pet container). This is required to ensure that the pipeline has access
-to `/dev/kvm`:
+If you're using `oc cluster up` (which is an older OpenShift with Docker)
+the easiest is to install `oci-kvm-hook` on your host system (not in a
+pet container).  NOTE: The production path for this in modern clusters is
+the [KVM device plugin](https://github.com/kubevirt/kubernetes-device-plugins/blob/master/docs/README.kvm.md)
+linked in the `[PROD]` docs.
 
 ```
 rpm-ostree install oci-kvm-hook # if on OSTree-based system
-dnf install -y oci-kvm-hook # if on traditional
+yum -y install oci-kvm-hook # if on traditional
 ```
 
 We will use `oc cluster up` to set up a local cluster for testing. To do
-this, simply obtain the OpenShift v3.6.1 binary from
+this, obtain the OpenShift v3.6.1 binary from
 [here](https://github.com/openshift/origin/releases/tag/v3.6.1). We want
 to match the OCP version running in CentOS CI.
 
@@ -231,6 +244,7 @@ but without the `--official` switch:
 You may also want to provide additional switches depending on the
 circumstances. Here are some of them:
 
+- `--kvm-selector=kvm-device-plugin`: Use this if you're using the KVM device plugin (modern Kubernetes/OpenShift 4+).
 - `--prefix PREFIX`
     - The prefix to prepend to created developer-specific resources. By
       default, this will be your username, but you can provide a

--- a/deploy
+++ b/deploy
@@ -98,6 +98,9 @@ def parse_args():
                         help="Repo and ref to use for FCOS config")
     parser.add_argument("--bucket", metavar='BUCKET',
                         help="AWS S3 bucket to use")
+    parser.add_argument("--kvm-selector", help="KVM selector",
+                        choices=['kvm-device-plugin', 'legacy-oci-kvm-hook'],
+                        default='legacy-oci-kvm-hook')
     parser.add_argument("--cosa-img", metavar='FQIN',
                         help="Pullspec to use for COSA image")
     parser.add_argument("--pvc-size", metavar='SIZE',
@@ -141,6 +144,7 @@ def process_template(args):
         params += [f'COREOS_ASSEMBLER_IMAGE={args.cosa_img}']
     if args.pvc_size:
         params += [f'PVC_SIZE={args.pvc_size}']
+    params += [f'KVM_SELECTOR={args.kvm_selector}']
 
     print("Parameters:")
     for param in params:

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -41,6 +41,9 @@ parameters:
   - description: AWS S3 bucket in which to store builds (or blank for none)
     name: S3_BUCKET
     value: fcos-builds
+  - description: Whether to use KVM device plugin or legacy OCI KVM hook
+    name: KVM_SELECTOR
+    value: kvm-device-plugin
 
 objects:
 
@@ -175,6 +178,7 @@ objects:
         coreos.com/source-config-ref: ${PIPELINE_FCOS_CONFIG_REF}
         coreos.com/developer-prefix: ${DEVELOPER_PREFIX}
         coreos.com/s3-bucket: ${S3_BUCKET}
+        coreos.com/kvm-selector: ${KVM_SELECTOR}
     spec:
       # note no triggers: the base pipeline is only ever triggered manually, or
       # by one of the stream-specific pipelines

--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -45,8 +45,7 @@ spec:
      resources:
        requests:
          memory: COREOS_ASSEMBLER_MEMORY_REQUEST
-  nodeSelector:
-    oci_kvm_hook: allowed
+       limits: {}
   volumes:
   - name: data
     persistentVolumeClaim:


### PR DESCRIPTION
Let's focus people on the new way forward for KVM, which is
the KVM device plugin from Kubevirt.  This is also now documented
in coreos-assembler.

Tested in the CoreOS CI cluster, an OpenShift 4.2 GCP nested virt setup following
https://github.com/coreos/coreos-assembler/blob/master/doc/openshift-gcp-nested-virt.md

I didn't test that the OCI KVM hook path still works.