### PR TITLE
jenkins: add github-oauth plugin

### DIFF
--- a/jenkins/master/plugins.txt
+++ b/jenkins/master/plugins.txt
@@ -1,0 +1,1 @@
+github-oauth:0.33


### PR DESCRIPTION
This is the first step towards setting up GitHub auth login for Jenkins.
Still playing around with this, and I'd like first to start with
enabling it for the coreos-ci project (where GitHub PRs will be tested).
But I want that project to use the exact same Jenkins definition as here
to ensure equivalence.