### PR TITLE
Jenkinsfile.kola.aws: use `cosa kola` to run tests

### DIFF
--- a/Jenkinsfile.kola.aws
+++ b/Jenkinsfile.kola.aws
@@ -64,7 +64,8 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
         stage('AWS Kola Run') {
           utils.shwrap("""
           export AWS_CONFIG_FILE=\${AWS_FCOS_KOLA_BOT_CONFIG}
-          kola run -p aws --aws-ami ${ami} --aws-region ${ami_region} -b fcos -j 5 || :
+          # use `cosa kola` here since it knows about blacklisted tests
+          cosa kola -- run -p aws --aws-ami ${ami} --aws-region ${ami_region} -b fcos -j 5 || :
           tar -cf - _kola_temp/ | xz -c9 > _kola_temp.tar.xz
           """)
           archiveArtifacts "_kola_temp.tar.xz"


### PR DESCRIPTION
Right now, the logic for parsing `kola-blacklist.yaml` lives in cosa. So
use that to run the tests.

Could make `cosa kola` smarter here so that it picks up the AMI from the
metadata and passes that instead of the qemu image. But this hack works
for now.