### PR TITLE
manifests: add jenkins.yaml template

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -220,11 +220,7 @@ And provide it to `--bucket` below.
 ### Create a Jenkins instance with a persistent volume backing store
 
 ```
-oc new-app --template=jenkins-persistent \
-    --param=NAMESPACE=fedora-coreos \
-    --param=MEMORY_LIMIT=2Gi \
-    --param=VOLUME_CAPACITY=2Gi \
-    --param=JENKINS_IMAGE_STREAM_TAG=jenkins:2
+oc new-app --file=manifests/jenkins.yaml --param=NAMESPACE=fedora-coreos
 ```
 
 Notice the `NAMESPACE` parameter. This makes the Jenkins master use the
@@ -232,14 +228,6 @@ image from our namespace, which we'll create in the next step. (The
 reason we create the app first is that otherwise OpenShift will
 automatically instantiate Jenkins with default parameters when creating
 the Jenkins pipeline).
-
-The `jenkins:2` parameter is to match the tag name in the latest
-OpenShift. Some older versions of the template in OpenShift uses
-`jenkins:latest`. This will no longer be needed once we are running on a
-newer version of OpenShift than 3.6 in
-CentOS CI. See [#32](https://github.com/coreos/fedora-coreos-pipeline/pull/32)
-and [#70](https://github.com/coreos/fedora-coreos-pipeline/pull/70)
-for more context).
 
 ### Creating the pipeline
 
@@ -260,7 +248,6 @@ but without the `--official` switch:
 You may also want to provide additional switches depending on the
 circumstances. Here are some of them:
 
-- `--kvm-selector=kvm-device-plugin`: Use this if you're using the KVM device plugin (modern Kubernetes/OpenShift 4+).
 - `--prefix PREFIX`
     - The prefix to prepend to created developer-specific resources. By
       default, this will be your username, but you can provide a
@@ -269,6 +256,9 @@ circumstances. Here are some of them:
     - Git source URL and optional git ref for pipeline Jenkinsfile.
 - `--config <URL>[@REF]`
     - Git source URL and optional git ref for FCOS config.
+- `--kvm-selector=kvm-device-plugin`:
+    - Use this if you're using the KVM device plugin (modern
+      Kubernetes/OpenShift 4+).
 - `--pvc-size <SIZE>`
     - Size of the cache PVC to create. Note that the PVC size cannot be
       changed after creation. The format is the one understood by

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -1,0 +1,210 @@
+# This is a fork of the `jenkins-persistent` OpenShift template because we need
+# to be able to pass in more information to the Jenkins pod, such as env vars,
+# secrets, configmaps, etc...
+
+apiVersion: v1
+kind: Template
+labels:
+  app: fedora-coreos
+  template: fedora-coreos-jenkins-template
+metadata:
+  annotations:
+    description: |-
+      Jenkins service for the Fedora CoreOS pipeline.
+    iconClass: icon-jenkins
+    openshift.io/display-name: Fedora CoreOS Jenkins
+    openshift.io/documentation-url: https://github.com/coreos/fedora-coreos-pipeline
+    openshift.io/support-url: https://github.com/coreos/fedora-coreos-pipeline
+    openshift.io/provider-display-name: Fedora CoreOS
+    tags: fcos,jenkins,fedora
+  name: fedora-coreos-jenkins
+objects:
+- apiVersion: v1
+  kind: Route
+  metadata:
+    annotations:
+      template.openshift.io/expose-uri: http://{.spec.host}{.spec.path}
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
+    to:
+      kind: Service
+      name: ${JENKINS_SERVICE_NAME}
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${VOLUME_CAPACITY}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    replicas: 1
+    selector:
+      name: ${JENKINS_SERVICE_NAME}
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: ${JENKINS_SERVICE_NAME}
+      spec:
+        containers:
+        - capabilities: {}
+          env:
+          - name: OPENSHIFT_ENABLE_OAUTH
+            value: ${ENABLE_OAUTH}
+          - name: OPENSHIFT_ENABLE_REDIRECT_PROMPT
+            value: "true"
+          - name: OPENSHIFT_JENKINS_JVM_ARCH
+            value: ${JVM_ARCH}
+          - name: KUBERNETES_MASTER
+            value: https://kubernetes.default:443
+          - name: KUBERNETES_TRUST_CERTIFICATES
+            value: "true"
+          - name: JNLP_SERVICE_NAME
+            value: ${JNLP_SERVICE_NAME}
+          image: ' '
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /login
+              port: 8080
+            initialDelaySeconds: 420
+            timeoutSeconds: 3
+          name: jenkins
+          readinessProbe:
+            httpGet:
+              path: /login
+              port: 8080
+            initialDelaySeconds: 3
+            timeoutSeconds: 3
+          resources:
+            limits:
+              memory: ${MEMORY_LIMIT}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+          volumeMounts:
+          - mountPath: /var/lib/jenkins
+            name: ${JENKINS_SERVICE_NAME}-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        serviceAccountName: ${JENKINS_SERVICE_NAME}
+        volumes:
+        - name: ${JENKINS_SERVICE_NAME}-data
+          persistentVolumeClaim:
+            claimName: ${JENKINS_SERVICE_NAME}
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - jenkins
+        from:
+          kind: ImageStreamTag
+          name: ${JENKINS_IMAGE_STREAM_TAG}
+          namespace: ${NAMESPACE}
+        lastTriggeredImage: ""
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.jenkins: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"${JENKINS_SERVICE_NAME}"}}'
+    name: ${JENKINS_SERVICE_NAME}
+- apiVersion: v1
+  groupNames: null
+  kind: RoleBinding
+  metadata:
+    name: ${JENKINS_SERVICE_NAME}_edit
+  roleRef:
+    name: edit
+  subjects:
+  - kind: ServiceAccount
+    name: ${JENKINS_SERVICE_NAME}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: ${JNLP_SERVICE_NAME}
+  spec:
+    ports:
+    - name: agent
+      nodePort: 0
+      port: 50000
+      protocol: TCP
+      targetPort: 50000
+    selector:
+      name: ${JENKINS_SERVICE_NAME}
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      service.alpha.openshift.io/dependencies: '[{"name": "${JNLP_SERVICE_NAME}",
+        "namespace": "", "kind": "Service"}]'
+      service.openshift.io/infrastructure: "true"
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    ports:
+    - name: web
+      nodePort: 0
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: ${JENKINS_SERVICE_NAME}
+    sessionAffinity: None
+    type: ClusterIP
+parameters:
+- description: The name of the OpenShift Service exposed for the Jenkins container.
+  displayName: Jenkins Service Name
+  name: JENKINS_SERVICE_NAME
+  value: jenkins
+- description: The name of the service used for master/slave communication.
+  displayName: Jenkins JNLP Service Name
+  name: JNLP_SERVICE_NAME
+  value: jenkins-jnlp
+- description: Whether to enable OAuth OpenShift integration. If false, the static
+    account 'admin' will be initialized with the password 'password'.
+  displayName: Enable OAuth in Jenkins
+  name: ENABLE_OAUTH
+  value: "true"
+- description: Whether Jenkins runs with a 32 bit (i386) or 64 bit (x86_64) JVM.
+  displayName: Jenkins JVM Architecture
+  name: JVM_ARCH
+  value: i386
+- description: Maximum amount of memory the container can use.
+  displayName: Memory Limit
+  # DELTA: changed from 512Mi
+  name: MEMORY_LIMIT
+  value: 2Gi
+- description: Volume space available for data, e.g. 512Mi, 2Gi.
+  displayName: Volume Capacity
+  name: VOLUME_CAPACITY
+  required: true
+  # DELTA: changed from 1Gi
+  value: 2Gi
+- description: The OpenShift Namespace where the Jenkins ImageStream resides.
+  displayName: Jenkins ImageStream Namespace
+  name: NAMESPACE
+  value: openshift
+- description: Name of the ImageStreamTag to be used for the Jenkins image.
+  displayName: Jenkins ImageStreamTag
+  name: JENKINS_IMAGE_STREAM_TAG
+  # DELTA: changed from jenkins:latest
+  # https://github.com/coreos/fedora-coreos-pipeline/pull/70
+  value: jenkins:2

--- a/manifests/jenkins.yaml.orig
+++ b/manifests/jenkins.yaml.orig
@@ -1,0 +1,223 @@
+# This is the original Jenkins template from which we forked. Will be useful
+# for rebasing.
+#
+# Obtained using:
+#   oc get templates -n openshift -o yaml jenkins-persistent > manifests/jenkins.yaml.orig
+#
+# To diff:
+#   git diff --no-index manifests/jenkins.yaml{.orig,}
+
+apiVersion: v1
+kind: Template
+labels:
+  template: jenkins-persistent-template
+message: A Jenkins service has been created in your project.  Log into Jenkins with
+  your OpenShift account.  The tutorial at https://github.com/openshift/origin/blob/master/examples/jenkins/README.md
+  contains more information about using this template.
+metadata:
+  annotations:
+    description: |-
+      Jenkins service, with persistent storage.
+
+      NOTE: You must have persistent volumes available in your cluster to use this template.
+    iconClass: icon-jenkins
+    openshift.io/display-name: Jenkins (Persistent)
+    tags: instant-app,jenkins
+    template.openshift.io/documentation-url: https://docs.openshift.org/latest/using_images/other_images/jenkins.html
+    template.openshift.io/long-description: This template deploys a Jenkins server
+      capable of managing OpenShift Pipeline builds and supporting OpenShift-based
+      oauth login.
+    template.openshift.io/provider-display-name: Red Hat, Inc.
+    template.openshift.io/support-url: https://access.redhat.com
+  creationTimestamp: 2017-06-07T22:44:34Z
+  name: jenkins-persistent
+  namespace: openshift
+  resourceVersion: "9280678"
+  selfLink: /oapi/v1/namespaces/openshift/templates/jenkins-persistent
+  uid: e102f731-4bd2-11e7-aab3-0cc47a66a374
+objects:
+- apiVersion: v1
+  kind: Route
+  metadata:
+    annotations:
+      template.openshift.io/expose-uri: http://{.spec.host}{.spec.path}
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
+    to:
+      kind: Service
+      name: ${JENKINS_SERVICE_NAME}
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${VOLUME_CAPACITY}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    replicas: 1
+    selector:
+      name: ${JENKINS_SERVICE_NAME}
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: ${JENKINS_SERVICE_NAME}
+      spec:
+        containers:
+        - capabilities: {}
+          env:
+          - name: OPENSHIFT_ENABLE_OAUTH
+            value: ${ENABLE_OAUTH}
+          - name: OPENSHIFT_ENABLE_REDIRECT_PROMPT
+            value: "true"
+          - name: OPENSHIFT_JENKINS_JVM_ARCH
+            value: ${JVM_ARCH}
+          - name: KUBERNETES_MASTER
+            value: https://kubernetes.default:443
+          - name: KUBERNETES_TRUST_CERTIFICATES
+            value: "true"
+          - name: JNLP_SERVICE_NAME
+            value: ${JNLP_SERVICE_NAME}
+          image: ' '
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /login
+              port: 8080
+            initialDelaySeconds: 420
+            timeoutSeconds: 3
+          name: jenkins
+          readinessProbe:
+            httpGet:
+              path: /login
+              port: 8080
+            initialDelaySeconds: 3
+            timeoutSeconds: 3
+          resources:
+            limits:
+              memory: ${MEMORY_LIMIT}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+          volumeMounts:
+          - mountPath: /var/lib/jenkins
+            name: ${JENKINS_SERVICE_NAME}-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        serviceAccountName: ${JENKINS_SERVICE_NAME}
+        volumes:
+        - name: ${JENKINS_SERVICE_NAME}-data
+          persistentVolumeClaim:
+            claimName: ${JENKINS_SERVICE_NAME}
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - jenkins
+        from:
+          kind: ImageStreamTag
+          name: ${JENKINS_IMAGE_STREAM_TAG}
+          namespace: ${NAMESPACE}
+        lastTriggeredImage: ""
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.jenkins: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"${JENKINS_SERVICE_NAME}"}}'
+    name: ${JENKINS_SERVICE_NAME}
+- apiVersion: v1
+  groupNames: null
+  kind: RoleBinding
+  metadata:
+    name: ${JENKINS_SERVICE_NAME}_edit
+  roleRef:
+    name: edit
+  subjects:
+  - kind: ServiceAccount
+    name: ${JENKINS_SERVICE_NAME}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: ${JNLP_SERVICE_NAME}
+  spec:
+    ports:
+    - name: agent
+      nodePort: 0
+      port: 50000
+      protocol: TCP
+      targetPort: 50000
+    selector:
+      name: ${JENKINS_SERVICE_NAME}
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      service.alpha.openshift.io/dependencies: '[{"name": "${JNLP_SERVICE_NAME}",
+        "namespace": "", "kind": "Service"}]'
+      service.openshift.io/infrastructure: "true"
+    name: ${JENKINS_SERVICE_NAME}
+  spec:
+    ports:
+    - name: web
+      nodePort: 0
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: ${JENKINS_SERVICE_NAME}
+    sessionAffinity: None
+    type: ClusterIP
+parameters:
+- description: The name of the OpenShift Service exposed for the Jenkins container.
+  displayName: Jenkins Service Name
+  name: JENKINS_SERVICE_NAME
+  value: jenkins
+- description: The name of the service used for master/slave communication.
+  displayName: Jenkins JNLP Service Name
+  name: JNLP_SERVICE_NAME
+  value: jenkins-jnlp
+- description: Whether to enable OAuth OpenShift integration. If false, the static
+    account 'admin' will be initialized with the password 'password'.
+  displayName: Enable OAuth in Jenkins
+  name: ENABLE_OAUTH
+  value: "true"
+- description: Whether Jenkins runs with a 32 bit (i386) or 64 bit (x86_64) JVM.
+  displayName: Jenkins JVM Architecture
+  name: JVM_ARCH
+  value: i386
+- description: Maximum amount of memory the container can use.
+  displayName: Memory Limit
+  name: MEMORY_LIMIT
+  value: 512Mi
+- description: Volume space available for data, e.g. 512Mi, 2Gi.
+  displayName: Volume Capacity
+  name: VOLUME_CAPACITY
+  required: true
+  value: 1Gi
+- description: The OpenShift Namespace where the Jenkins ImageStream resides.
+  displayName: Jenkins ImageStream Namespace
+  name: NAMESPACE
+  value: openshift
+- description: Name of the ImageStreamTag to be used for the Jenkins image.
+  displayName: Jenkins ImageStreamTag
+  name: JENKINS_IMAGE_STREAM_TAG
+  value: jenkins:latest


### PR DESCRIPTION
There is this great plugin which I've somehow only learned about
recently to make Jenkins configuration much easier:

https://github.com/jenkinsci/configuration-as-code-plugin

The RHCOS pipeline already makes use of it.

To use this though, we need to be able to change the podspec of Jenkins
itself, which until now was embedded in the `jenkins-persistent`
template.

There's more though: I want to be able to define environment variables,
configmaps, secrets, etc... The default template doesn't provide
facilities for this.

So this patch essentially imports the template into our tree so that we
can have more control. The downside of course is that we lose updates to
the template. (Though that could also be seen as an upside too: we get
better reproducibility even if the template is upgrade.)

One convention I'm using is prefacing all the changes from the default
template values with a comment saying "DELTA:". That way, we can more
easily track what we added on top, and make rebasing easier in the
future.

Another advantage is that it makes setting it up easier because we don't
have to customize as many parameters: we can just set the right default
for us.