### PR TITLE
Add support for Slack notifications

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -163,7 +163,7 @@ If you're planning to test changes, it would be best to fork
 this repo so that you do your work there. The workflow
 requires a remote repo to which to push changes.
 
-### Creating AWS credentials configs
+### [OPTIONAL] Creating AWS credentials configs
 
 If you are in production where we upload builds to S3 OR you want to
 test uploading to S3 as part of your pipeline development, you need to
@@ -216,6 +216,19 @@ $ aws s3 mb my-fcos-bucket
 ```
 
 And provide it to `--bucket` below.
+
+### [OPTIONAL] Slack integration
+
+If you want to be able to have build status messages appear in Slack,
+create a `slack-api-token` secret:
+
+```
+$ echo -n "$TOKEN" > slack-token
+$ oc create secret generic slack-api-token --from-file=token=slack-token
+```
+
+You can obtain a token when creating a new instance of the Jenkins CI
+app in your Slack workspace.
 
 ### Create a Jenkins instance with a persistent volume backing store
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -387,3 +387,24 @@ http://simple-httpd-fedora-coreos.$CLUSTER_URL
 ```
 
 (Or simply check the output of `oc get route simple-httpd`).
+
+### Nuking everything
+
+One can leverage Kubernetes labels to delete all objects
+related to the pipeline:
+
+```
+oc delete all -l app=fedora-coreos
+```
+
+This won't delete a few resources. Notably the PVC and the
+SA. Deleting the PVC is usually not recommended since it may
+require cluster admin access to reallocate it in the future
+(if it doesn't, feel free to delete it!). To delete the
+other objects:
+
+```
+oc delete serviceaccounts -l app=fedora-coreos
+oc delete rolebindings -l app=fedora-coreos
+oc delete configmaps -l app=fedora-coreos
+```

--- a/jenkins/master/plugins.txt
+++ b/jenkins/master/plugins.txt
@@ -1,1 +1,3 @@
 github-oauth:0.33
+configuration-as-code:1.33
+slack:2.34

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -74,6 +74,9 @@ objects:
             value: "true"
           - name: JNLP_SERVICE_NAME
             value: ${JNLP_SERVICE_NAME}
+          # DELTA: point c-as-c plugin to config map files; see below
+          - name: CASC_JENKINS_CONFIG
+            value: /var/lib/jenkins/configuration-as-code
           image: ' '
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -100,6 +103,14 @@ objects:
           volumeMounts:
           - mountPath: /var/lib/jenkins
             name: ${JENKINS_SERVICE_NAME}-data
+          # DELTA: mount c-as-c config map
+          - name: ${JENKINS_SERVICE_NAME}-casc-cfg
+            mountPath: /var/lib/jenkins/configuration-as-code
+            readOnly: true
+          # DELTA: mount Slack token; see below
+          - name: slack-token
+            mountPath: /var/run/secrets/slack-api-token
+            readOnly: true
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         serviceAccountName: ${JENKINS_SERVICE_NAME}
@@ -107,6 +118,15 @@ objects:
         - name: ${JENKINS_SERVICE_NAME}-data
           persistentVolumeClaim:
             claimName: ${JENKINS_SERVICE_NAME}
+        # DELTA: add a configmap -- it's defined in pipeline.yaml
+        - name: ${JENKINS_SERVICE_NAME}-casc-cfg
+          configMap:
+            name: jenkins-casc-cfg
+        # DELTA: add the Slack token
+        - name: slack-token
+          secret:
+            secretName: slack-api-token
+            optional: true
     triggers:
     - imageChangeParams:
         automatic: true

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -44,6 +44,12 @@ parameters:
   - description: Whether to use KVM device plugin or legacy OCI KVM hook
     name: KVM_SELECTOR
     value: kvm-device-plugin
+  - description: Slack domain on which to post build status updates
+    name: SLACK_DOMAIN
+    value: coreos
+  - description: Slack channel on which to post build status updates
+    name: SLACK_CHANNEL
+    value: jenkins-coreos
 
 objects:
 
@@ -122,6 +128,33 @@ objects:
             name: docker.io/openshift/jenkins-slave-base-centos7:latest
           importPolicy:
             scheduled: true
+
+  ### JENKINS CONFIGURATION ###
+
+  # this uses the configuration-as-code plugin:
+  # https://github.com/jenkinsci/configuration-as-code-plugin
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: jenkins-casc-cfg
+      annotations:
+        coreos.com/deploy-default: "true"
+    data:
+      jenkins.yaml: |
+          credentials:
+            system:
+              domainCredentials:
+                - credentials:
+                  - string:
+                      scope: GLOBAL
+                      id: slack-token
+                      secret: ${slack-api-token/token}
+                      description: Slack API token
+          unclassified:
+            slackNotifier:
+              teamDomain: ${SLACK_DOMAIN}
+              tokenCredentialId: slack-token
+              room: "#${SLACK_CHANNEL}"
 
   ### COREOS-ASSEMBLER ###
 

--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -4,6 +4,8 @@
 apiVersion: v1
 metadata:
   name: coreos-assembler
+  labels:
+    app: fedora-coreos
 kind: Pod
 spec:
   # run as `jenkins` so we can do `oc start-build`


### PR DESCRIPTION
We need to add more monitoring on the pipeline. Otherwise it's going to
be very easy to go red for a few days without noticing.

My initial goal was to hook up to IRC, but the reality is that I think
we'll need both Slack and IRC because many folks mostly live in Slack
nowadays.

(That said, I still fully intend to add IRC support via fedmsgs as
discussed in #41).

Now, how this patch works is that we add two new Jenkins plugins:
- configuration-as-code
- slack

The first one is used to configure the second one. More broadly, it's
able to configure almost all of Jenkins and its plugins via YAML instead
of dropping to XML, so we'll likely be leveraging it some more in the
future.

The actual configuration bit here is more or less the same as RHCOS,
with some minor variations (we use secrets instead of defining the token
at template generation time, and we just set a default channel instead
of passing it through an env var)

Of course, this is all still optional. The local developer workflow
should still work fine.