### PR TITLE
Jenkinsfile.kola.aws: fix the path to the report

### DIFF
--- a/Jenkinsfile.kola.aws
+++ b/Jenkinsfile.kola.aws
@@ -71,7 +71,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod, defaultCon
           archiveArtifacts "kola_tmp.tar.xz"
         }
 
-        def report = readJSON file: "_kola_temp/aws-latest/reports/report.json"
+        def report = readJSON file: "tmp/kola/reports/report.json"
         if (report["result"] != "PASS") {
           currentBuild.result = 'FAILURE'
           return


### PR DESCRIPTION
It's no longer under `_kola_temp` and for some reason it's also no longer
under `aws-latest`.