### PR TITLE
Jenkinsfile: don't sign the ostree commit for now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -261,17 +261,17 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod) {
             }
         }
 
-        if (official && s3_stream_dir && utils.path_exists("/etc/fedora-messaging-cfg/fedmsg.toml")) {
-            stage('Sign OSTree') {
-                utils.shwrap("""
-                export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
-                cosa sign robosignatory --s3 ${s3_stream_dir}/builds \
-                    --extra-fedmsg-keys stream=${params.STREAM} \
-                    --ostree --gpgkeypath /etc/pki/rpm-gpg \
-                    --fedmsg-conf /etc/fedora-messaging-cfg/fedmsg.toml
-                """)
-            }
-        }
+      //if (official && s3_stream_dir && utils.path_exists("/etc/fedora-messaging-cfg/fedmsg.toml")) {
+      //    stage('Sign OSTree') {
+      //        utils.shwrap("""
+      //        export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
+      //        cosa sign robosignatory --s3 ${s3_stream_dir}/builds \
+      //            --extra-fedmsg-keys stream=${params.STREAM} \
+      //            --ostree --gpgkeypath /etc/pki/rpm-gpg \
+      //            --fedmsg-conf /etc/fedora-messaging-cfg/fedmsg.toml
+      //        """)
+      //    }
+      //}
 
         stage('Build QEMU') {
             utils.shwrap("""


### PR DESCRIPTION
This isn't working for some reason. Let's see if we can unblock the
pipeline. We might need to disable the signing of the artifacts later
as well.

This is related to https://github.com/coreos/fedora-coreos-pipeline/issues/178