### PR TITLE
Jenkinsfile: stop building the installer ISO/kernel/initrd artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -305,12 +305,6 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod) {
                 """)
             }
 
-            stage('Build Installer') {
-                utils.shwrap("""
-                coreos-assembler buildextend-installer
-                """)
-            }
-
             stage('Build Live') {
                 utils.shwrap("""
                 coreos-assembler buildextend-live


### PR DESCRIPTION
We'll now use the Live ISO/kernel/initrd for installs. This is related
to: coreos/fedora-coreos-config#261