### PR TITLE
Jenkinsfile: Handle the case of unofficial versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -229,7 +229,7 @@ podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod) {
             }
 
             def force = params.FORCE ? "--force" : ""
-            def version
+            def version = ""
             if (params.VERSION) {
                 version = "--version ${params.VERSION}"
             } else if (official) {


### PR DESCRIPTION
Regression from 4531066e5dd0a99bf827181af8094acb9ad42dc0 in the
case where no version override is provided, and we're doing
an unofficial build.  My test pipeline blew up with a `null`
in the commandline.