### PR TITLE
Jenkinsfile: use random UUID as node label

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,8 +126,11 @@ node {
 
 echo "Final podspec: ${pod}"
 
-podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod) {
-    node('coreos-assembler') { container('coreos-assembler') {
+// use a unique label to force Kubernetes to provision a separate pod per run
+def pod_label = "cosa-${UUID.randomUUID().toString()}"
+
+podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
+    node(pod_label) { container('coreos-assembler') {
 
         // declare this early so we can use it in Slack
         def newBuildID

--- a/Jenkinsfile.kola.aws
+++ b/Jenkinsfile.kola.aws
@@ -32,8 +32,11 @@ pod = pod.replace("COREOS_ASSEMBLER_IMAGE", "coreos-assembler:master")
 // shouldn't need more than 256Mi for this job
 pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "256Mi")
 
-podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod) {
-    node('coreos-assembler') { container('coreos-assembler') {
+// use a unique label to force Kubernetes to provision a separate pod per run
+def pod_label = "cosa-${UUID.randomUUID().toString()}"
+
+podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
+    node(pod_label) { container('coreos-assembler') {
         def ami, ami_region
         def no_ami = false
 

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -46,8 +46,11 @@ pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "256Mi")
 
 echo "Final podspec: ${pod}"
 
-podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod) {
-    node('coreos-assembler') { container('coreos-assembler') {
+// use a unique label to force Kubernetes to provision a separate pod per run
+def pod_label = "cosa-${UUID.randomUUID().toString()}"
+
+podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
+    node(pod_label) { container('coreos-assembler') {
         if (params.AWS_REPLICATION == 'true') {
             // Replicate the newly uploaded AMI to other regions. Intentionally
             // split out from the 'Upload AWS' stage to allow for tests to be added

--- a/Jenkinsfile.stream.metadata.generator
+++ b/Jenkinsfile.stream.metadata.generator
@@ -27,8 +27,11 @@ pod = pod.replace("COREOS_ASSEMBLER_IMAGE", "coreos-assembler:master")
 // shouldn't need more than 256Mi for this job
 pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "256Mi")
 
-podTemplate(cloud: 'openshift', label: 'coreos-assembler', yaml: pod) {
-    node('coreos-assembler') { container('coreos-assembler') {
+// use a unique label to force Kubernetes to provision a separate pod per run
+def pod_label = "cosa-${UUID.randomUUID().toString()}"
+
+podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
+    node(pod_label) { container('coreos-assembler') {
         stage('Stream Metadata' ) {
             def gopath = "${env.WORKSPACE}" + "/go/"
             def gocache = "${env.WORKSPACE}" + "/gocache/"


### PR DESCRIPTION
This will force the Kubernetes plugin to provision a new pod for each
job run rather than try to reuse them.

This is also prep for having parallel pipeline runs.