### PR TITLE
Jenkinsfile{,.kola.aws}: tweak upgrade test output dir

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -310,11 +310,11 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
         stage('Kola:QEMU upgrade') {
             utils.shwrap("""
             coreos-assembler kola --upgrades --no-test-exit-error
-            tar -cf - tmp/kola/ | xz -c9 > kola-run-upgrade.tar.xz
+            tar -cf - tmp/kola-upgrade | xz -c9 > kola-run-upgrade.tar.xz
             """)
             archiveArtifacts "kola-run-upgrade.tar.xz"
         }
-        if (!utils.checkKolaSuccess("tmp/kola", currentBuild)) {
+        if (!utils.checkKolaSuccess("tmp/kola-upgrade", currentBuild)) {
             return
         }
 

--- a/Jenkinsfile.kola.aws
+++ b/Jenkinsfile.kola.aws
@@ -85,7 +85,7 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
                     utils.shwrap("""
                     export AWS_CONFIG_FILE=\${AWS_FCOS_KOLA_BOT_CONFIG}
                     coreos-assembler kola --upgrades -p=aws --aws-region=${ami_region} --no-test-exit-error
-                    tar -cf - tmp/kola/ | xz -c9 > kola-run-upgrade.tar.xz
+                    tar -cf - tmp/kola-upgrade | xz -c9 > kola-run-upgrade.tar.xz
                     """)
                     archiveArtifacts "kola-run-upgrade.tar.xz"
                 }


### PR DESCRIPTION
Cosa now puts the output of upgrade tests in `tmp/kola-upgrade`, so
tweak things here accordingly.

This makes the two jobs more consistent and also fixes the issue of
`Jenkinsfile.kola.aws` running both testsuites in parallel but
outputting into the same directory.