### PR TITLE
ci: hook up to CoreOS CI

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,0 +1,12 @@
+@Library('github.com/coreos/coreos-ci-lib@master') _
+
+node {
+    checkout scm
+
+    stage("Test") {
+        // for now, just sanity check all the manifests
+        coreos.shwrap("""
+        find manifests/ -iname '*.yaml' | xargs -n 1 oc create --dry-run -f
+        """)
+    }
+}


### PR DESCRIPTION
For now, this just does a basic sanity checking that the manifest files
in `manifests/` are valid. Though in the future, we can make e.g. it run
through the pipeline itself in dry-run mode.