### PR TITLE
Allow concurrent builds/releases/tests

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -49,6 +49,10 @@ echo "Final podspec: ${pod}"
 // use a unique label to force Kubernetes to provision a separate pod per run
 def pod_label = "cosa-${UUID.randomUUID().toString()}"
 
+// We just lock here out of an abundance of caution in case somehow two release
+// jobs run for the same stream, but that really shouldn't happen. Anyway, if it
+// *does*, this makes sure they're run serially.
+lock(resource: "release-${params.STREAM}") {
 podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
     node(pod_label) { container('coreos-assembler') {
         if (params.AWS_REPLICATION == 'true') {
@@ -88,4 +92,4 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
           """)
         }
     }}
-}
+}}

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -220,6 +220,7 @@ objects:
         git:
           uri: ${PIPELINE_REPO_URL}
           ref: ${PIPELINE_REPO_REF}
+      runPolicy: Parallel
       strategy:
         jenkinsPipelineStrategy:
           type: JenkinsPipeline

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -366,3 +366,4 @@ objects:
         jenkinsPipelineStrategy:
           type: JenkinsPipeline
           jenkinsfilePath: Jenkinsfile.kola.aws
+      runPolicy: Parallel

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -323,6 +323,7 @@ objects:
         jenkinsPipelineStrategy:
           type: JenkinsPipeline
           jenkinsfilePath: Jenkinsfile.release
+      runPolicy: Parallel
 
   ### FEDORA COREOS STREAM PIPELINE ###
 


### PR DESCRIPTION
Sprinkle `runPolicy: Parallel` a bit everywhere, then adapt the various pipeline code to deal with it correctly. See individual commit messages for details!