### PR TITLE
Prep patches for sharing with CoreOS CI

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -315,7 +315,7 @@ one can use to make this smaller if you do not have enough space. E.g.
 We can now start a build of the Jenkins master:
 
 ```
-oc start-build --follow fedora-coreos-jenkins
+oc start-build --follow jenkins
 ```
 
 Once the Jenkins master image is built, Jenkins should start up (verify

--- a/deploy
+++ b/deploy
@@ -154,13 +154,19 @@ def process_template(args):
         print(f"  {k}={v}")
     print()
 
-    def gen_param_args():
-        return [q for k, v in params.items() for q in ['--param', f'{k}={v}']]
+    def gen_param_args(selected):
+        selected_params = {(k, v) for k, v in params.items() if k in selected}
+        return [q for k, v in selected_params for q in ['--param', f'{k}={v}']]
 
     resources = []
-    for template in ['pipeline.yaml']:
+    for template in ['pipeline.yaml', 'jenkins-s2i.yaml']:
+        # we only want to pass the params which each template actually
+        # supports, so filter it down for this specific template
+        with open(f'manifests/{template}') as f:
+            t = yaml.safe_load(f)
+            tparams = [p['name'] for p in t.get('parameters', [])]
         # and generate the --param FOO=bar ... args for this template
-        param_args = gen_param_args()
+        param_args = gen_param_args(tparams)
         j = json.loads(subprocess.check_output(
             ['oc', 'process', '--filename', f'manifests/{template}'] + param_args))
         resources += j['items']

--- a/deploy
+++ b/deploy
@@ -132,37 +132,44 @@ def get_username():
 
 
 def process_template(args):
-    params = []
+    params = {}
     if not args.official:
-        params += [f'DEVELOPER_PREFIX={args.prefix}']
+        params['DEVELOPER_PREFIX'] = args.prefix
     if args.pipeline:
-        params += params_from_git_refspec(args.pipeline, 'JENKINS_S2I')
-        params += params_from_git_refspec(args.pipeline, 'JENKINS_JOBS')
+        params.update(params_from_git_refspec(args.pipeline, 'JENKINS_S2I'))
+        params.update(params_from_git_refspec(args.pipeline, 'JENKINS_JOBS'))
     if args.config:
-        params += params_from_git_refspec(args.config, 'FCOS_CONFIG')
+        params.update(params_from_git_refspec(args.config, 'FCOS_CONFIG'))
     if args.bucket:
-        params += [f'S3_BUCKET={args.bucket}']
+        params['S3_BUCKET'] = args.bucket
     if args.cosa_img:
-        params += [f'COREOS_ASSEMBLER_IMAGE={args.cosa_img}']
+        params['COREOS_ASSEMBLER_IMAGE'] = args.cosa_img
     if args.pvc_size:
-        params += [f'PVC_SIZE={args.pvc_size}']
+        params['PVC_SIZE'] = args.pvc_size
     if args.kvm_selector:
-        params += [f'KVM_SELECTOR={args.kvm_selector}']
+        params['KVM_SELECTOR'] = args.kvm_selector
 
     print("Parameters:")
-    for param in params:
-        print(f"  {param}")
-    params = [q for p in params for q in ['--param', p]]
+    for k, v in params.items():
+        print(f"  {k}={v}")
     print()
 
-    resources = subprocess.check_output(
-        ['oc', 'process', '--filename', 'manifests/pipeline.yaml'] + params)
-    return json.loads(resources)
+    def gen_param_args():
+        return [q for k, v in params.items() for q in ['--param', f'{k}={v}']]
+
+    resources = []
+    for template in ['pipeline.yaml']:
+        # and generate the --param FOO=bar ... args for this template
+        param_args = gen_param_args()
+        j = json.loads(subprocess.check_output(
+            ['oc', 'process', '--filename', f'manifests/{template}'] + param_args))
+        resources += j['items']
+    return resources
 
 
 def update_resources(args, resources):
     print("Updating:")
-    for resource in resources['items']:
+    for resource in resources:
         if args.all or is_default_resource(resource):
             action = resource_action(resource)
             if action == 'skip':
@@ -204,7 +211,7 @@ def resource_exists(resource):
 def delete_developer_resources(args, resources):
     # only delete prefixed resources
     print("Deleting:")
-    for resource in resources['items']:
+    for resource in resources:
         if resource['metadata']['name'].startswith(args.prefix):
             out = subprocess.run(['oc', 'delete', '--filename', '-'],
                                  input=json.dumps(resource), encoding='utf-8',
@@ -215,8 +222,8 @@ def delete_developer_resources(args, resources):
 
 def params_from_git_refspec(refspec, param_prefix):
     url, ref = parse_git_refspec(refspec)
-    return [f'{param_prefix}_URL={url}',
-            f'{param_prefix}_REF={ref}']
+    return {f'{param_prefix}_URL': url,
+            f'{param_prefix}_REF': ref}
 
 
 def parse_git_refspec(refspec):

--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: Template
+labels:
+  app: fedora-coreos
+  template: fedora-coreos-jenkins-s2i-template
+metadata:
+  annotations:
+    description: |-
+      Jenkins S2I builder for Fedora CoreOS.
+    iconClass: icon-jenkins
+    openshift.io/display-name: Fedora CoreOS Jenkins S2I
+    openshift.io/documentation-url: https://github.com/coreos/fedora-coreos-pipeline
+    openshift.io/support-url: https://github.com/coreos/fedora-coreos-pipeline
+    openshift.io/provider-display-name: Fedora CoreOS
+    tags: fcos,jenkins,fedora
+  name: fedora-coreos-jenkins-s2i
+parameters:
+  - description: Git source URI for Jenkins S2I
+    name: JENKINS_S2I_URL
+    value: https://github.com/coreos/fedora-coreos-pipeline
+  - description: Git branch/tag reference for Jenkins S2I
+    name: JENKINS_S2I_REF
+    value: master
+  - description: Git source URI for Jenkins jobs
+    name: JENKINS_JOBS_URL
+    value: https://github.com/coreos/fedora-coreos-pipeline
+  - description: Git branch/tag reference for Jenkins jobs
+    name: JENKINS_JOBS_REF
+    value: master
+
+objects:
+
+  ### JENKINS MASTER ###
+
+  # use our own "gated" imagestream for the Jenkins master so we can test new
+  # images before upgrading
+  - apiVersion: v1
+    kind: ImageStream
+    metadata:
+      name: jenkins-s2i
+      annotations:
+        coreos.com/deploy-default: "true"
+    spec:
+      tags:
+        - name: stable
+          from:
+            kind: DockerImage
+            # 2.204.1
+            name: docker.io/openshift/jenkins-2-centos7@sha256:9b75175c6feabfac03f39af5342b31cb4931b53ad9d077d843bb2f1e2d9eb408
+  - apiVersion: v1
+    kind: ImageStream
+    metadata:
+      name: jenkins
+      annotations:
+        coreos.com/deploy-default: "true"
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: jenkins
+      annotations:
+        coreos.com/deploy-default: "true"
+        # These annotations will allow Jenkins to know from where to seed its
+        # jobs once it comes up. Note that it can be from a different git repo
+        # than where the S2I repo is defined.
+        coreos.com/jenkins-jobs-url: ${JENKINS_JOBS_URL}
+        coreos.com/jenkins-jobs-ref: ${JENKINS_JOBS_REF}
+    # Note no triggers: we don't want e.g. git pushes/config changes to restart
+    # Jenkins. Let's just require manual restarts here. XXX: Should investigate
+    # if there's an easy way to auto-redeploy during downtimes.
+    spec:
+      source:
+        type: Git
+        git:
+          uri: ${JENKINS_S2I_URL}
+          ref: ${JENKINS_S2I_REF}
+        contextDir: jenkins/master
+      strategy:
+        type: Source
+        sourceStrategy:
+          from:
+            kind: ImageStreamTag
+            name: jenkins-s2i:stable
+          forcePull: true
+      output:
+        to:
+          kind: ImageStreamTag
+          name: jenkins:2
+      successfulBuildsHistoryLimit: 2
+      failedBuildsHistoryLimit: 2
+
+  ### JENKINS SLAVE ###
+
+  # keep a local copy of the Jenkins slave image so we're not constantly pulling
+  # it each time from docker.io
+  - apiVersion: v1
+    kind: ImageStream
+    metadata:
+      name: jenkins-slave-base-centos7
+      annotations:
+        coreos.com/deploy-default: "true"
+    spec:
+      lookupPolicy:
+        # this allows e.g. the pipeline to directly reference the imagestream
+        local: true
+      tags:
+        - name: latest
+          from:
+            kind: DockerImage
+            # target :latest for now
+            name: docker.io/openshift/jenkins-slave-base-centos7:latest
+          importPolicy:
+            scheduled: true

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -15,12 +15,6 @@ metadata:
     tags: fcos,jenkins,fedora
   name: fedora-coreos
 parameters:
-  - description: Git source URI for Jenkins S2I
-    name: JENKINS_S2I_URL
-    value: https://github.com/coreos/fedora-coreos-pipeline
-  - description: Git branch/tag reference for Jenkins S2I
-    name: JENKINS_S2I_REF
-    value: master
   - description: Git source URI for Jenkins jobs
     name: JENKINS_JOBS_URL
     value: https://github.com/coreos/fedora-coreos-pipeline
@@ -52,82 +46,6 @@ parameters:
     value: legacy-oci-kvm-hook
 
 objects:
-
-  ### JENKINS MASTER ###
-
-  # use our own "gated" imagestream for the Jenkins master so we can test new
-  # images before upgrading
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      name: jenkins-s2i
-      annotations:
-        coreos.com/deploy-default: "true"
-    spec:
-      tags:
-        - name: stable
-          from:
-            kind: DockerImage
-            # 2.204.1
-            name: docker.io/openshift/jenkins-2-centos7@sha256:9b75175c6feabfac03f39af5342b31cb4931b53ad9d077d843bb2f1e2d9eb408
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      name: jenkins
-      annotations:
-        coreos.com/deploy-default: "true"
-  - kind: BuildConfig
-    apiVersion: v1
-    metadata:
-      name: fedora-coreos-jenkins
-      annotations:
-        coreos.com/deploy-default: "true"
-    # Note no triggers: we don't want e.g. git pushes/config changes to restart
-    # Jenkins. Let's just require manual restarts here. XXX: Should investigate
-    # if there's an easy way to auto-redeploy during downtimes.
-    spec:
-      source:
-        type: Git
-        git:
-          uri: ${JENKINS_S2I_URL}
-          ref: ${JENKINS_S2I_REF}
-        contextDir: jenkins/master
-      strategy:
-        type: Source
-        sourceStrategy:
-          from:
-            kind: ImageStreamTag
-            name: jenkins-s2i:stable
-          forcePull: true
-      output:
-        to:
-          kind: ImageStreamTag
-          name: jenkins:2
-      successfulBuildsHistoryLimit: 2
-      failedBuildsHistoryLimit: 2
-
-  ### JENKINS SLAVE ###
-
-  # keep a local copy of the Jenkins slave image so we're not constantly pulling
-  # it each time from docker.io
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      name: jenkins-slave-base-centos7
-      annotations:
-        coreos.com/deploy-default: "true"
-    spec:
-      lookupPolicy:
-        # this allows e.g. the pipeline to directly reference the imagestream
-        local: true
-      tags:
-        - name: latest
-          from:
-            kind: DockerImage
-            # target :latest for now
-            name: docker.io/openshift/jenkins-slave-base-centos7:latest
-          importPolicy:
-            scheduled: true
 
   ### COREOS-ASSEMBLER ###
 


### PR DESCRIPTION
See individual commit messages, but essentially the end goal here is preparations for sharing things with [CoreOS CI](https://github.com/jlebon/coreos-ci). Specifically, I want CoreOS CI to use the exact same Jenkins build configs, i.e. the inputs to the S2I builder. However, the pipeline and CoreOS CI will have different JCasC configurations (provided via configmaps) and Jenkins app templates (`jenkins.yaml`).