### PR TITLE
Jenkinsfile.kola.aws: fix upgrade testing

### DIFF
--- a/Jenkinsfile.kola.aws
+++ b/Jenkinsfile.kola.aws
@@ -45,7 +45,7 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
             utils.shwrap("""
             export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
             coreos-assembler init https://github.com/coreos/fedora-coreos-config
-            coreos-assembler buildprep s3://${params.S3_STREAM_DIR}/builds
+            coreos-assembler buildprep --ostree s3://${params.S3_STREAM_DIR}/builds
             """)
 
             def basearch = utils.shwrap_capture("coreos-assembler basearch")
@@ -76,9 +76,6 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
                   """)
                   archiveArtifacts "kola-run.tar.xz"
                 }
-                if (!utils.checkKolaSuccess("tmp/kola", currentBuild)) {
-                    return
-                }
             },
             aws_upgrade: {
                 stage('Kola:AWS upgrade') {
@@ -89,10 +86,11 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
                     """)
                     archiveArtifacts "kola-run-upgrade.tar.xz"
                 }
-                if (!utils.checkKolaSuccess("tmp/kola-upgrade", currentBuild)) {
-                    return
-                }
             }
+        }
+        if (!utils.checkKolaSuccess("tmp/kola", currentBuild) ||
+            !utils.checkKolaSuccess("tmp/kola-upgrade", currentBuild)) {
+                return
         }
     }}
 }


### PR DESCRIPTION
There were two issues here. First, we were doing return inside of
`stage {}`, so we weren't actually failing the build. Fix this by moving
the result check outside.

Second, the upgrade test needs the OSTree tarball. Pass `--ostree` to
`buildprep` so it downloads it. I hesitated putting the test in the
build pipeline instead, since we obviously have the tarball already, but
I think keeping all AWS testing outside the main build path is better.
Note the main pipeline does do upgrade testing via QEMU already.