### PR TITLE
switch cosa buildprep commands to specify which build

### DIFF
--- a/Jenkinsfile.kola.aws
+++ b/Jenkinsfile.kola.aws
@@ -45,7 +45,7 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
             utils.shwrap("""
             export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
             coreos-assembler init https://github.com/coreos/fedora-coreos-config
-            coreos-assembler buildprep --ostree s3://${params.S3_STREAM_DIR}/builds
+            coreos-assembler buildprep --ostree --build=${params.VERSION} s3://${params.S3_STREAM_DIR}/builds
             """)
 
             def basearch = utils.shwrap_capture("coreos-assembler basearch")
@@ -71,7 +71,7 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
                   utils.shwrap("""
                   export AWS_CONFIG_FILE=\${AWS_FCOS_KOLA_BOT_CONFIG}
                   # use `cosa kola` here since it knows about blacklisted tests
-                  cosa kola run -p aws --aws-ami ${ami} --aws-region ${ami_region} -b fcos -j 5 --no-test-exit-error
+                  cosa kola run --build=${params.VERSION} -p aws --aws-ami ${ami} --aws-region ${ami_region} -b fcos -j 5 --no-test-exit-error
                   tar -cf - tmp/kola | xz -c9 > kola-run.tar.xz
                   """)
                   archiveArtifacts "kola-run.tar.xz"
@@ -81,7 +81,7 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
                 stage('Kola:AWS upgrade') {
                     utils.shwrap("""
                     export AWS_CONFIG_FILE=\${AWS_FCOS_KOLA_BOT_CONFIG}
-                    coreos-assembler kola --upgrades -p=aws --aws-region=${ami_region} --no-test-exit-error
+                    coreos-assembler kola --build=${params.VERSION} --upgrades -p=aws --aws-region=${ami_region} --no-test-exit-error
                     tar -cf - tmp/kola-upgrade | xz -c9 > kola-run-upgrade.tar.xz
                     """)
                     archiveArtifacts "kola-run-upgrade.tar.xz"

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -64,17 +64,14 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
             // only modifies the meta.json
             stage('Replicate AWS AMI') {
                 s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
-                // TODO: Once buildprep supports pulling specific builds
-                // operate on the specific build rather than the most
-                // recent build
                 utils.shwrap("""
                 export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
                 coreos-assembler init https://github.com/coreos/fedora-coreos-config
-                coreos-assembler buildprep s3://${s3_stream_dir}/builds
+                coreos-assembler buildprep --build=${params.VERSION} s3://${s3_stream_dir}/builds
                 coreos-assembler aws-replicate --build=${params.VERSION} --log-level=INFO
                 git clone https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng
-                /var/tmp/fcos-releng/coreos-meta-translator/trans.py --workdir .
-                coreos-assembler buildupload --skip-builds-json s3 --acl=public-read ${s3_stream_dir}/builds
+                /var/tmp/fcos-releng/coreos-meta-translator/trans.py --build-id ${params.VERSION} --workdir .
+                coreos-assembler buildupload --build=${params.VERSION} --skip-builds-json s3 --acl=public-read ${s3_stream_dir}/builds
                 """)
             }
         }


### PR DESCRIPTION
Now that buildprep supports passing in a build id let's use that
so we're more explicit.