### PR TITLE
Jenkinsfiles: add hint for vim to choose correct sytax highlighting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
+// vim: set syntax=groovy:
 import org.yaml.snakeyaml.Yaml;
 
 def utils, streams, official, official_jenkins, developer_prefix, src_config_url, src_config_ref, s3_bucket

--- a/Jenkinsfile.development
+++ b/Jenkinsfile.development
@@ -1,3 +1,4 @@
+// vim: set syntax=groovy:
 def utils, streams
 node {
     checkout scm

--- a/Jenkinsfile.kola.aws
+++ b/Jenkinsfile.kola.aws
@@ -1,3 +1,4 @@
+// vim: set syntax=groovy:
 def utils, streams
 node {
     checkout scm

--- a/Jenkinsfile.mechanical
+++ b/Jenkinsfile.mechanical
@@ -1,3 +1,4 @@
+// vim: set syntax=groovy:
 def utils, streams
 node {
     checkout scm

--- a/Jenkinsfile.production
+++ b/Jenkinsfile.production
@@ -1,3 +1,4 @@
+// vim: set syntax=groovy:
 def utils, streams
 node {
     checkout scm

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -1,3 +1,4 @@
+// vim: set syntax=groovy:
 def utils, streams, s3_bucket
 node {
     checkout scm

--- a/Jenkinsfile.stream.metadata.generator
+++ b/Jenkinsfile.stream.metadata.generator
@@ -1,3 +1,4 @@
+// vim: set syntax=groovy:
 def utils, streams
 node {
     checkout scm


### PR DESCRIPTION
Without the .groovy extension these files won't get any highlighting.
Setting this on the modeline helps.