### PR TITLE
Add stages for importing OSTree commits into Fedora OSTree repos

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,7 +146,7 @@ lock(resource: "build-${params.STREAM}") {
         // future, we'll probably want this either part of the cosa image, or
         // in a derivative of cosa for pipeline needs.
         utils.shwrap("""
-        git clone https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng
+        git clone --depth=1 https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng
         """)
 
         // this is defined IFF we *should* and we *can* upload to S3

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -63,6 +63,13 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
         git clone --depth=1 https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng
         """)
 
+        // Buildprep for the build we are interested in
+        utils.shwrap("""
+        export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
+        cosa init --branch ${params.STREAM} https://github.com/coreos/fedora-coreos-config
+        cosa buildprep --build=${params.VERSION} s3://${s3_stream_dir}/builds
+        """)
+
         if (params.AWS_REPLICATION == 'true') {
             // Replicate the newly uploaded AMI to other regions. Intentionally
             // split out from the 'Upload AWS' stage to allow for tests to be added
@@ -74,8 +81,6 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
                 s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
                 utils.shwrap("""
                 export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
-                cosa init --branch ${params.STREAM} https://github.com/coreos/fedora-coreos-config
-                cosa buildprep --build=${params.VERSION} s3://${s3_stream_dir}/builds
                 cosa aws-replicate --build=${params.VERSION} --log-level=INFO
                 /var/tmp/fcos-releng/coreos-meta-translator/trans.py --build-id ${params.VERSION} --workdir .
                 cosa buildupload --build=${params.VERSION} --skip-builds-json s3 --acl=public-read ${s3_stream_dir}/builds

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -55,6 +55,14 @@ def pod_label = "cosa-${UUID.randomUUID().toString()}"
 lock(resource: "release-${params.STREAM}") {
 podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
     node(pod_label) { container('coreos-assembler') {
+
+        // Clone the automation repo, which contains helper scripts. In the
+        // future, we'll probably want this either part of the cosa image, or
+        // in a derivative of cosa for pipeline needs.
+        utils.shwrap("""
+        git clone --depth=1 https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng
+        """)
+
         if (params.AWS_REPLICATION == 'true') {
             // Replicate the newly uploaded AMI to other regions. Intentionally
             // split out from the 'Upload AWS' stage to allow for tests to be added
@@ -69,7 +77,6 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
                 cosa init --branch ${params.STREAM} https://github.com/coreos/fedora-coreos-config
                 cosa buildprep --build=${params.VERSION} s3://${s3_stream_dir}/builds
                 cosa aws-replicate --build=${params.VERSION} --log-level=INFO
-                git clone https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng
                 /var/tmp/fcos-releng/coreos-meta-translator/trans.py --build-id ${params.VERSION} --workdir .
                 cosa buildupload --build=${params.VERSION} --skip-builds-json s3 --acl=public-read ${s3_stream_dir}/builds
                 """)

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -72,6 +72,18 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
         cosa buildprep --build=${params.VERSION} s3://${s3_stream_dir}/builds
         """)
 
+        // For production streams, import the OSTree into the prod
+        // OSTree repo.
+        if ((params.STREAM in streams.production) && utils.path_exists("/etc/fedora-messaging-cfg/fedmsg.toml")) {
+            stage("OSTree Import: Prod Repo") {
+                utils.shwrap("""
+                /var/tmp/fcos-releng/coreos-ostree-importer/send-ostree-import-request.py \
+                    --build=${params.VERSION} --s3=${s3_stream_dir} --repo=prod \
+                    --fedmsg-conf=/etc/fedora-messaging-cfg/fedmsg.toml
+                """)
+            }
+        }
+
         if (params.AWS_REPLICATION == 'true') {
             // Replicate the newly uploaded AMI to other regions. Intentionally
             // split out from the 'Upload AWS' stage to allow for tests to be added

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -56,6 +56,8 @@ lock(resource: "release-${params.STREAM}") {
 podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
     node(pod_label) { container('coreos-assembler') {
 
+        def s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
+
         // Clone the automation repo, which contains helper scripts. In the
         // future, we'll probably want this either part of the cosa image, or
         // in a derivative of cosa for pipeline needs.
@@ -78,7 +80,6 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
             // We have to re-run the coreos-meta-translator as aws-replicate
             // only modifies the meta.json
             stage('Replicate AWS AMI') {
-                s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
                 utils.shwrap("""
                 export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
                 cosa aws-replicate --build=${params.VERSION} --log-level=INFO


### PR DESCRIPTION
Add stages to call fcos-pipeline-ostree-import-request.py from the
fedora-coreos-releng-automation repo in order to send requests via
Fedora Messaging to the coreos-ostree-importer that is running within
Fedora Infrastructure's OpenShift instance.

There are two import stages. One in the normal pipeline (Jenkinsfile)
that is for importing all commits into the compose repo and one in
the release pipeline (Jenkinsfile.release) that will only run for
production streams and import commits into the production OSTree repo.

Additionally there are a few other commits. Please see individual commit
messages for more information.
