### PR TITLE
Jenkinsfile: do `oc get pods -o wide` upfront

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,6 +137,11 @@ lock(resource: "build-${params.STREAM}") {
     podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
     node(pod_label) { container('coreos-assembler') {
 
+        // first, print out the list of pods for debugging purposes
+        container('jnlp') {
+            utils.shwrap("oc get pods -o wide")
+        }
+
         // declare this early so we can use it in Slack
         def newBuildID
 


### PR DESCRIPTION
We're seeing occasional issues where pods can't find `/dev/kvm` even
though we have a `oci_kvm_hook: allowed` selector (and in fact
`oci-kvm-hook` is installed on the whole cluster).

Print out the pod list on startup so that we can figure out on which
node the pod was scheduled to help debugging the next time we hit this.