### PR TITLE
ci: migrate to new coreos-ci project

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,11 +1,11 @@
-@Library('github.com/coreos/coreos-ci-lib@master') _
+// Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
 
 node {
     checkout scm
 
     stage("Test") {
         // for now, just sanity check all the manifests
-        coreos.shwrap("""
+        shwrap("""
         find manifests/ -iname '*.yaml' | xargs -n 1 oc create --dry-run -f
         """)
     }


### PR DESCRIPTION
Straight-forward. As mentioned before, there's much more we could do
here by factoring things out from the build pipeline, but will keep that
as a separate endeavour.

Requires: https://github.com/coreos/coreos-ci/pull/6