### PR TITLE
Add Exoscale buildextend to pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -346,6 +346,12 @@ lock(resource: "build-${params.STREAM}") {
                 cosa buildextend-azure
                 """)
             }
+            
+            stage('Build Exoscale') {
+                utils.shwrap("""
+                cosa buildextend-exoscale
+                """)
+            }
 
             stage('Build Openstack') {
                 utils.shwrap("""


### PR DESCRIPTION
Add `buildextend-exoscale` to pipeline
https://github.com/coreos/fedora-coreos-tracker/issues/384