### PR TITLE
manifests/pod: stop using PVC cache for now

### DIFF
--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -25,7 +25,7 @@ spec:
        - name: AWS_FCOS_KOLA_BOT_CONFIG
          value: /.aws-fcos-kola-bot-config/config
      volumeMounts:
-     - name: data
+     - name: cache
        mountPath: /srv/
      - name: aws-fcos-builds-bot-config
        mountPath: /.aws-fcos-builds-bot-config/
@@ -49,9 +49,12 @@ spec:
          memory: COREOS_ASSEMBLER_MEMORY_REQUEST
        limits: {}
   volumes:
-  - name: data
-    persistentVolumeClaim:
-      claimName: coreos-assembler-claim2
+  - name: cache
+    # XXX Disabled for now; we're seeing odd I/O issues possibly related to NFS:
+    # https://github.com/coreos/fedora-coreos-pipeline/issues/212
+    #persistentVolumeClaim:
+    #  claimName: coreos-assembler-claim2
+    emptyDir: {}
   # This secret is used for uploading to AWS
   - name: aws-fcos-builds-bot-config
     secret:


### PR DESCRIPTION
We've been hitting strange I/O related issues recently. We originally
traced it down to a specific node that was cordoned off, but now we're
hitting it on other nodes as well.

I think it might be related to the cache qcow2 being on an NFS and some
I/O patterns we do trigger some issues. Anyway, since the pipeline is
failing pretty bad, let's test that theory and swap it out for just an
`emptyDir`.

Also rename the mount to `cache` rather than `data` to make it clear we
don't actually need it.