### PR TITLE
pipeline: add overall timeout of 4h

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ lock(resource: "build-${params.STREAM}") {
         // declare this early so we can use it in Slack
         def newBuildID
 
-        try {
+        try { timeout(time: 240, unit: 'MINUTES') {
 
         // Clone the automation repo, which contains helper scripts. In the
         // future, we'll probably want this either part of the cosa image, or
@@ -509,8 +509,8 @@ lock(resource: "build-${params.STREAM}") {
 
         currentBuild.result = 'SUCCESS'
 
-        // main try {} finishes here
-        } catch (e) {
+        // main timeout and try {} finish here
+        }} catch (e) {
             currentBuild.result = 'FAILURE'
             throw e
         } finally {


### PR DESCRIPTION
Let's cap build runs to 4h. Builds should never take that long. Ideally,
we'd do timeouts per stage, and that could make sense (e.g. signing for
example could in the worst case take more than 1h, but building the
qcow2 shouldn't really take more than 15m), though just having one
overall timeout to start with will at least prevent jobs from getting
stuck anywhere in the process forever and taking up a pod in a cluster.

Closes: #195