### PR TITLE
utils: fail the build if kola tests fail

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -54,9 +54,11 @@ boolean checkKolaSuccess(dir, currentBuild) {
     def report = readJSON file: "${dir}/reports/report.json"
     def result = report["result"]
     print("kola result: ${result}")
-    if (result != "PASS" && report["platform"] == "qemu-unpriv") {
-        shwrap("coreos-assembler compress --compressor xz")
-        archiveArtifacts "builds/latest/**/*.qcow2.xz"
+    if (result != "PASS") {
+        if (report["platform"] == "qemu-unpriv") {
+            shwrap("coreos-assembler compress --compressor xz")
+            archiveArtifacts "builds/latest/**/*.qcow2.xz"
+        }
         currentBuild.result = 'FAILURE'
         return false
     }


### PR DESCRIPTION
We want to always fail the build if the result is not `PASS`. But we
only want to archive the qcow2 if the platform is `qemu-unpriv`.