### PR TITLE
Jenkinsfile: add description for the GCP uploaded image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -424,13 +424,15 @@ lock(resource: "build-${params.STREAM}") {
                     utils.shwrap("""
                     # pick up the project to use from the config
                     gcp_project=\$(jq -r .project_id \${GCP_IMAGE_UPLOAD_CONFIG})
+                    today=\$(date +%Y-%m-%d)
                     cosa buildextend-gcp \
                         --build=${newBuildID} \
                         --upload \
                         --family fedora-coreos-${params.STREAM} \
                         --project=\${gcp_project} \
                         --bucket gs://${gcp_gs_bucket}/image-import \
-                        --json \${GCP_IMAGE_UPLOAD_CONFIG}
+                        --json \${GCP_IMAGE_UPLOAD_CONFIG} \
+                        --description=\"Fedora CoreOS, Fedora CoreOS ${params.STREAM}, ${newBuildID}, ${basearch} published on \$today\"
                     """)
                 }
             }


### PR DESCRIPTION
For public images GCP would like for the description of the image to be
in the format: `DISTRO, DISTRO RELEASE, VERSION, INFO` so that information
can get pulled into web UIs and documentation. Let's start with something
like:

```
Fedora CoreOS, Fedora CoreOS stable, 31.20200310.3.0, x86_64 published on 2020-03-25
```