### PR TITLE
streams: disable bodhi-updates and next-devel for now

### DIFF
--- a/Jenkinsfile.development
+++ b/Jenkinsfile.development
@@ -20,5 +20,7 @@ node {
     )
 
     stream = streams.from_branch(change.GIT_BRANCH)
-    streams.build_stream(stream)
+    if (stream != "") {
+        streams.build_stream(stream)
+    }
 }

--- a/Jenkinsfile.mechanical
+++ b/Jenkinsfile.mechanical
@@ -25,7 +25,9 @@ node {
 
     if (streams.triggered_by_push()) {
         stream = streams.from_branch(change.GIT_BRANCH)
-        streams.build_stream(stream)
+        if (stream != "") {
+            streams.build_stream(stream)
+        }
     } else {
         // cron or manual build: build all mechanical streams
         streams.mechanical.each{ streams.build_stream(it) }

--- a/Jenkinsfile.production
+++ b/Jenkinsfile.production
@@ -21,5 +21,7 @@ node {
     )
 
     stream = streams.from_branch(change.GIT_BRANCH)
-    streams.build_stream(stream)
+    if (stream != "") {
+        streams.build_stream(stream)
+    }
 }

--- a/streams.groovy
+++ b/streams.groovy
@@ -1,18 +1,25 @@
 // Canonical definition of all our streams and their type.
 
 production = ['testing', 'stable' /* , 'next' */]
-development = ['testing-devel', 'next-devel']
-mechanical = ['bodhi-updates' /* , 'bodhi-updates-testing', 'branched', 'rawhide' */]
+development = ['testing-devel' /* , 'next-devel' */]
+mechanical = [/*'bodhi-updates', 'bodhi-updates-testing', 'branched', 'rawhide' */]
+
+all_streams = production + development + mechanical
 
 // Maps a list of streams to a list of GitSCM branches.
 def as_branches(streams) {
     return streams.collect{ [name: "origin/${it}"] }
 }
 
-// Retrieves the stream name from a branch name.
+// Retrieves the stream name from a branch name. Returns "" if branch doesn't
+// correspond to a stream.
 def from_branch(branch) {
     assert branch.startsWith('origin/')
-    return branch['origin/'.length()..-1]
+    stream = branch['origin/'.length()..-1]
+    if (stream in all_streams) {
+        return stream
+    }
+    return ""
 }
 
 // Returns the default trigger for push notifications. This will trigger builds


### PR DESCRIPTION
There's more work needed before we can unblock those. For background,
on bodhi-updates, see:

https://github.com/coreos/fedora-coreos-config/pull/335#issuecomment-610634917

For the next-devel stream, see:

https://github.com/coreos/fedora-coreos-tracker/issues/283#issuecomment-610974733