### PR TITLE
streams: re-enable next-devel

### DIFF
--- a/streams.groovy
+++ b/streams.groovy
@@ -1,7 +1,7 @@
 // Canonical definition of all our streams and their type.
 
 production = ['testing', 'stable' /* , 'next' */]
-development = ['testing-devel' /* , 'next-devel' */]
+development = ['testing-devel', 'next-devel']
 mechanical = [/*'bodhi-updates', 'bodhi-updates-testing', 'branched', 'rawhide' */]
 
 all_streams = production + development + mechanical


### PR DESCRIPTION
We should be able to rebuild this stream soon after
https://github.com/coreos/fedora-coreos-config/pull/351 merges.