### PR TITLE
pipeline: use `cosa build --strict`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -254,7 +254,7 @@ lock(resource: "build-${params.STREAM}") {
                 version = "--version ${new_version}"
             }
             utils.shwrap("""
-            cosa build ostree --skip-prune ${force} ${version} ${parent_arg}
+            cosa build ostree --strict --skip-prune ${force} ${version} ${parent_arg}
             """)
         }
 


### PR DESCRIPTION
We always want to build in strict mode. See:
https://github.com/coreos/fedora-coreos-tracker/issues/454