### PR TITLE
pipeline: use `cosa fetch --strict`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -221,7 +221,7 @@ lock(resource: "build-${params.STREAM}") {
             }
 
             utils.shwrap("""
-            cosa fetch
+            cosa fetch --strict
             """)
         }
 


### PR DESCRIPTION
We also need to fetch in strict mode. This requires [1]. See that PR
for more information.

[1] https://github.com/coreos/coreos-assembler/pull/1378