### PR TITLE
jenkins/config: add seed.yaml

### DIFF
--- a/jenkins/config/seed.yaml
+++ b/jenkins/config/seed.yaml
@@ -1,0 +1,51 @@
+# This seed job simply defines a new pipeline job for each Jenkinsfile found in
+# the jobs/ directory of the target jenkins jobs repo.
+
+security:
+  globalJobDslSecurityConfiguration:
+    # turn off approval for job DSL; we already approve scripts via PR review
+    useScriptSecurity: false
+jobs:
+  - script: |
+      pipelineJob('seed') {
+        definition {
+          cps {
+            sandbox(true)
+            script('''
+              node {
+                // XXX: hack, should put this in coreos-ci-lib
+                sh("curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-pipeline/master/utils.groovy")
+                def utils = load("utils.groovy")
+
+                def url = utils.get_annotation("jenkins", "jenkins-jobs-url")
+                def ref = utils.get_annotation("jenkins", "jenkins-jobs-ref")
+                utils.shwrap("rm -rf source")
+                utils.shwrap("git clone -b ^${ref} ^${url} source")
+
+                findFiles(glob: "source/jobs/*.Jenkinsfile").each { file ->
+                  def split = file.name.split("\\\\.")
+                  assert split[1] == "Jenkinsfile"
+                  def jobName = split[0]
+                  jobDsl scriptText: """
+                    pipelineJob("^${jobName}") {
+                      definition {
+                        cpsScm {
+                          scm {
+                            git {
+                              remote { url("^${url}") }
+                              branches("^${ref}")
+                              extensions { }
+                            }
+                            scriptPath("jobs/^${file.name}")
+                          }
+                        }
+                      }
+                    }
+                  """
+                }
+              }
+            '''.stripIndent())
+          }
+        }
+      }
+      queue('seed')


### PR DESCRIPTION
This patch begins the transition from our current buildconfig-based
pipeline jobs to the one used by CoreOS CI, which is CasC + job DSL +
simple Groovy files in a `jobs/` dir + using the shared coreos-ci-lib
library for making it easy to leverage OpenShift. I really like how it
all fits together, and the upstream CI experimentation has seen some
positive results.

For now, we only install the seed job. This will allow us to then
add pipeline jobs directly in `jobs/`. This is the same CasC fragment
present in CoreOS CI:

https://github.com/coreos/coreos-ci/blob/2421fabaef79f93d2c111fdf9bce648ab3d19680/jenkins/config/seed.yaml

There's follow-ups there to make that seed job cleaner (and deduping
from CoreOS CI).