### PR TITLE
jobs: add bump-lockfile

### DIFF
--- a/jenkins/config/github-coreosbot.yaml
+++ b/jenkins/config/github-coreosbot.yaml
@@ -1,0 +1,15 @@
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+        - usernamePassword:
+            scope: GLOBAL
+            id: github-coreosbot-token
+            username: coreosbot
+            password: ${github-coreosbot-token/token}
+            description: GitHub coreosbot token
+        - string:
+            scope: GLOBAL
+            id: github-coreosbot-token-string
+            secret: ${github-coreosbot-token/token}
+            description: GitHub coreosbot token as a string

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -1,0 +1,80 @@
+@Library('github.com/coreos/coreos-ci-lib@master') _
+
+repo = "coreos/fedora-coreos-config"
+branches = [
+    "testing-devel",
+    "next-devel"
+]
+botCreds = "github-coreosbot-token"
+
+properties([
+    pipelineTriggers([
+        // we don't need to bump lockfiles any more often than daily
+        cron("H H * * *")
+    ])
+])
+
+cosaPod {
+    parallel branches.collectEntries { branch -> [branch, {
+        shwrap("mkdir ${branch}")
+        dir(branch) {
+            shwrap("cosa init --branch ${branch} https://github.com/${repo}")
+
+            shwrap("""
+              git -C src/config config --global user.name "CoreOS Bot"
+              git -C src/config config --global user.email "coreosbot@fedoraproject.org"
+            """)
+
+            // do a first fetch where we only fetch metadata; no point in
+            // importing RPMs if nothing actually changed
+            stage("Fetch Metadata") {
+                shwrap("cosa fetch --update-lockfile --dry-run")
+            }
+
+            if (shwrapRc("git -C src/config diff --exit-code") == 0) {
+                println("No changes")
+                return
+            }
+
+            // sanity-check only base lockfiles were changed
+            shwrap("""
+              # do this separately so set -e kicks in if it fails
+              files=\$(git -C src/config ls-files --modified --deleted)
+              for f in \${files}; do
+                if ! [[ \${f} =~ ^manifest-lock\\.[0-9a-z_]+\\.json ]]; then
+                  echo "Unexpected modified file \${f}"
+                  exit 1
+                fi
+              done
+            """)
+
+            stage("Fetch") {
+                // XXX: hack around subtle lockfile bug (jlebon to submit an
+                // rpm-ostree issue or patch about this)
+                shwrap("cp src/config/fedora-coreos-pool.repo{,.bak}")
+                shwrap("echo cost=500 >> src/config/fedora-coreos-pool.repo")
+                shwrap("cosa fetch --strict")
+                shwrap("cp src/config/fedora-coreos-pool.repo{.bak,}")
+            }
+
+            stage("Build") {
+                shwrap("cosa build --strict")
+            }
+
+            fcosKola(cosaDir: ".")
+
+            // OK, it passed kola: just push to the branch. In the future, we might be
+            // fancier here; e.g. if tests fail, just open a PR, or if tests passed but a
+            // package was added or removed.
+            stage("Push") {
+                shwrap("git -C src/config commit -am 'lockfiles: bump to latest'")
+                withCredentials([usernamePassword(credentialsId: botCreds,
+                                                  usernameVariable: 'GHUSER',
+                                                  passwordVariable: 'GHTOKEN')]) {
+                  // should gracefully handle race conditions here
+                  sh("git -C src/config push https://${GHUSER}:${GHTOKEN}@github.com/${repo} ${branch}")
+                }
+            }
+        }
+    }] }
+}


### PR DESCRIPTION
This job will implement lockfile bumping for testing-devel and
next-devel: coreos/fedora-coreos-tracker#293.

The original plan for this functionality was to have it in config-bot:
coreos/fedora-coreos-releng-automation#48

But in the end, I think it's more natural to have it as a Jenkins job
given that it does a lot of the same things as the pipeline/upstream CI
jobs. So that way it looks and feels just like another job that runs
cosa, and we get kola artifacts, we can re-use the shared library,
it's easily inspectable, we can hook it to Slack, etc...