### PR TITLE
pipeline: add temporary knob to allow upgrade tests to fail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,9 @@ properties([
       booleanParam(name: 'MINIMAL',
                    defaultValue: (official ? false : true),
                    description: 'Whether to only build the OSTree and qemu images'),
+      booleanParam(name: 'ALLOW_KOLA_UPGRADE_FAILURE',
+                   defaultValue: false,
+                   description: "Don't error out if upgrade tests fail (temporary)"),
       // use a string here because passing booleans via `oc start-build -e`
       // is non-trivial
       choice(name: 'AWS_REPLICATION',
@@ -328,7 +331,7 @@ lock(resource: "build-${params.STREAM}") {
             """)
             archiveArtifacts "kola-run-upgrade.tar.xz"
         }
-        if (!utils.checkKolaSuccess("tmp/kola-upgrade", currentBuild)) {
+        if (!params.ALLOW_KOLA_UPGRADE_FAILURE && !utils.checkKolaSuccess("tmp/kola-upgrade", currentBuild)) {
             return
         }
 


### PR DESCRIPTION
Upgrade tests on the `next` stream are going to fail right now because
of a known regression:

https://github.com/coreos/fedora-coreos-tracker/issues/473

Add a temporary knob to allow continuing the build without it.

I initially tried just blacklisting it, but because it's the only test
in the suite right now, kola errors out due to no tests being available
to run.