### PR TITLE
Add pipeline to test GCP images

### DIFF
--- a/Jenkinsfile.kola.gcp
+++ b/Jenkinsfile.kola.gcp
@@ -1,0 +1,121 @@
+def utils, streams
+node {
+    checkout scm
+    utils = load("utils.groovy")
+    streams = load("streams.groovy")
+    pod = readFile(file: "manifests/pod.yaml")
+}
+
+properties([
+    pipelineTriggers([]),
+    parameters([
+      string(name: 'STREAM',
+             description: 'The Stream we are testing against',
+             defaultValue: '',
+             trim: true),
+      string(name: 'VERSION',
+             description: 'Fedora CoreOS Build ID to test',
+             defaultValue: '',
+             trim: true),
+      string(name: 'S3_STREAM_DIR',
+             description: 'Fedora CoreOS S3 Stream Directory',
+             defaultValue: '',
+             trim: true),
+      string(name: 'COREOS_ASSEMBLER_IMAGE',
+             description: 'Override coreos-assembler image to use',
+             defaultValue: "coreos-assembler:master",
+             trim: true)
+    ])
+])
+
+currentBuild.description = "[${params.STREAM}] - ${params.VERSION}"
+
+// substitute the right COSA image into the pod definition before spawning it
+pod = pod.replace("COREOS_ASSEMBLER_IMAGE", params.COREOS_ASSEMBLER_IMAGE)
+
+// shouldn't need more than 256Mi for this job
+pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "256Mi")
+
+// use a unique label to force Kubernetes to provision a separate pod per run
+def pod_label = "cosa-${UUID.randomUUID().toString()}"
+
+podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
+    node(pod_label) { container('coreos-assembler') {
+        def gcp_image, no_gcp_image
+        def no_gcp_image = false
+        // we'll want to get the image project from the meta.json in the
+        // future, but it's not in there for now.
+        // def gcp_image_project
+        def gcp_image_project='fedora-coreos-cloud'
+
+        def meta_json
+        stage('Fetch Metadata') {
+            utils.shwrap("""
+            export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
+            cosa init --branch ${params.STREAM} https://github.com/coreos/fedora-coreos-config
+            cosa buildprep --ostree --build=${params.VERSION} s3://${params.S3_STREAM_DIR}/builds
+            """)
+
+            def basearch = utils.shwrap_capture("cosa basearch")
+            meta_json = "builds/${params.VERSION}/${basearch}/meta.json"
+            def meta = readJSON file: meta_json
+            if (meta.gcp.image) {
+                gcp_image = meta.gcp.image
+            } else {
+                no_gcp_image = true
+            }
+        }
+
+        // fail immediately if the build contained no GCP image
+        if (no_gcp_image) {
+          currentBuild.result = 'FAILURE'
+          return
+        }
+
+        stage('Kola') {
+            parallel gcp: {
+                stage('Kola:GCP') {
+                  utils.shwrap("""
+                  # pick up the project to use from the config
+                  gcp_project=\$(jq -r .project_id \${GCP_KOLA_TESTS_CONFIG})
+                  # use `cosa kola` here since it knows about blacklisted tests
+                  cosa kola run \
+                      -b fcos -j 5 \
+                      --no-test-exit-error \
+                      --build=${params.VERSION} \
+                      --platform gce \
+                      --gce-project=\${gcp_project} \
+                      --gce-image="projects/${gcp_image_project}/global/images/${gcp_image}" \
+                      --gce-json-key=\${GCP_KOLA_TESTS_CONFIG}
+                  tar -cf - tmp/kola | xz -c9 > kola-run.tar.xz
+                  """)
+                  archiveArtifacts "kola-run.tar.xz"
+                }
+            },
+            gcp_upgrade: {
+                stage('Kola:GCP upgrade') {
+                  utils.shwrap("""
+                  # pick up the project to use from the config
+                  gcp_project=\$(jq -r .project_id \${GCP_KOLA_TESTS_CONFIG})
+                  # use `cosa kola` here since it knows about blacklisted tests
+                  cosa kola run \
+                      -b fcos -j 5 \
+                      --no-test-exit-error \
+                      --build=${params.VERSION} \
+                      --platform gce \
+                      --gce-project=\${gcp_project} \
+                      --gce-image="projects/${gcp_image_project}/global/images/${gcp_image}" \
+                      --gce-json-key=\${GCP_KOLA_TESTS_CONFIG}
+                      --upgrades
+                  tar -cf - tmp/kola-upgrade | xz -c9 > kola-run-upgrade.tar.xz
+                  """)
+                  archiveArtifacts "kola-run-upgrade.tar.xz"
+                }
+            }
+        }
+        if (!utils.checkKolaSuccess("tmp/kola", currentBuild) ||
+            !utils.checkKolaSuccess("tmp/kola-upgrade", currentBuild)) {
+                return
+        }
+    }}
+}


### PR DESCRIPTION
This adds the Jenkinsfile.kola.gcp file that will allow us to run tests
against GCP images just like we do for AWS images.