### PR TITLE
Add new sync-stream-metadata job

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -169,20 +169,28 @@ If you are in production where we upload builds to S3 OR you want to
 test uploading to S3 as part of your pipeline development, you need to
 create a credentials config as a secret within OpenShift.
 
-First create a file with your secret content:
+First create files with your secret content:
 
 ```
-cat <<'EOF' > /path/to/upload-secret
+mkdir dir
+cat <<'EOF' > dir/config
 [default]
 aws_access_key_id=keyid
 aws_secret_access_key=key
 EOF
+echo keyid > dir/accessKey
+echo key > dir/secretKey
 ```
+
+We expose it in different ways (as an AWS config file and as direct
+fields) because those credentials are used both directly as Jenkins
+credentials (which use the direct fields) and by e.g. `cosa`, which
+accepts an AWS config file.
 
 Then create the secret in OpenShift:
 
 ```
-oc create secret generic aws-fcos-builds-bot-config --from-file=config=/path/to/upload-secret
+oc create secret generic aws-fcos-builds-bot-config --from-file=dir
 ```
 
 We also have a second AWS config that can be used for running kola

--- a/jenkins/config/aws.yaml
+++ b/jenkins/config/aws.yaml
@@ -1,0 +1,10 @@
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+        - aws:
+            scope: GLOBAL
+            id: aws-fcos-builds-bot
+            accessKey: ${aws-fcos-builds-bot-config/accessKey}
+            secretKey: ${aws-fcos-builds-bot-config/secretKey}
+            description: AWS fcos-builds-bot credentials

--- a/jenkins/master/plugins.txt
+++ b/jenkins/master/plugins.txt
@@ -3,3 +3,4 @@ configuration-as-code:1.33
 slack:2.34
 job-dsl:1.76
 matrix-auth:2.4.2
+aws-credentials:1.28

--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -1,0 +1,20 @@
+@Library('github.com/coreos/coreos-ci-lib@master') _
+
+properties([
+    pipelineTriggers([
+        githubPush(),
+        // also run every 15 mins as a fallback in case webhooks are down
+        pollSCM('H/15 * * * *')
+    ])
+])
+
+cosaPod {
+    git(url: 'https://github.com/coreos/fedora-coreos-streams', credentialsId: 'github-coreosbot-token')
+    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-fcos-builds-bot']]) {
+        shwrap("""
+            aws s3 sync --acl public-read --cache-control 'max-age=60' \
+                --exclude '*' --include 'streams/*' --include 'updates/*' \
+                    ./ s3://fcos-builds
+        """)
+    }
+}

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -111,6 +111,10 @@ objects:
           - name: slack-token
             mountPath: /var/run/secrets/slack-api-token
             readOnly: true
+          # DELTA: mount AWS creds; see below
+          - name: aws-fcos-builds-bot-creds
+            mountPath: /var/run/secrets/aws-fcos-builds-bot-config
+            readOnly: true
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         serviceAccountName: ${JENKINS_SERVICE_NAME}
@@ -122,10 +126,15 @@ objects:
         - name: ${JENKINS_SERVICE_NAME}-casc-cfg
           configMap:
             name: jenkins-casc-cfg
-        # DELTA: add the Slack token
+        # DELTA: add the Slack token (needed to report pipeline failures)
         - name: slack-token
           secret:
             secretName: slack-api-token
+            optional: true
+        # DELTA: add AWS creds (used by the sync-stream-metadata job)
+        - name: aws-fcos-builds-bot-creds
+          secret:
+            secretName: aws-fcos-builds-bot-config
             optional: true
     triggers:
     - imageChangeParams:


### PR DESCRIPTION
Add a new job that will automatically sync the fedora-coreos-streams
metadata to S3. This is part of streamlining the release process.