### PR TITLE
Jenkinsfile.kola.gcp: drop --gce-image

### DIFF
--- a/Jenkinsfile.kola.gcp
+++ b/Jenkinsfile.kola.gcp
@@ -101,7 +101,6 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
                       --no-test-exit-error \
                       --platform=gce \
                       --gce-project=\${gcp_project} \
-                      --gce-image="projects/${gcp_image_project}/global/images/${gcp_image}" \
                       --gce-json-key=\${GCP_KOLA_TESTS_CONFIG}
                   tar -cf - tmp/kola-upgrade | xz -c9 > kola-run-upgrade.tar.xz
                   """)


### PR DESCRIPTION
Upgrade tests use the image of the previous release, not the candidate
release we're testing itself. The `--find-parent-image` switch will
automatically find the starting image to use.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/487