### PR TITLE
Jenkinsfile: attach nested virtualization license to GCP images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -448,6 +448,7 @@ lock(resource: "build-${params.STREAM}") {
                         --deprecated \
                         --family fedora-coreos-${params.STREAM} \
                         --license fedora-coreos-${params.STREAM} \
+                        --license "https://compute.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx" \
                         --project=\${gcp_project} \
                         --bucket gs://${gcp_gs_bucket}/image-import \
                         --json \${GCP_IMAGE_UPLOAD_CONFIG} \


### PR DESCRIPTION
This will allow for launched instances to have access to /dev/kvm
by default. I am not aware of any known drawbacks to doing this as
I've been informed by GCP folks that if there is an environment that
doesn't have nested virt support or if there is a policy that disallows
it the instance simply won't have access to /dev/kvm. No other errors
would be presented to the user (like not being able to launch an
instance).