### PR TITLE
Jenkinsfile: tweak parallel branches' names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -363,9 +363,9 @@ lock(resource: "build-${params.STREAM}") {
                 export XZ_DEFAULTS=--memlimit=${xz_memlimit}Mi
                 cosa compress --compressor xz --artifact metal --artifact metal4k
                 """)
-                parallel 512b: {
+                parallel metal: {
                     utils.shwrap("kola testiso -S")
-                }, 4k: {
+                }, metal4k: {
                     utils.shwrap("kola testiso -SP --qemu-native-4k")
                 }
             }


### PR DESCRIPTION
I think Jenkins doesn't like that the parallel branch name starts with
numbers. Anyway, I think it's clearer if we just use the same names as
the artifacts that each branch is testing.