### PR TITLE
bump-lockfile: fix variable substitution for auth

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -72,7 +72,7 @@ cosaPod {
                                                   usernameVariable: 'GHUSER',
                                                   passwordVariable: 'GHTOKEN')]) {
                   // should gracefully handle race conditions here
-                  sh("git -C src/config push https://${GHUSER}:${GHTOKEN}@github.com/${repo} ${branch}")
+                  sh("git -C src/config push https://\${GHUSER}:\${GHTOKEN}@github.com/${repo} ${branch}")
                 }
             }
         }


### PR DESCRIPTION
The credential bindings bind to environment variables that e.g. `bash`
can access. So here we need to escape the variable references to make
sure it's `bash` that dereferences them. Oddly, this somehow did work at
first, so I think it did/does sometimes also bind to Groovy variables.