### PR TITLE
Disable next-devel stream for now

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -2,8 +2,8 @@
 
 repo = "coreos/fedora-coreos-config"
 branches = [
-    "testing-devel",
-    "next-devel"
+    "testing-devel"
+    // "next-devel"
 ]
 botCreds = "github-coreosbot-token"
 

--- a/streams.groovy
+++ b/streams.groovy
@@ -1,7 +1,7 @@
 // Canonical definition of all our streams and their type.
 
 production = ['testing', 'stable', 'next']
-development = ['testing-devel', 'next-devel']
+development = ['testing-devel'] /* , 'next-devel'] */
 mechanical = [/*'bodhi-updates', 'bodhi-updates-testing', 'branched', 'rawhide' */]
 
 all_streams = production + development + mechanical


### PR DESCRIPTION
Until f33 branches or we start using it to track new kernel/systemd
updates.