### PR TITLE
pipeline: archive liveiso on failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -369,6 +369,9 @@ lock(resource: "build-${params.STREAM}") {
                     }, metal4k: {
                         utils.shwrap("kola testiso -SP --qemu-native-4k --output-dir tmp/kola-metal4k")
                     }
+                } catch (Throwable e) {
+                    archiveArtifacts "builds/latest/**/*.iso"
+                    throw e
                 } finally {
                     utils.shwrap("tar -cf - tmp/kola-metal/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal.tar.xz")
                     utils.shwrap("tar -cf - tmp/kola-metal4k/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal4k.tar.xz")


### PR DESCRIPTION
This is a bit heavy-handed, but the pipeline is failing right now at the
`metal4k` `iso-offline-install` test and I can't reproduce it locally.
It's possible that there's a subtle mismatch, or it's somehow down to
the Jenkins environment. To rule that out, let's just archive the iso
for now if `testiso` failed.