### PR TITLE
pipeline: generate liveiso after metal4k

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -342,15 +342,15 @@ lock(resource: "build-${params.STREAM}") {
                 """)
             }
 
-            stage('Build Live') {
-                utils.shwrap("""
-                cosa buildextend-live
-                """)
-            }
-
             stage('Build Metal (4K Native)') {
                 utils.shwrap("""
                 cosa buildextend-metal4k
+                """)
+            }
+
+            stage('Build Live') {
+                utils.shwrap("""
+                cosa buildextend-live
                 """)
             }
 


### PR DESCRIPTION
We need the metal4k image in place before generating the ISO so that we
can `osmet pack` it. Otherwise understandably, the `iso-offline-install`
test for `metal4k` will fail. We should probably add a switch that makes
it required to `buildextend-live`.