### PR TITLE
Some webhook configuration improvements

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -407,18 +407,6 @@ oc create secret generic fedora-messaging-coreos-key \
   --from-file=coreos.crt --from-file=coreos.key
 ```
 
-### [PROD] Set up webhooks/automation
-
-- From the GitHub Settings tab for `fedora-coreos-config`, go to the
-  "Webhooks" panel
-- Click "Add webhook"
-- In the address, type `$JENKINS_URL/github-webhook/`. So e.g.:
-  https://jenkins-fedora-coreos-devel.apps.ci.centos.org/github-webhook/
-- Change the Content Type from GitHub’s default `application/x-www-form-urlencoded` to `application/json`.
-- Click "Add webhook"
-
-Repeat these steps for the `fedora-coreos-pipeline` repo.
-
 ### [OPTIONAL] Set up simple-httpd
 
 When hacking locally, it might be useful to look at the contents of the

--- a/HACKING.md
+++ b/HACKING.md
@@ -261,6 +261,15 @@ $ oc create secret generic slack-api-token --from-file=token=slack-token
 You can obtain a token when creating a new instance of the Jenkins CI
 app in your Slack workspace.
 
+### [PROD] GitHub webhook shared secret
+
+Create a shared webhook secret using e.g. `uuidgen -r`:
+
+```
+uuidgen -r > secret
+oc secret new github-webhook-shared-secret secret=secret
+```
+
 ### Create a Jenkins instance with a persistent volume backing store
 
 ```

--- a/jenkins/config/github-webhook.yaml
+++ b/jenkins/config/github-webhook.yaml
@@ -1,5 +1,16 @@
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+        - string:
+            scope: GLOBAL
+            id: github-webhook-shared-secret
+            secret: ${github-webhook-shared-secret/secret}
+            description: GitHub Webhook Shared Secret
 unclassified:
   gitHubPluginConfig:
+    hookSecretConfig:
+      credentialsId: github-webhook-shared-secret
     configs:
       - credentialsId: github-coreosbot-token-string
         manageHooks: true

--- a/jenkins/config/github-webhook.yaml
+++ b/jenkins/config/github-webhook.yaml
@@ -1,0 +1,5 @@
+unclassified:
+  gitHubPluginConfig:
+    configs:
+      - credentialsId: github-coreosbot-token-string
+        manageHooks: true


### PR DESCRIPTION
```
$ git log master..
commit a1abda72f11dfd0a56b456760aa45ac13ca89034
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Fri Jun 5 16:43:18 2020 -0400

    config: use a webhook shared secret

    Just as good practice, we should use a shared secret when using
    webhooks.

commit 8ca6a5a076bcf3c69e1af46966c1f477c71e7096
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Fri Jun 5 16:42:36 2020 -0400

    config: let Jenkins manage webhooks

    That way we don't have to go fiddle around in repo settings manually.

```