### PR TITLE
Jenkinsfile: slightly change description for GCP images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -480,7 +480,7 @@ lock(resource: "build-${params.STREAM}") {
                         --project=\${gcp_project} \
                         --bucket gs://${gcp_gs_bucket}/image-import \
                         --json \${GCP_IMAGE_UPLOAD_CONFIG} \
-                        --description=\"Fedora CoreOS, Fedora CoreOS ${params.STREAM}, ${newBuildID}, ${basearch} published on \$today\"
+                        --description=\"Fedora, Fedora CoreOS ${params.STREAM}, ${newBuildID}, ${basearch} published on \$today\"
                     """)
                 }
             }


### PR DESCRIPTION
There is a box in the web UI that shows the images were
"Created By: Fedora CoreOS". Let's change our description
slightly so that it says "Created By: Fedora" instead.