### PR TITLE
jobs: pin to coreos-ci-lib for OCP3 for now

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('github.com/coreos/coreos-ci-lib@master') _
+@Library('github.com/coreos/coreos-ci-lib@ocp3') _
 
 repo = "coreos/fedora-coreos-config"
 branches = [

--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('github.com/coreos/coreos-ci-lib@master') _
+@Library('github.com/coreos/coreos-ci-lib@ocp3') _
 
 properties([
     pipelineTriggers([


### PR DESCRIPTION
I'd like to have CoreOS CI exercise the new cluster for a bit before
moving the production pipeline itself over. For now, let's pin the
version of coreos-ci-lib we use here which still uses oci-kvm-hook
instead of kubevirt.