### PR TITLE
Re-enable `next-devel` stream

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -2,8 +2,8 @@
 
 repo = "coreos/fedora-coreos-config"
 branches = [
-    "testing-devel"
-    // "next-devel"
+    "testing-devel",
+    "next-devel"
 ]
 botCreds = "github-coreosbot-token"
 

--- a/streams.groovy
+++ b/streams.groovy
@@ -1,7 +1,7 @@
 // Canonical definition of all our streams and their type.
 
 production = ['testing', 'stable', 'next']
-development = ['testing-devel'] /* , 'next-devel'] */
+development = ['testing-devel', 'next-devel']
 mechanical = [/*'bodhi-updates', 'bodhi-updates-testing', 'branched', 'rawhide' */]
 
 all_streams = production + development + mechanical


### PR DESCRIPTION
We want to experiment in `next` with the major podman version bump
so let's re-enable `next-devel`.

See https://github.com/coreos/fedora-coreos-tracker/issues/560

This reverts commit d65ae1cba488c4be9ae6b43b5e7975c49f5776ac.