### PR TITLE
pipeline: build legacy PXE images for now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -359,7 +359,7 @@ lock(resource: "build-${params.STREAM}") {
 
             stage('Build Live') {
                 utils.shwrap("""
-                cosa buildextend-live
+                cosa buildextend-live --legacy-pxe
                 """)
             }
 


### PR DESCRIPTION
Generate a PXE rootfs image that only contains a flag file for alerting purposes.  We'll switch to a real separate rootfs image after a deprecation period.

For https://github.com/coreos/fedora-coreos-tracker/issues/390.  Must be merged at the same time as https://github.com/coreos/coreos-assembler/pull/1608.