### PR TITLE
pipeline: update comment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -364,8 +364,8 @@ lock(resource: "build-${params.STREAM}") {
             }
 
             stage('Test Live ISO') {
-                // compress the metal and metal4k images now so that each test
-                // doesn't have to compress them
+                // compress the metal and metal4k images now so we're testing
+                // installs with the image format we ship
                 // lower to make sure we don't go over and account for overhead
                 def xz_memlimit = cosa_memory_request_mb - 512
                 utils.shwrap("""


### PR DESCRIPTION
With https://github.com/coreos/coreos-assembler/pull/1620, running `cosa compress` before `kola testiso` is no longer more efficient, but we should still test with compressed artifacts because that's what users will use.