### PR TITLE
pipeline: disable legacy PXE artifacts except on testing*/stable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -359,7 +359,14 @@ lock(resource: "build-${params.STREAM}") {
 
             stage('Build Live') {
                 utils.shwrap("""
-                cosa buildextend-live --legacy-pxe
+                case "${params.STREAM}" in
+                testing-devel|testing|stable)
+                    cosa buildextend-live --legacy-pxe
+                    ;;
+                *)
+                    cosa buildextend-live
+                    ;;
+                esac
                 """)
             }
 


### PR DESCRIPTION
Switch next and next-devel to the modern artifacts.