### PR TITLE
Move pipeline to new OCP4 cluster

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -17,7 +17,7 @@ In the following sections, the section header may indicate whether the
 section applies to the local cluster case (`[LOCAL]`) or the official
 prod case (`[PROD]`).
 
-You'll want to be sure you have KVM available in your cluster.  See
+You'll want to be sure you have kubevirt available in your cluster.  See
 [this section of the coreos-assembler docs](https://github.com/coreos/coreos-assembler/blob/master/README.md#getting-started---prerequisites).
 
 ### Using a production OpenShift cluster
@@ -306,9 +306,6 @@ circumstances. Here are some of them:
     - Git source URL and optional git ref for pipeline Jenkinsfile.
 - `--config <URL>[@REF]`
     - Git source URL and optional git ref for FCOS config.
-- `--kvm-selector=kvm-device-plugin`:
-    - Use this if you're using the KVM device plugin (modern
-      Kubernetes/OpenShift 4+).
 - `--pvc-size <SIZE>`
     - Size of the cache PVC to create. Note that the PVC size cannot be
       changed after creation. The format is the one understood by

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ node {
     pod = readFile(file: "manifests/pod.yaml")
 
     // just autodetect if we're in the official prod Jenkins or not
-    official_jenkins = (env.JENKINS_URL == 'https://jenkins-fedora-coreos.apps.ci.centos.org/')
+    official_jenkins = (env.JENKINS_URL == 'https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/')
     def official_job = (env.JOB_NAME == 'fedora-coreos/fedora-coreos-fedora-coreos-pipeline')
     official = (official_jenkins && official_job)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,6 @@ node {
     src_config_url = utils.get_pipeline_annotation('source-config-url')
     src_config_ref = utils.get_pipeline_annotation('source-config-ref')
     s3_bucket = utils.get_pipeline_annotation('s3-bucket')
-    kvm_selector = utils.get_pipeline_annotation('kvm-selector')
     gcp_gs_bucket = utils.get_pipeline_annotation('gcp-gs-bucket')
 
     // sanity check that a valid prefix is provided if in devel mode and drop
@@ -99,21 +98,6 @@ pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "${cosa_memory_request_mb}M
 pod = pod.replace("COREOS_ASSEMBLER_IMAGE", params.COREOS_ASSEMBLER_IMAGE)
 
 def podYaml = readYaml(text: pod);
-// And the KVM selector
-def cosaContainer = podYaml['spec']['containers'][1];
-switch (kvm_selector) {
-    case 'kvm-device-plugin':
-        def resources = cosaContainer['resources'];
-        def kvmres = 'devices.kubevirt.io/kvm';
-        resources['requests'][kvmres] = '1';
-        resources['limits'][kvmres] = '1';
-        break;
-    case 'legacy-oci-kvm-hook':
-        cosaContainer['nodeSelector'] = ['oci_kvm_hook': 'allowed'];
-        break;
-    default:
-        throw new Exception("Unknown KVM selector: ${kvm_selector}")
-}
 
 // And re-serialize; I couldn't figure out how to dump to a string
 // in a way allowed by the Groovy sandbox.  Tempting to just tell people

--- a/deploy
+++ b/deploy
@@ -102,8 +102,6 @@ def parse_args():
                         help="AWS S3 bucket to use")
     parser.add_argument("--gcp-gs-bucket", metavar='GCP_GS_BUCKET',
                         help="GCP GS bucket to use for image uploads during import")
-    parser.add_argument("--kvm-selector", help="KVM selector",
-                        choices=['kvm-device-plugin', 'legacy-oci-kvm-hook'])
     parser.add_argument("--cosa-img", metavar='FQIN',
                         help="Pullspec to use for COSA image")
     parser.add_argument("--pvc-size", metavar='SIZE',
@@ -148,8 +146,6 @@ def process_template(args):
         params['COREOS_ASSEMBLER_IMAGE'] = args.cosa_img
     if args.pvc_size:
         params['PVC_SIZE'] = args.pvc_size
-    if args.kvm_selector:
-        params['KVM_SELECTOR'] = args.kvm_selector
     if args.gcp_gs_bucket:
         params['GCP_GS_BUCKET'] = args.gcp_gs_bucket
 

--- a/deploy
+++ b/deploy
@@ -72,7 +72,7 @@ def targeting_official_namespace():
     assert len(url) == 1, f"Found {len(url)} clusters named '{cluster_name}'"
     url = url[0]
 
-    return (url == "https://console.apps.ci.centos.org:8443" and
+    return (url == "https://api.ocp.ci.centos.org:6443" and
             namespace == 'fedora-coreos')
 
 

--- a/jenkins/master/plugins.txt
+++ b/jenkins/master/plugins.txt
@@ -1,5 +1,5 @@
 github-oauth:0.33
-configuration-as-code:1.33
+configuration-as-code:1.35
 slack:2.34
 job-dsl:1.76
 matrix-auth:2.4.2

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('github.com/coreos/coreos-ci-lib@ocp3') _
+@Library('github.com/coreos/coreos-ci-lib') _
 
 repo = "coreos/fedora-coreos-config"
 branches = [

--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('github.com/coreos/coreos-ci-lib@ocp3') _
+@Library('github.com/coreos/coreos-ci-lib') _
 
 properties([
     pipelineTriggers([

--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -32,21 +32,6 @@ objects:
 
   ### JENKINS MASTER ###
 
-  # use our own "gated" imagestream for the Jenkins master so we can test new
-  # images before upgrading
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      name: jenkins-s2i
-      annotations:
-        coreos.com/deploy-default: "true"
-    spec:
-      tags:
-        - name: stable
-          from:
-            kind: DockerImage
-            # 2.204.1
-            name: docker.io/openshift/jenkins-2-centos7@sha256:9b75175c6feabfac03f39af5342b31cb4931b53ad9d077d843bb2f1e2d9eb408
   - apiVersion: v1
     kind: ImageStream
     metadata:
@@ -79,7 +64,8 @@ objects:
         sourceStrategy:
           from:
             kind: ImageStreamTag
-            name: jenkins-s2i:stable
+            name: jenkins:2
+            namespace: openshift
           forcePull: true
       output:
         to:

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -2,27 +2,22 @@
 # to be able to pass in more information to the Jenkins pod, such as env vars,
 # secrets, configmaps, etc...
 
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 labels:
   app: fedora-coreos
   template: fedora-coreos-jenkins-template
+message: A Jenkins service has been created in your project.  Log into Jenkins with
+  your OpenShift account.  The tutorial at https://github.com/openshift/origin/blob/master/examples/jenkins/README.md
+  contains more information about using this template.
 metadata:
-  annotations:
-    description: |-
-      Jenkins service for the Fedora CoreOS pipeline.
-    iconClass: icon-jenkins
-    openshift.io/display-name: Fedora CoreOS Jenkins
-    openshift.io/documentation-url: https://github.com/coreos/fedora-coreos-pipeline
-    openshift.io/support-url: https://github.com/coreos/fedora-coreos-pipeline
-    openshift.io/provider-display-name: Fedora CoreOS
-    tags: fcos,jenkins,fedora
   name: fedora-coreos-jenkins
 objects:
 - apiVersion: v1
   kind: Route
   metadata:
     annotations:
+      haproxy.router.openshift.io/timeout: 4m
       template.openshift.io/expose-uri: http://{.spec.host}{.spec.path}
     name: ${JENKINS_SERVICE_NAME}
   spec:
@@ -66,33 +61,40 @@ objects:
             value: ${ENABLE_OAUTH}
           - name: OPENSHIFT_ENABLE_REDIRECT_PROMPT
             value: "true"
-          - name: OPENSHIFT_JENKINS_JVM_ARCH
-            value: ${JVM_ARCH}
+          - name: DISABLE_ADMINISTRATIVE_MONITORS
+            value: ${DISABLE_ADMINISTRATIVE_MONITORS}
           - name: KUBERNETES_MASTER
             value: https://kubernetes.default:443
           - name: KUBERNETES_TRUST_CERTIFICATES
             value: "true"
+          - name: JENKINS_SERVICE_NAME
+            value: ${JENKINS_SERVICE_NAME}
           - name: JNLP_SERVICE_NAME
             value: ${JNLP_SERVICE_NAME}
+          - name: ENABLE_FATAL_ERROR_LOG_FILE
+            value: ${ENABLE_FATAL_ERROR_LOG_FILE}
+          - name: JENKINS_UC_INSECURE
+            value: ${JENKINS_UC_INSECURE}
           # DELTA: point c-as-c plugin to config map files; see below
           - name: CASC_JENKINS_CONFIG
             value: /var/lib/jenkins/configuration-as-code
           image: ' '
           imagePullPolicy: IfNotPresent
           livenessProbe:
-            failureThreshold: 30
+            failureThreshold: 2
             httpGet:
               path: /login
               port: 8080
             initialDelaySeconds: 420
-            timeoutSeconds: 3
+            periodSeconds: 360
+            timeoutSeconds: 240
           name: jenkins
           readinessProbe:
             httpGet:
               path: /login
               port: 8080
             initialDelaySeconds: 3
-            timeoutSeconds: 3
+            timeoutSeconds: 240
           resources:
             limits:
               memory: ${MEMORY_LIMIT}
@@ -212,14 +214,10 @@ parameters:
   displayName: Enable OAuth in Jenkins
   name: ENABLE_OAUTH
   value: "true"
-- description: Whether Jenkins runs with a 32 bit (i386) or 64 bit (x86_64) JVM.
-  displayName: Jenkins JVM Architecture
-  name: JVM_ARCH
-  value: i386
 - description: Maximum amount of memory the container can use.
   displayName: Memory Limit
-  # DELTA: changed from 512Mi
   name: MEMORY_LIMIT
+  # DELTA: changed from 1Gi
   value: 2Gi
 - description: Volume space available for data, e.g. 512Mi, 2Gi.
   displayName: Volume Capacity
@@ -231,9 +229,24 @@ parameters:
   displayName: Jenkins ImageStream Namespace
   name: NAMESPACE
   value: openshift
+- description: Whether to perform memory intensive, possibly slow, synchronization
+    with the Jenkins Update Center on start.  If true, the Jenkins core update monitor
+    and site warnings monitor are disabled.
+  displayName: Disable memory intensive administrative monitors
+  name: DISABLE_ADMINISTRATIVE_MONITORS
+  value: "false"
 - description: Name of the ImageStreamTag to be used for the Jenkins image.
   displayName: Jenkins ImageStreamTag
   name: JENKINS_IMAGE_STREAM_TAG
-  # DELTA: changed from jenkins:latest
-  # https://github.com/coreos/fedora-coreos-pipeline/pull/70
   value: jenkins:2
+- description: When a fatal error occurs, an error log is created with information
+    and the state obtained at the time of the fatal error.
+  displayName: Fatal Error Log File
+  name: ENABLE_FATAL_ERROR_LOG_FILE
+  value: "false"
+- description: Whether to allow use of a Jenkins Update Center that uses invalid certificate
+    (self-signed, unknown CA). If any value other than 'false', certificate check
+    is bypassed. By default, certificate check is enforced.
+  displayName: Allows use of Jenkins Update Center repository with invalid SSL certificate
+  name: JENKINS_UC_INSECURE
+  value: "false"

--- a/manifests/jenkins.yaml.orig
+++ b/manifests/jenkins.yaml.orig
@@ -7,9 +7,10 @@
 # To diff:
 #   git diff --no-index manifests/jenkins.yaml{.orig,}
 
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 labels:
+  app: jenkins-persistent
   template: jenkins-persistent-template
 message: A Jenkins service has been created in your project.  Log into Jenkins with
   your OpenShift account.  The tutorial at https://github.com/openshift/origin/blob/master/examples/jenkins/README.md
@@ -21,25 +22,28 @@ metadata:
 
       NOTE: You must have persistent volumes available in your cluster to use this template.
     iconClass: icon-jenkins
-    openshift.io/display-name: Jenkins (Persistent)
+    openshift.io/display-name: Jenkins
+    openshift.io/documentation-url: https://docs.okd.io/latest/using_images/other_images/jenkins.html
+    openshift.io/long-description: This template deploys a Jenkins server capable
+      of managing OpenShift Pipeline builds and supporting OpenShift-based oauth login.
+    openshift.io/provider-display-name: Red Hat, Inc.
+    openshift.io/support-url: https://access.redhat.com
+    samples.operator.openshift.io/version: 4.5.4
     tags: instant-app,jenkins
-    template.openshift.io/documentation-url: https://docs.openshift.org/latest/using_images/other_images/jenkins.html
-    template.openshift.io/long-description: This template deploys a Jenkins server
-      capable of managing OpenShift Pipeline builds and supporting OpenShift-based
-      oauth login.
-    template.openshift.io/provider-display-name: Red Hat, Inc.
-    template.openshift.io/support-url: https://access.redhat.com
-  creationTimestamp: 2017-06-07T22:44:34Z
+  creationTimestamp: "2020-06-16T13:02:54Z"
+  labels:
+    samples.operator.openshift.io/managed: "true"
   name: jenkins-persistent
   namespace: openshift
-  resourceVersion: "9280678"
-  selfLink: /oapi/v1/namespaces/openshift/templates/jenkins-persistent
-  uid: e102f731-4bd2-11e7-aab3-0cc47a66a374
+  resourceVersion: "38535592"
+  selfLink: /apis/template.openshift.io/v1/namespaces/openshift/templates/jenkins-persistent
+  uid: 8e8533fa-daf6-4166-a51e-904c9e57ce5e
 objects:
 - apiVersion: v1
   kind: Route
   metadata:
     annotations:
+      haproxy.router.openshift.io/timeout: 4m
       template.openshift.io/expose-uri: http://{.spec.host}{.spec.path}
     name: ${JENKINS_SERVICE_NAME}
   spec:
@@ -83,30 +87,37 @@ objects:
             value: ${ENABLE_OAUTH}
           - name: OPENSHIFT_ENABLE_REDIRECT_PROMPT
             value: "true"
-          - name: OPENSHIFT_JENKINS_JVM_ARCH
-            value: ${JVM_ARCH}
+          - name: DISABLE_ADMINISTRATIVE_MONITORS
+            value: ${DISABLE_ADMINISTRATIVE_MONITORS}
           - name: KUBERNETES_MASTER
             value: https://kubernetes.default:443
           - name: KUBERNETES_TRUST_CERTIFICATES
             value: "true"
+          - name: JENKINS_SERVICE_NAME
+            value: ${JENKINS_SERVICE_NAME}
           - name: JNLP_SERVICE_NAME
             value: ${JNLP_SERVICE_NAME}
+          - name: ENABLE_FATAL_ERROR_LOG_FILE
+            value: ${ENABLE_FATAL_ERROR_LOG_FILE}
+          - name: JENKINS_UC_INSECURE
+            value: ${JENKINS_UC_INSECURE}
           image: ' '
           imagePullPolicy: IfNotPresent
           livenessProbe:
-            failureThreshold: 30
+            failureThreshold: 2
             httpGet:
               path: /login
               port: 8080
             initialDelaySeconds: 420
-            timeoutSeconds: 3
+            periodSeconds: 360
+            timeoutSeconds: 240
           name: jenkins
           readinessProbe:
             httpGet:
               path: /login
               port: 8080
             initialDelaySeconds: 3
-            timeoutSeconds: 3
+            timeoutSeconds: 240
           resources:
             limits:
               memory: ${MEMORY_LIMIT}
@@ -200,14 +211,10 @@ parameters:
   displayName: Enable OAuth in Jenkins
   name: ENABLE_OAUTH
   value: "true"
-- description: Whether Jenkins runs with a 32 bit (i386) or 64 bit (x86_64) JVM.
-  displayName: Jenkins JVM Architecture
-  name: JVM_ARCH
-  value: i386
 - description: Maximum amount of memory the container can use.
   displayName: Memory Limit
   name: MEMORY_LIMIT
-  value: 512Mi
+  value: 1Gi
 - description: Volume space available for data, e.g. 512Mi, 2Gi.
   displayName: Volume Capacity
   name: VOLUME_CAPACITY
@@ -217,7 +224,24 @@ parameters:
   displayName: Jenkins ImageStream Namespace
   name: NAMESPACE
   value: openshift
+- description: Whether to perform memory intensive, possibly slow, synchronization
+    with the Jenkins Update Center on start.  If true, the Jenkins core update monitor
+    and site warnings monitor are disabled.
+  displayName: Disable memory intensive administrative monitors
+  name: DISABLE_ADMINISTRATIVE_MONITORS
+  value: "false"
 - description: Name of the ImageStreamTag to be used for the Jenkins image.
   displayName: Jenkins ImageStreamTag
   name: JENKINS_IMAGE_STREAM_TAG
-  value: jenkins:latest
+  value: jenkins:2
+- description: When a fatal error occurs, an error log is created with information
+    and the state obtained at the time of the fatal error.
+  displayName: Fatal Error Log File
+  name: ENABLE_FATAL_ERROR_LOG_FILE
+  value: "false"
+- description: Whether to allow use of a Jenkins Update Center that uses invalid certificate
+    (self-signed, unknown CA). If any value other than 'false', certificate check
+    is bypassed. By default, certificate check is enforced.
+  displayName: Allows use of Jenkins Update Center repository with invalid SSL certificate
+  name: JENKINS_UC_INSECURE
+  value: "false"

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -43,7 +43,7 @@ parameters:
     value: fcos-builds
   - description: Whether to use KVM device plugin or legacy OCI KVM hook
     name: KVM_SELECTOR
-    value: legacy-oci-kvm-hook
+    value: kvm-device-plugin
   - description: GCP GS bucket to use for image uploads (or blank for none)
     name: GCP_GS_BUCKET
     value: fedora-coreos-cloud-image-uploads

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -41,9 +41,6 @@ parameters:
   - description: AWS S3 bucket in which to store builds (or blank for none)
     name: S3_BUCKET
     value: fcos-builds
-  - description: Whether to use KVM device plugin or legacy OCI KVM hook
-    name: KVM_SELECTOR
-    value: kvm-device-plugin
   - description: GCP GS bucket to use for image uploads (or blank for none)
     name: GCP_GS_BUCKET
     value: fedora-coreos-cloud-image-uploads
@@ -105,7 +102,6 @@ objects:
         coreos.com/source-config-ref: ${FCOS_CONFIG_REF}
         coreos.com/developer-prefix: ${DEVELOPER_PREFIX}
         coreos.com/s3-bucket: ${S3_BUCKET}
-        coreos.com/kvm-selector: ${KVM_SELECTOR}
         coreos.com/gcp-gs-bucket: ${GCP_GS_BUCKET}
     spec:
       # note no triggers: the base pipeline is only ever triggered manually, or

--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -57,7 +57,9 @@ spec:
      resources:
        requests:
          memory: COREOS_ASSEMBLER_MEMORY_REQUEST
-       limits: {}
+         devices.kubevirt.io/kvm: '1'
+       limits:
+         devices.kubevirt.io/kvm: '1'
   volumes:
   - name: cache
     # XXX Disabled for now; we're seeing odd I/O issues possibly related to NFS:


### PR DESCRIPTION
```
commit cc4b2095febdfdc697b8bffe86a68421126791eb
Date:   Mon Aug 24 09:44:59 2020 -0400

    jenkins: rebase to latest OCP4 template

    And as usual, keep marking all the deltas with `DELTA`.

commit 9564c1a289d2044593a5aec9dac2e052d599c6d1
Date:   Mon Aug 24 09:45:00 2020 -0400

    pipeline: adapt to new cluster URL and version

    Update the Jenkins URL and cluster URL to the new cluster, move the jobs
    which use coreos-ci-lib to go back to the master branch, and change the
    default KVM selector to kvm-device-plugin. (We'll rip out that switch
    altogether in a following patch).

commit 516091e19a778d18bd84f1d19e4c24049d1e4df3
Date:   Mon Aug 24 09:45:01 2020 -0400

    plugins: bump configuration-as-code to 1.35

    Otherwise we get version dependency issues with the other new plugins.

commit dd744d540f4bb4fa5077a20ab7563e1df6352bd1
Date:   Mon Aug 24 09:45:02 2020 -0400

    jenkins: switch to in-cluster Jenkins imagestream

    A nice change in OCP4 is that the S2I Jenkins image meant to match the
    cluster version is tracked by the cluster itself via an ImageStream.
    Let's make use of it instead of doing our own tracking.

commit 06a587e51f5267509f730884a30ec5900d7ae9f6
Date:   Mon Aug 24 09:45:03 2020 -0400

    pipeline: drop support for oci-kvm-hook

    Now that we're on OCP4, let's only support the kubevirt way of things.

commit 9c36085f257288d0faf8fc5f14b0c5b3ab9b325d
Date:   Mon Aug 24 09:45:04 2020 -0400

    HACKING: drop `oc cluster up` path

    It doesn't exist anymore in OCP4. Direct people to CRC or the installer
    and the OpenShift CNV docs.

```