### PR TITLE
Jenkins.release: error out if VERSION is not provided

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -36,6 +36,12 @@ properties([
     ])
 ])
 
+// no way to make a parameter required directly so manually check
+// https://issues.jenkins-ci.org/browse/JENKINS-3509
+if (params.VERSION == "") {
+    throw new Exception("Missing VERSION parameter!")
+}
+
 currentBuild.description = "[${params.STREAM}] - ${params.VERSION}"
 
 // substitute the right COSA image into the pod definition before spawning it


### PR DESCRIPTION
Let's be explicit and require that users/machines specify which version
to release instead of having a dangerous/racy "use latest" fallback.