### PR TITLE
Jenkinsfile.kola.{aws|gcp}: various improvements

### DIFF
--- a/Jenkinsfile.kola.aws
+++ b/Jenkinsfile.kola.aws
@@ -9,10 +9,10 @@ node {
 properties([
     pipelineTriggers([]),
     parameters([
-      string(name: 'STREAM',
-             description: 'The Stream we are testing against',
-             defaultValue: '',
-             trim: true),
+      choice(name: 'STREAM',
+             // list devel first so that it's the default choice
+             choices: (streams.development + streams.production + streams.mechanical),
+             description: 'Fedora CoreOS stream to test'),
       string(name: 'VERSION',
              description: 'Fedora CoreOS Build ID to test',
              defaultValue: '',

--- a/Jenkinsfile.kola.aws
+++ b/Jenkinsfile.kola.aws
@@ -30,6 +30,10 @@ properties([
 
 currentBuild.description = "[${params.STREAM}] - ${params.VERSION}"
 
+if (params.S3_STREAM_DIR == "") {
+    params.S3_STREAM_DIR = "fcos-builds/prod/streams/${params.STREAM}"
+}
+
 // substitute the right COSA image into the pod definition before spawning it
 pod = pod.replace("COREOS_ASSEMBLER_IMAGE", params.COREOS_ASSEMBLER_IMAGE)
 

--- a/Jenkinsfile.kola.gcp
+++ b/Jenkinsfile.kola.gcp
@@ -9,10 +9,10 @@ node {
 properties([
     pipelineTriggers([]),
     parameters([
-      string(name: 'STREAM',
-             description: 'The Stream we are testing against',
-             defaultValue: '',
-             trim: true),
+      choice(name: 'STREAM',
+             // list devel first so that it's the default choice
+             choices: (streams.development + streams.production + streams.mechanical),
+             description: 'Fedora CoreOS stream to test'),
       string(name: 'VERSION',
              description: 'Fedora CoreOS Build ID to test',
              defaultValue: '',

--- a/Jenkinsfile.kola.gcp
+++ b/Jenkinsfile.kola.gcp
@@ -30,6 +30,10 @@ properties([
 
 currentBuild.description = "[${params.STREAM}] - ${params.VERSION}"
 
+if (params.S3_STREAM_DIR == "") {
+    params.S3_STREAM_DIR = "fcos-builds/prod/streams/${params.STREAM}"
+}
+
 // substitute the right COSA image into the pod definition before spawning it
 pod = pod.replace("COREOS_ASSEMBLER_IMAGE", params.COREOS_ASSEMBLER_IMAGE)
 


### PR DESCRIPTION
```
commit 184ef19b52f2ac5ab370c134039afc0bf48f8889
Date:   Tue Aug 25 11:50:42 2020 -0400

    Jenkinsfile.kola.{aws|gcp}: make STREAM param a choice

    Matches the main pipeline.

commit e13e1e464e0cc86b6e657e4b6d2af93b4eea74b6
Date:   Tue Aug 25 11:51:12 2020 -0400

    Jenkinsfile.kola.{aws|gcp}: auto-generate stream dir if missing

    It's annoying to have to type it in when triggering tests manually.

    (That parameter ideally wouldn't be needed at all. But it's useful in
    the developer case where we're targeting a separate bucket. I'd like to
    rework the developer workflow eventually.)
```