### PR TITLE
bump-lockfile: add timeout and send Slack msg on failure

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -14,7 +14,7 @@ properties([
     ])
 ])
 
-cosaPod {
+try { timeout(time: 120, unit: 'MINUTES') { cosaPod {
     parallel branches.collectEntries { branch -> [branch, {
         shwrap("mkdir ${branch}")
         dir(branch) {
@@ -77,4 +77,11 @@ cosaPod {
             }
         }
     }] }
+}}} catch (e) {
+    currentBuild.result = 'FAILURE'
+    throw e
+} finally {
+    if (currentBuild.result != 'SUCCESS') {
+        slackSend(color: 'danger', message: ":fcos: :trashfire: <${env.BUILD_URL}|bump-lockfile #${env.BUILD_NUMBER}>")
+    }
 }


### PR DESCRIPTION
This job is key to our promotion model. We've had lapses in the past
where we didn't realize it was failing for a few days.

Let's send a Slack notification whenever the job fails to prevent this
(and yes, still hoping to eventually move to IRC notifications).

While we're here, also wrap it all in a timeout as good practice.