### PR TITLE
bump-lockfile: explicitly mark build as SUCCESS

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -101,6 +101,7 @@ try { timeout(time: 120, unit: 'MINUTES') { cosaPod {
             }
         }
     }] }
+    currentBuild.result = 'SUCCESS'
 }}} catch (e) {
     currentBuild.result = 'FAILURE'
     throw e


### PR DESCRIPTION
In a good build, in the `finally` block the current build's status isn't
*yet* `SUCCESS`... because the build is still running. And so the
conditional we have there fails. Fix this by explicitly setting the
status to `SUCCESS` at the end of the job.