### PR TITLE
pipeline: switch testing builds back to legacy PXE artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -340,7 +340,7 @@ lock(resource: "build-${params.STREAM}") {
             stage('Build Live') {
                 utils.shwrap("""
                 case "${params.STREAM}" in
-                stable)
+                testing|stable)
                     cosa buildextend-live --legacy-pxe
                     ;;
                 *)


### PR DESCRIPTION
We need to do an out-of-cycle testing release this week.