### PR TITLE
pipeline: switch testing builds back to modern PXE artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -340,7 +340,7 @@ lock(resource: "build-${params.STREAM}") {
             stage('Build Live') {
                 utils.shwrap("""
                 case "${params.STREAM}" in
-                testing|stable)
+                stable)
                     cosa buildextend-live --legacy-pxe
                     ;;
                 *)


### PR DESCRIPTION
Hold until the out-of-cycle testing release is complete.

This reverts commit ca0f43ca09d126376503d09dac69199e4630120f.