### PR TITLE
manifests/jenkins: use emptyDir for now

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -130,8 +130,11 @@ objects:
         serviceAccountName: ${JENKINS_SERVICE_NAME}
         volumes:
         - name: ${JENKINS_SERVICE_NAME}-data
-          persistentVolumeClaim:
-            claimName: ${JENKINS_SERVICE_NAME}
+        # Temporarily stop using the PVC, see
+        # https://pagure.io/centos-infra/issue/26
+        # persistentVolumeClaim:
+        #   claimName: ${JENKINS_SERVICE_NAME}
+          emptyDir: {}
         # DELTA: add a configmap -- it's defined in pipeline.yaml
         - name: ${JENKINS_SERVICE_NAME}-casc-cfg
           configMap:


### PR DESCRIPTION
We're seeing intermittent issues where the NFS PVC mount seems too slow
for Jenkins to function properly:

https://pagure.io/centos-infra/issue/26#comment-685779

Switch over to an emptyDir for now. (This means that on restarts Jenkins
will lose all job history.)