### PR TITLE
jenkins/plugins: bump configuration-as-code to 1.39

### DIFF
--- a/jenkins/master/plugins.txt
+++ b/jenkins/master/plugins.txt
@@ -1,5 +1,5 @@
 github-oauth:0.33
-configuration-as-code:1.35
+configuration-as-code:1.39
 slack:2.34
 job-dsl:1.76
 matrix-auth:2.4.2


### PR DESCRIPTION
I think we're hitting
https://github.com/jenkinsci/configuration-as-code-plugin/pull/1359,
which is fixed in v1.39.

```
2020-09-16 16:38:13 WARNING jenkins.telemetry.impl.java11.MissingClassTelemetry reportException Added a missed class for missing class telemetry. Class: javax.annotation.Nonnull
java.lang.ClassNotFoundException: javax.annotation.Nonnull
        at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1387)
        at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1342)
        at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1089)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.tryConstructor(DataBoundConfigurator.java:118)
```

Let's try out that release.