### PR TITLE
Go back to using a PVC for Jenkins

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -130,11 +130,8 @@ objects:
         serviceAccountName: ${JENKINS_SERVICE_NAME}
         volumes:
         - name: ${JENKINS_SERVICE_NAME}-data
-        # Temporarily stop using the PVC, see
-        # https://pagure.io/centos-infra/issue/26
-        # persistentVolumeClaim:
-        #   claimName: ${JENKINS_SERVICE_NAME}
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: ${JENKINS_SERVICE_NAME}
         # DELTA: add a configmap -- it's defined in pipeline.yaml
         - name: ${JENKINS_SERVICE_NAME}-casc-cfg
           configMap:

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -240,7 +240,7 @@ parameters:
   name: VOLUME_CAPACITY
   required: true
   # DELTA: changed from 1Gi
-  value: 2Gi
+  value: 5Gi
 - description: The OpenShift Namespace where the Jenkins ImageStream resides.
   displayName: Jenkins ImageStream Namespace
   name: NAMESPACE


### PR DESCRIPTION
```
commit e750f1fdde511f9a9db415c635a5e71e540044df
Date:   Thu Oct 22 12:05:24 2020 -0400

    Revert "manifests/jenkins: use emptyDir for now"

    This reverts commit e519ccc6e9359e56050711dbac25cd2d83c2c021.

    The NFS backend is still recovering, but it seems fast enough now to
    handle Jenkins using it again.

commit ca9510dcb37fad05454d94f2dd21fa1619dedff9
Date:   Thu Oct 22 13:40:43 2020 -0400

    jenkins.yaml: bump VOLUME_CAPACITY to 5Gi

    This is the size of the PVC that was actually created back when we
    migrated to the cluster. Might as well make the manifest match what
    we're operating with now.
```