### PR TITLE
jobs/kola-{aws,gcp}: use `--arg=val` format for platform args

### DIFF
--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -57,8 +57,8 @@ cosaPod(image: params.COREOS_ASSEMBLER_IMAGE, memory: "256Mi",
     }
 
     fcosKola(cosaDir: env.WORKSPACE, parallel: 5, build: params.VERSION,
-             platformArgs: """-p aws \
-                --aws-credentials-file \${AWS_FCOS_KOLA_BOT_CONFIG}/config \
-                --aws-ami ${ami} \
-                --aws-region ${ami_region}""")
+             platformArgs: """-p=aws \
+                --aws-credentials-file=\${AWS_FCOS_KOLA_BOT_CONFIG}/config \
+                --aws-ami=${ami} \
+                --aws-region=${ami_region}""")
 }

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -61,8 +61,8 @@ cosaPod(image: params.COREOS_ASSEMBLER_IMAGE, memory: "256Mi",
     }
 
     fcosKola(cosaDir: env.WORKSPACE, parallel: 5, build: params.VERSION,
-             platformArgs: """-p gce \
+             platformArgs: """-p=gce \
                 --gce-json-key=\${GCP_KOLA_TESTS_CONFIG}/config \
-                --gce-project ${gcp_project} \
-                --gce-image projects/${gcp_image_project}/global/images/${gcp_image}""")
+                --gce-project=${gcp_project} \
+                --gce-image=projects/${gcp_image_project}/global/images/${gcp_image}""")
 }


### PR DESCRIPTION
Otherwise, it confuses the `cosa kola` wrapper which tries to process
the arguments.

We should fold the denylist handling and basic scenario testing into
kola proper so we can drop this wrapper.