### PR TITLE
Add new fedmsgs for builds, releases, and metadata

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -268,6 +268,14 @@ lock(resource: "build-${params.STREAM}") {
                 meta["fedora-coreos.parent-commit"] = parent_commit
                 writeJSON file: meta_json, json: meta
             }
+
+            if (official) {
+                utils.shwrap("""
+                /var/tmp/fcos-releng/scripts/broadcast-fedmsg.py --fedmsg-conf=/etc/fedora-messaging-cfg/fedmsg.toml \
+                    build.state.change --build ${newBuildID} --basearch ${basearch} --stream ${params.STREAM} \
+                    --state STARTED
+                """)
+            }
         }
 
         if (official && s3_stream_dir && utils.path_exists("/etc/fedora-messaging-cfg/fedmsg.toml")) {
@@ -562,6 +570,11 @@ lock(resource: "build-${params.STREAM}") {
             try {
                 if (official) {
                     slackSend(color: color, message: message)
+                    utils.shwrap("""
+                    /var/tmp/fcos-releng/scripts/broadcast-fedmsg.py --fedmsg-conf=/etc/fedora-messaging-cfg/fedmsg.toml \
+                        build.state.change --build ${newBuildID} --basearch ${basearch} --stream ${params.STREAM} \
+                        --state FINISHED --result ${currentBuild.result}
+                    """)
                 }
             } finally {
                 echo message

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -147,5 +147,10 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
               --bucket ${s3_bucket}
           """)
         }
+
+        utils.shwrap("""
+        /var/tmp/fcos-releng/scripts/broadcast-fedmsg.py --fedmsg-conf=/etc/fedora-messaging-cfg/fedmsg.toml \
+            stream.release --build ${params.VERSION} --stream ${params.STREAM}
+        """)
     }}
 }}

--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -11,10 +11,18 @@ properties([
 cosaPod {
     git(url: 'https://github.com/coreos/fedora-coreos-streams', credentialsId: 'github-coreosbot-token')
     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-fcos-builds-bot']]) {
-        shwrap("""
+        cmd = """
             aws s3 sync --acl public-read --cache-control 'max-age=60' \
                 --exclude '*' --include 'streams/*' --include 'updates/*' \
                     ./ s3://fcos-builds
-        """)
+        """
+
+        // Do a dry run first to see if there's any work that actually needs to
+        // be done. `aws s3 sync` doesn't print anything if everything is
+        // synced up.
+        def dry_run = shwrapCapture("${cmd} --dryrun").trim()
+        if (dry_run != "") {
+            shwrap("${cmd}")
+        }
     }
 }


### PR DESCRIPTION
This patch adds four new fedmsgs:
- `build.state.change`: emitted at the start and end of a build
- `stream.release`: emitted when a build is released
- `stream.metadata.update`: emitted for stream/graph metadata updates

This will allow other services to hook more closely into our process.
Some use cases right now are AWS Marketplace listing updates, mirrors
triggering a sync, and OpenQA testing the latest artifacts.

I started with a helper for sending the messages in `utils`, but I'd
like to get rid of `utils` down the line in favour of moving all that
functionality into the shared library.

Closes: coreos/fedora-coreos-tracker#225

