### PR TITLE
Point fedmsg config to new k8s secret path

### DIFF
--- a/configs/fedmsg.toml
+++ b/configs/fedmsg.toml
@@ -3,8 +3,8 @@ amqp_url = "amqps://coreos:@rabbitmq.fedoraproject.org/%2Fpubsub"
 
 [tls]
 ca_cert = "/etc/fedora-messaging/cacert.pem"
-keyfile = "/run/fedora-messaging-coreos-key/coreos.key"
-certfile = "/run/fedora-messaging-coreos-key/coreos.crt"
+keyfile = "/run/kubernetes/secrets/fedora-messaging-coreos-key/coreos.key"
+certfile = "/run/kubernetes/secrets/fedora-messaging-coreos-key/coreos.crt"
 
 [client_properties]
 app = "Fedora CoreOS Pipeline"

--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -11,9 +11,6 @@ properties([
 cosaPod(configMaps: ["fedora-messaging-cfg"], secrets: ["fedora-messaging-coreos-key"]) {
     git(url: 'https://github.com/coreos/fedora-coreos-streams', credentialsId: 'github-coreosbot-token')
     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-fcos-builds-bot']]) {
-        // XXX: update configMap to use the /run/secrets value
-        shwrap("ln -sf \${FEDORA_MESSAGING_COREOS_KEY} /run/fedora-messaging-coreos-key")
-
         // XXX: eventually we want this as part of the pod or built into the image we use
         shwrap("git clone --depth=1 https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng")
 

--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -50,7 +50,7 @@ spec:
        mountPath: /etc/fedora-messaging-cfg
        readOnly: true
      - name: fedora-messaging-coreos-key
-       mountPath: /run/fedora-messaging-coreos-key
+       mountPath: /run/kubernetes/secrets/fedora-messaging-coreos-key
        readOnly: true
      securityContext:
        privileged: false


### PR DESCRIPTION
This is the path under which `coreos-ci-lib` puts the secret. We want
the config to work in both the "old world" (where it uses `pod.yaml`)
and the "new world" (where it uses `pod(secret: ...)` from
`coreos-ci-lib`), so let's update the path in the config and `pod.yaml`
to match `coreos-ci-lib`.

This fixes one `XXX` in the `sync-stream-metadata` job which turns out
to be a hard blocker because the container runs as non-root and so
doesn't have the privs to link at `/run/fedora-messaging-coreos-key`.