### PR TITLE
jobs/sync-stream-metadata: sync one stream at a time

### DIFF
--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -1,5 +1,11 @@
 @Library('github.com/coreos/coreos-ci-lib') _
 
+def streams
+node {
+    checkout scm
+    streams = load("streams.groovy")
+}
+
 properties([
     pipelineTriggers([
         githubPush(),
@@ -14,25 +20,27 @@ cosaPod(configMaps: ["fedora-messaging-cfg"], secrets: ["fedora-messaging-coreos
         // XXX: eventually we want this as part of the pod or built into the image we use
         shwrap("git clone --depth=1 https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng")
 
-        def cmd = """
-            aws s3 sync --acl public-read --cache-control 'max-age=60' \
-                --exclude '*' --include 'streams/*' --include 'updates/*' \
-                    ./ s3://fcos-builds
-        """
+        streams.production.each{stream ->
+            def cmd = """
+                aws s3 sync --acl public-read --cache-control 'max-age=60' \
+                    --exclude '*' --include 'streams/${stream}.json' --include 'updates/${stream}.json' \
+                        ./ s3://fcos-builds
+            """
 
-        // trim so that when we append --dryrun below, it's on the same line
-        cmd = cmd.trim()
+            // trim so that when we append --dryrun below, it's on the same line
+            cmd = cmd.trim()
 
-        // Do a dry run first to see if there's any work that actually needs to
-        // be done. `aws s3 sync` doesn't print anything if everything is
-        // synced up.
-        def dry_run = shwrapCapture("${cmd} --dryrun").trim()
-        if (dry_run != "") {
-            shwrap("${cmd}")
-            utils.shwrap("""
-            /var/tmp/fcos-releng/scripts/broadcast-fedmsg.py --fedmsg-conf=\${FEDORA_MESSAGING_CFG}/fedmsg.toml \
-                stream.metadata.update --stream ${params.STREAM}
-            """)
+            // Do a dry run first to see if there's any work that actually needs to
+            // be done. `aws s3 sync` doesn't print anything if everything is
+            // synced up.
+            def dry_run = shwrapCapture("${cmd} --dryrun").trim()
+            if (dry_run != "") {
+                shwrap("${cmd}")
+                utils.shwrap("""
+                /var/tmp/fcos-releng/scripts/broadcast-fedmsg.py --fedmsg-conf=\${FEDORA_MESSAGING_CFG}/fedmsg.toml \
+                    stream.metadata.update --stream ${stream}
+                """)
+            }
         }
     }
 }


### PR DESCRIPTION
One obvious thing that I missed while working on #288 was that this job
doesn't actually have a `STREAM` parameter since it syncs all the
streams in one shot. So the fedmsg it emits will have `null` as the
stream name.

To make this stream-sensitive, let's change to doing `aws s3 sync`
separately for each stream with change detection for each. That way we
only emit fedmsgs for streams which actually had their metadata changed.

Patch best viewed with whitespace ignored.