### PR TITLE
manifests/pod: use jnlp image from quay.io

### DIFF
--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -12,7 +12,7 @@ spec:
   serviceAccountName: jenkins
   containers:
    - name: jnlp
-     image: jenkins-slave-base-centos7:latest
+     image: quay.io/openshift/origin-jenkins-agent-base:latest
      args: ['$(JENKINS_SECRET)', '$(JENKINS_NAME)']
    - name: coreos-assembler
      image: COREOS_ASSEMBLER_IMAGE


### PR DESCRIPTION
We're hitting pull limit errors on Docker Hub, and anyway that one is
deprecated in favour of the one on Quay.io so let's switch to that.