### PR TITLE
Jenkinsfile: Create and upload keylime hashlist

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -444,6 +444,16 @@ lock(resource: "build-${params.STREAM}") {
             }
         }
 
+        // Generate KeyLime hashes for attestation on official builds
+        // This is a POC setup and will be modified over time
+        // See: https://github.com/keylime/enhancements/blob/master/16_remote_allowlist_retrieval.md
+        stage('KeyLime Hash Generation') {
+            utils.shwrap("""
+            cosa generate-hashlist --release=${newBuildID} --output=builds/${newBuildID}/${basearch}/exp-hash.json
+            sha256sum builds/${newBuildID}/${basearch}/exp-hash.json > builds/${newBuildID}/${basearch}/exp-hash.json-CHECKSUM
+            """)
+        }
+
         stage('Archive') {
             // lower to make sure we don't go over and account for overhead
             def xz_memlimit = cosa_memory_request_mb - 512


### PR DESCRIPTION
When a builds occur we now generate a keylime hashlist and upload it to an expected location. We also upload a sha256sum.

See:
- https://github.com/keylime/enhancements/blob/master/16_remote_allowlist_retrieval.md
- https://github.com/coreos/coreos-assembler/blob/master/src/cmd-generate-hashlist
- ~https://github.com/coreos/coreos-assembler/pull/1970~


When closing [the upload PR](https://github.com/coreos/coreos-assembler/pull/1970) we decided to modify the pattern for POC as such:
- Output the hashlist as `exp-hash.json`
- Ensure the `exp-hash.json` file is in the builds/ directory so it is uploaded as a sibling of `{meta|commitmeta}.json`
- sha256sum the `exp-hash.json` file as `exp-hash.json-CHECKSUM`
- Once this work moves beyond POC we will update the output file to an expected location + sign the hashlist

cc @mpeters