### PR TITLE
Add configuration-as-code-groovy and basic-branch-build-strategies plugins

### DIFF
--- a/jenkins/master/plugins.txt
+++ b/jenkins/master/plugins.txt
@@ -4,3 +4,4 @@ slack:2.34
 job-dsl:1.76
 matrix-auth:2.4.2
 aws-credentials:1.28
+configuration-as-code-groovy:1.1

--- a/jenkins/master/plugins.txt
+++ b/jenkins/master/plugins.txt
@@ -4,4 +4,5 @@ slack:2.34
 job-dsl:1.76
 matrix-auth:2.4.2
 aws-credentials:1.28
+basic-branch-build-strategies:1.3.2
 configuration-as-code-groovy:1.1


### PR DESCRIPTION
```
commit f1cba81bf0d139474a7b126bb231bd3fdba81058
Date:   Wed Dec 16 10:56:56 2020 -0500

    plugins: add configuration-as-code-groovy

    This is needed so that we can run some Groovy code via CASC dropins.
    Obviously this goes against the declarative CASC premise a bit, but in
    some cases you need that escape hatch. Here for example, we'll use this
    to modify the pod concurrency cap on the *pre-existing* "openshift"
    cloud that gets created (which it seems you can't do in pure CASC).

commit 35191fa603ff5ddbbdcdbc1591e771666a16e40a
Date:   Wed Dec 16 10:59:03 2020 -0500

    plugins: add basic-branch-build-strategies

    This will be used to allow skipping PR rebuilds when only the base
    changes.
```