### PR TITLE
streams: add rawhide mechanical stream

### DIFF
--- a/Jenkinsfile.mechanical
+++ b/Jenkinsfile.mechanical
@@ -6,10 +6,9 @@ node {
 }
 
 properties([
-    pipelineTriggers(streams.get_push_trigger() + [
-        // also run every 6h: we could increase the interval more if we start
-        // triggering on the relevant fedmsgs.
-        cron("H H/6 * * *")
+    pipelineTriggers([
+        // run every 24h only for now
+        cron("H H * * *")
     ])
 ])
 

--- a/streams.groovy
+++ b/streams.groovy
@@ -2,7 +2,7 @@
 
 production = ['testing', 'stable', 'next']
 development = ['testing-devel', 'next-devel']
-mechanical = [/*'bodhi-updates', 'bodhi-updates-testing', 'branched', 'rawhide' */]
+mechanical = ['rawhide' /*'bodhi-updates', 'bodhi-updates-testing', 'branched' */]
 
 all_streams = production + development + mechanical
 


### PR DESCRIPTION
We need to start tracking changes that happen in rawhide earlier so that
we can better participate in the branching and stabilization process of
Fedora releases.

Let's create a mechanical rawhide stream.