### PR TITLE
pipeline: don't upload to clouds for rawhide for now

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -81,9 +81,9 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
             """)
 
             def basearch = utils.shwrap_capture("cosa basearch")
-            meta_json = "builds/${params.VERSION}/${basearch}/meta.json"
+            def meta_json = "builds/${params.VERSION}/${basearch}/meta.json"
             def meta = readJSON file: meta_json
-            if (meta.gcp.image) {
+            if (meta.gcp?.image) {
                 gcp_image = meta.gcp.image
             }
         }


### PR DESCRIPTION
It doesn't quite work yet because e.g. in GCP we need to create a
license. But at least, let's push out builds which passed local QEMU
tests.

(Related to this, adding another stream like this reminds we really need
to tackle GC at some point. E.g. for rawhide, we should have an
aggressive policy.)