### PR TITLE
pipeline: move from `trans.py` to `cosa generate-release-meta`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -455,7 +455,7 @@ lock(resource: "build-${params.STREAM}") {
             // Run the coreos-meta-translator against the most recent build,
             // which will generate a release.json from the meta.json files
             utils.shwrap("""
-            /var/tmp/fcos-releng/coreos-meta-translator/trans.py --workdir .
+            cosa generate-release-meta --workdir .
             """)
 
             if (s3_stream_dir) {

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -129,7 +129,7 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
                 utils.shwrap("""
                 export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
                 cosa aws-replicate --build=${params.VERSION} --log-level=INFO
-                /var/tmp/fcos-releng/coreos-meta-translator/trans.py --build-id ${params.VERSION} --workdir .
+                cosa generate-release-meta --build-id ${params.VERSION} --workdir .
                 cosa buildupload --build=${params.VERSION} --skip-builds-json s3 --acl=public-read ${s3_stream_dir}/builds
                 """)
             }


### PR DESCRIPTION
This was moved to cosa in
https://github.com/coreos/coreos-assembler/pull/2006.