### PR TITLE
jenkins: add timestamper plugin

### DIFF
--- a/jenkins/master/plugins.txt
+++ b/jenkins/master/plugins.txt
@@ -6,3 +6,4 @@ matrix-auth:2.4.2
 aws-credentials:1.28
 basic-branch-build-strategies:1.3.2
 configuration-as-code-groovy:1.1
+timestamper:1.11.8


### PR DESCRIPTION
This will allow us to add timestamps to all build logs.

Prompted by: https://github.com/coreos/rpm-ostree/pull/2583