### PR TITLE
streams: don't wait for build to finish

### DIFF
--- a/streams.groovy
+++ b/streams.groovy
@@ -45,8 +45,7 @@ def triggered_by_push() {
 def build_stream(stream) {
     // Use `oc start-build` instead of the build step:
     // https://bugzilla.redhat.com/show_bug.cgi?id=1580468
-    // With `--wait`, we'll error out if the build actually failed.
-    sh "oc start-build --wait fedora-coreos-pipeline -e STREAM=${stream}"
+    sh "oc start-build fedora-coreos-pipeline -e STREAM=${stream}"
 }
 
 return this


### PR DESCRIPTION
Right now, the top-level
`fedora-coreos-pipeline-{development,mechanical,production}` jobs wait
on each FCOS build it spawns and errors out if any fails. But we don't
really need to do that because we barely look at those top-level jobs
anyway since all the action is in the primary `fedora-coreos-pipeline`
job, which also already emits Slack messages on failures.

This also causes FCOS builds to be done serially instead of in parallel.
And worse, failures in the first ones cause the latter ones to never be
triggered. (Right now for example, `rawhide` is failing and it's
preventing `branched` from even running.)

So drop the `--wait` switch.