### PR TITLE
plugins: add build-token-root

### DIFF
--- a/jenkins/master/plugins.txt
+++ b/jenkins/master/plugins.txt
@@ -7,3 +7,4 @@ aws-credentials:1.28
 basic-branch-build-strategies:1.3.2
 configuration-as-code-groovy:1.1
 timestamper:1.11.8
+build-token-root:1.7


### PR DESCRIPTION
This plugin allows scripts to trigger jobs using a secret token without
having to set up authentication. I'd like to use this with GitHub
Actions in the future.