### PR TITLE
jenkins/config: turn on timestamper for all pipeline jobs

### DIFF
--- a/jenkins/config/timestamper.yaml
+++ b/jenkins/config/timestamper.yaml
@@ -1,0 +1,3 @@
+unclassified:
+  timestamper:
+    allPipelines: true


### PR DESCRIPTION
Follow-up to https://github.com/coreos/fedora-coreos-pipeline/pull/309.