### PR TITLE
Revert "Temporarily use --no-default-checks"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -303,10 +303,8 @@ lock(resource: "build-${params.STREAM}") {
         }
 
         stage('Kola:QEMU basic') {
-            // XXX: temporarily use --no-default-checks to work around:
-            // https://github.com/coreos/fedora-coreos-tracker/issues/751
             utils.shwrap("""
-            cosa kola run --basic-qemu-scenarios --no-test-exit-error --no-default-checks
+            cosa kola run --basic-qemu-scenarios --no-test-exit-error
             tar -cf - tmp/kola/ | xz -c9 > kola-run-basic.tar.xz
             """)
             archiveArtifacts "kola-run-basic.tar.xz"
@@ -317,11 +315,9 @@ lock(resource: "build-${params.STREAM}") {
 
         stage('Kola:QEMU') {
             // leave 512M for overhead; VMs are 1G each
-            // XXX: temporarily use --no-default-checks to work around:
-            // https://github.com/coreos/fedora-coreos-tracker/issues/751
             def parallel = ((cosa_memory_request_mb - 512) / 1024) as Integer
             utils.shwrap("""
-            cosa kola run --parallel ${parallel} --no-test-exit-error --no-default-checks
+            cosa kola run --parallel ${parallel} --no-test-exit-error
             tar -cf - tmp/kola/ | xz -c9 > kola-run.tar.xz
             """)
             archiveArtifacts "kola-run.tar.xz"
@@ -331,10 +327,8 @@ lock(resource: "build-${params.STREAM}") {
         }
 
         stage('Kola:QEMU upgrade') {
-            // XXX: temporarily use --no-default-checks to work around:
-            // https://github.com/coreos/fedora-coreos-tracker/issues/751
             utils.shwrap("""
-            cosa kola --upgrades --no-test-exit-error --no-default-checks
+            cosa kola --upgrades --no-test-exit-error
             tar -cf - tmp/kola-upgrade | xz -c9 > kola-run-upgrade.tar.xz
             """)
             archiveArtifacts "kola-run-upgrade.tar.xz"

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -63,9 +63,7 @@ cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
 
     fcosKola(cosaDir: env.WORKSPACE, parallel: 5, build: params.VERSION,
              extraArgs: params.KOLA_TESTS,
-            // XXX: temporarily use --no-default-checks to work around:
-            // https://github.com/coreos/fedora-coreos-tracker/issues/751
-             platformArgs: """--no-default-checks -p=aws \
+             platformArgs: """-p=aws \
                 --aws-credentials-file=\${AWS_FCOS_KOLA_BOT_CONFIG}/config \
                 --aws-ami=${ami} \
                 --aws-region=${ami_region}""")

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -66,9 +66,7 @@ cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
 
     fcosKola(cosaDir: env.WORKSPACE, parallel: 5, build: params.VERSION,
              extraArgs: params.KOLA_TESTS,
-            // XXX: temporarily use --no-default-checks to work around:
-            // https://github.com/coreos/fedora-coreos-tracker/issues/751
-             platformArgs: """--no-default-checks -p=gce \
+             platformArgs: """-p=gce \
                 --gce-json-key=\${GCP_KOLA_TESTS_CONFIG}/config \
                 --gce-project=${gcp_project} \
                 --gce-image=projects/${gcp_image_project}/global/images/${gcp_image}""")

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -100,9 +100,7 @@ cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
         fcosKola(cosaDir: env.WORKSPACE, parallel: 5,
                  build: params.VERSION, skipUpgrade: true,
                  extraArgs: params.KOLA_TESTS,
-                 // XXX: temporarily use --no-default-checks to work around:
-                 // https://github.com/coreos/fedora-coreos-tracker/issues/751
-                 platformArgs: """--no-default-checks -p=openstack                               \
+                 platformArgs: """-p=openstack                               \
                     --openstack-config-file=\${OPENSTACK_KOLA_TESTS_CONFIG}/config \
                     --openstack-flavor=v1-standard-4                         \
                     --openstack-network=private                              \


### PR DESCRIPTION
This reverts commit 74a78a3858038cdf738b3e4952e8c94e8ebd50d5.

We're dropping SELinux checking and support for that switch from kola,
so stop using it:

https://github.com/coreos/coreos-assembler/pull/2066