### PR TITLE
Jenkinsfile.production: trigger on GitHub pushes

### DIFF
--- a/Jenkinsfile.mechanical
+++ b/Jenkinsfile.mechanical
@@ -13,22 +13,6 @@ properties([
 ])
 
 node {
-    change = checkout(
-        [$class: 'GitSCM',
-         userRemoteConfigs: [
-            [url: 'https://github.com/coreos/fedora-coreos-config']
-         ],
-         branches: streams.as_branches(streams.mechanical)
-        ]
-    )
-
-    if (streams.triggered_by_push()) {
-        stream = streams.from_branch(change.GIT_BRANCH)
-        if (stream != "") {
-            streams.build_stream(stream)
-        }
-    } else {
-        // cron or manual build: build all mechanical streams
-        streams.mechanical.each{ streams.build_stream(it) }
-    }
+    // cron or manual build: build all mechanical streams
+    streams.mechanical.each{ streams.build_stream(it) }
 }

--- a/Jenkinsfile.production
+++ b/Jenkinsfile.production
@@ -6,8 +6,9 @@ node {
 }
 
 properties([
-    // no triggers; we'll drive production releases manually in the short-term
-    pipelineTriggers([])
+    pipelineTriggers([
+        githubPush()
+    ])
 ])
 
 node {


### PR DESCRIPTION
So far, we've been triggering new production builds manually during the
release process.

In an effort to streamline that process, let's now switch to
automatically triggering a new Jenkins build whenever one of the
production branches is pushed to.

This does mean that we'll be triggering builds even when making changes
on the branch between releases (e.g. tweaking `manifest.yaml`). However,
this happens very rarely, and even then, it's totally fine if it
triggers a build. The pipeline is designed to allow multiple release
candidate builds.