### PR TITLE
jobs/bump-lockfile: fix artifact archiving

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -65,7 +65,11 @@ try { timeout(time: 120, unit: 'MINUTES') { cosaPod {
                 shwrap("cosa build --strict")
             }
 
-            fcosKola(cosaDir: ".")
+            // need to run this in the workspace context because `fcosKola()`
+            // archives directly there but archiveArtifacts is dir-sensitive
+            dir(env.WORKSPACE) {
+                fcosKola(cosaDir: branch)
+            }
 
             stage("Build Metal") {
                 shwrap("cosa buildextend-metal")


### PR DESCRIPTION
We weren't correctly archiving artifacts because we run inside a
`dir(branch) { ... }` block, which causes `archiveArtifacts` to
interpret paths relative to that dir, but `fcosKola()` outputs the
artifact at the top-level workspace directory.

Work around this by just calling `fcosKola` from the workspace.