### PR TITLE
bump-lockfile: strengthen no-op detection

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -23,6 +23,7 @@ try { timeout(time: 120, unit: 'MINUTES') { cosaPod {
         dir(branch) {
             shwrap("cosa init --branch ${branch} https://github.com/${repo}")
             shwrap("cosa buildprep ${BUILDS_BASE_HTTP_URL}/${branch}/builds")
+            def prevBuildID = shwrapCapture("readlink builds/latest")
 
             shwrap("""
               git -C src/config config --global user.name "CoreOS Bot"
@@ -63,6 +64,12 @@ try { timeout(time: 120, unit: 'MINUTES') { cosaPod {
 
             stage("Build") {
                 shwrap("cosa build --strict")
+            }
+
+            def buildID = shwrapCapture("readlink builds/latest")
+            if (prevBuildID == buildID) {
+                println("No changes")
+                return
             }
 
             // need to run this in the workspace context because `fcosKola()`


### PR DESCRIPTION
Right now, we try to no-op early if we detect that the base lockfiles
didn't change. However, `--update-lockfile` will still touch the
lockfiles if just the repo timestamps changed (#232). This then causes
us to run `cosa build`, which no-ops, and then subsequent tests fail
because there is no e.g. qcow2 or ostree artifact that was built.

Fix this by detecting the no-op case just like the main pipeline does.

Closes: #232