### PR TITLE
Revert "bump-lockfile: strengthen no-op detection" and compare lockfiles directly to determine no-op 

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -29,13 +29,16 @@ try { timeout(time: 120, unit: 'MINUTES') { cosaPod {
               git -C src/config config --global user.email "coreosbot@fedoraproject.org"
             """)
 
+            def prevPkgChecksum = shwrapCapture("jq -c .packages src/config/manifest-lock.*.json | sha256sum")
+
             // do a first fetch where we only fetch metadata; no point in
             // importing RPMs if nothing actually changed
             stage("Fetch Metadata") {
                 shwrap("cosa fetch --update-lockfile --dry-run")
             }
 
-            if (shwrapRc("git -C src/config diff --exit-code") == 0) {
+            def newPkgChecksum = shwrapCapture("jq -c .packages src/config/manifest-lock.*.json | sha256sum")
+            if (newPkgChecksum == prevPkgChecksum) {
                 println("No changes")
                 return
             }

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -23,7 +23,6 @@ try { timeout(time: 120, unit: 'MINUTES') { cosaPod {
         dir(branch) {
             shwrap("cosa init --branch ${branch} https://github.com/${repo}")
             shwrap("cosa buildprep ${BUILDS_BASE_HTTP_URL}/${branch}/builds")
-            def prevBuildID = shwrapCapture("readlink builds/latest")
 
             shwrap("""
               git -C src/config config --global user.name "CoreOS Bot"
@@ -64,12 +63,6 @@ try { timeout(time: 120, unit: 'MINUTES') { cosaPod {
 
             stage("Build") {
                 shwrap("cosa build --strict")
-            }
-
-            def buildID = shwrapCapture("readlink builds/latest")
-            if (prevBuildID == buildID) {
-                println("No changes")
-                return
             }
 
             // need to run this in the workspace context because `fcosKola()`


### PR DESCRIPTION
```
commit b25627639f2778e6d4a305bcbe3125bb93d72290
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Wed Apr 7 12:12:57 2021 -0400

    Revert "bump-lockfile: strengthen no-op detection"

    This reverts commit 94f68d41d4258b1b9be3546bf4c0016c0c4bd3ed.

    Just checking that a new build was created is not enough. One scenario
    is if:
    - the base lockfile was updated
    - no new builds with the updated base lockfile happened
    - no new packages are available

    Then we'll be doing a `buildprep` for a build using the old package set
    even though the lockfile in git is up to date.

    The next commit will switch tactics.
```

```
commit ea2f08797bfe553bd2c560270e2c7bfeadcb9577
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Wed Apr 7 12:15:53 2021 -0400

    bump-lockfile: compare lockfiles directly to determine no-op

    The current `git diff` check we have here is good, but it's not entirely
    foolproof because repo timestamps might have changed while the package
    set did not.

    Instead of using `git diff`, let's be more precise and specifically
    compare the `packages` map in the files. That way we truly only ever do
    any work (and push an update) if the package set changed.

    Closes: #232
```