### PR TITLE
streams: disable mechanical streams for now

### DIFF
--- a/streams.groovy
+++ b/streams.groovy
@@ -2,7 +2,7 @@
 
 production = ['testing', 'stable', 'next']
 development = ['testing-devel', 'next-devel']
-mechanical = ['rawhide', 'branched' /*'bodhi-updates', 'bodhi-updates-testing' */]
+mechanical = [/* 'rawhide', 'branched', 'bodhi-updates', 'bodhi-updates-testing' */]
 
 all_streams = production + development + mechanical
 


### PR DESCRIPTION
We've got plenty of CI failures that we need to sort through. Let's
disable these streams to decrease the noise for now.