### PR TITLE
jenkins: increase HEARTBEAT_CHECK_INTERVAL to 10 mins and turn on LAUNCH_DIAGNOSTICS

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -78,6 +78,12 @@ objects:
           # DELTA: point c-as-c plugin to config map files; see below
           - name: CASC_JENKINS_CONFIG
             value: /var/lib/jenkins/configuration-as-code
+          # DELTA: Increase heartbeat interval so durable-task-plugin waits a
+          # bit longer for scripts to start before failing the build.
+          # https://github.com/coreos/coreos-ci/issues/28
+          - name: JENKINS_JAVA_OVERRIDES
+            value: >-
+              -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=600
           image: ' '
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -84,6 +84,7 @@ objects:
           - name: JENKINS_JAVA_OVERRIDES
             value: >-
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=600
+              -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true
           image: ' '
           imagePullPolicy: IfNotPresent
           livenessProbe:


### PR DESCRIPTION
This is basically the same as https://github.com/coreos/coreos-ci/pull/30, which seems to be working well.