### PR TITLE
jenkins/config: fix deprecated hookSecretConfig

### DIFF
--- a/jenkins/config/github-webhook.yaml
+++ b/jenkins/config/github-webhook.yaml
@@ -9,8 +9,8 @@ credentials:
             description: GitHub Webhook Shared Secret
 unclassified:
   gitHubPluginConfig:
-    hookSecretConfig:
-      credentialsId: github-webhook-shared-secret
+    hookSecretConfigs:
+      - credentialsId: github-webhook-shared-secret
     configs:
       - credentialsId: github-coreosbot-token-string
         manageHooks: true


### PR DESCRIPTION
This is now called `hookSecretConfigs` and it's an array.