### PR TITLE
Jenkinsfile: temporarily don't run upgrade tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -326,16 +326,18 @@ lock(resource: "build-${params.STREAM}") {
             return
         }
 
-        stage('Kola:QEMU upgrade') {
-            utils.shwrap("""
-            cosa kola --upgrades --no-test-exit-error
-            tar -cf - tmp/kola-upgrade | xz -c9 > kola-run-upgrade.tar.xz
-            """)
-            archiveArtifacts "kola-run-upgrade.tar.xz"
-        }
-        if (!params.ALLOW_KOLA_UPGRADE_FAILURE && !utils.checkKolaSuccess("tmp/kola-upgrade", currentBuild)) {
-            return
-        }
+      // Unblock our builds for now because the previous run `next-devel` image
+      // signatures didn't get created.
+      //stage('Kola:QEMU upgrade') {
+      //    utils.shwrap("""
+      //    cosa kola --upgrades --no-test-exit-error
+      //    tar -cf - tmp/kola-upgrade | xz -c9 > kola-run-upgrade.tar.xz
+      //    """)
+      //    archiveArtifacts "kola-run-upgrade.tar.xz"
+      //}
+      //if (!params.ALLOW_KOLA_UPGRADE_FAILURE && !utils.checkKolaSuccess("tmp/kola-upgrade", currentBuild)) {
+      //    return
+      //}
 
         if (!params.MINIMAL) {
 


### PR DESCRIPTION
The latest run of `next-devel` didn't sign images because of a failure.
Because the image signatures don't exist the upgrade test fails because
it can't verify the image download, which `coreos-installer download`
tries to do. Easiest thing to do for now is just disable the run upgrade
stage so we can get `next-devel` unblocked.