### PR TITLE
manifest/jenkins: bump readiness timeout to 20 mins

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -49,6 +49,9 @@ objects:
       name: ${JENKINS_SERVICE_NAME}
     strategy:
       type: Recreate
+      # DELTA: allow 20 mins for pod to be ready to account for slow NFS
+      recreateParams:
+        timeoutSeconds: 1200
     template:
       metadata:
         labels:


### PR DESCRIPTION
The default is 10 mins, which is too short for Jenkins to come up
(likely because of slow NFS). So then OCP considers the rollout failed
and reverts to the previous version.