### PR TITLE
Revert "pipeline: stop triggering OpenStack tests"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -533,18 +533,17 @@ lock(resource: "build-${params.STREAM}") {
                 ]
             }
         }
-        // temporarily disabled due to https://github.com/coreos/coreos-assembler/issues/1977
-        //if (!params.MINIMAL && s3_stream_dir &&
-        //        utils.path_exists("\${OPENSTACK_KOLA_TESTS_CONFIG}") && !is_mechanical) {
-        //    stage('Kola:OpenStack') {
-        //        // We consider the OpenStack kola tests to be a followup job, so we use `wait: false` here.
-        //        build job: 'kola-openstack', wait: false, parameters: [
-        //            string(name: 'STREAM', value: params.STREAM),
-        //            string(name: 'VERSION', value: newBuildID),
-        //            string(name: 'S3_STREAM_DIR', value: s3_stream_dir)
-        //        ]
-        //    }
-        //}
+        if (!params.MINIMAL && s3_stream_dir &&
+                utils.path_exists("\${OPENSTACK_KOLA_TESTS_CONFIG}") && !is_mechanical) {
+            stage('Kola:OpenStack') {
+                // We consider the OpenStack kola tests to be a followup job, so we use `wait: false` here.
+                build job: 'kola-openstack', wait: false, parameters: [
+                    string(name: 'STREAM', value: params.STREAM),
+                    string(name: 'VERSION', value: newBuildID),
+                    string(name: 'S3_STREAM_DIR', value: s3_stream_dir)
+                ]
+            }
+        }
 
         // For now, we auto-release all non-production streams builds. That
         // way, we can e.g. test testing-devel AMIs easily.


### PR DESCRIPTION
This reverts commit c5bcb1acf416c198517f4105c28935530154c47d.

With https://github.com/coreos/coreos-assembler/pull/2138
the issue is fixed now!