### PR TITLE
bump-lockfile: de-parallelize

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -1,23 +1,32 @@
 @Library('github.com/coreos/coreos-ci-lib') _
 
+def streams
+node {
+    checkout scm
+    streams = load("streams.groovy")
+}
+
 repo = "coreos/fedora-coreos-config"
-branches = [
-    "testing-devel",
-    "next-devel"
-]
 botCreds = "github-coreosbot-token"
 
 // Base URL through which to download artifacts
 BUILDS_BASE_HTTP_URL = "https://builds.coreos.fedoraproject.org/prod/streams"
 
 properties([
-    pipelineTriggers([
-        // we don't need to bump lockfiles any more often than daily
-        cron("H H * * *")
+    // we're only triggered by bump-lockfiles
+    pipelineTriggers([]),
+    parameters([
+        choice(name: 'STREAM',
+               choices: streams.development,
+               description: 'Fedora CoreOS development stream to bump'),
     ])
 ])
 
-try { timeout(time: 120, unit: 'MINUTES') { cosaPod {
+echo "Waiting for bump-${params.STREAM} lock"
+currentBuild.description = "[${params.STREAM}] Waiting"
+
+try { lock(resource: "bump-${params.STREAM}") { timeout(time: 120, unit: 'MINUTES') { cosaPod {
+    currentBuild.description = "[${params.STREAM}] Running"
 
     // set up git user upfront
     shwrap("""
@@ -25,97 +34,91 @@ try { timeout(time: 120, unit: 'MINUTES') { cosaPod {
       git config --global user.email "coreosbot@fedoraproject.org"
     """)
 
-    parallel branches.collectEntries { branch -> [branch, {
-        shwrap("mkdir ${branch}")
-        dir(branch) {
-            shwrap("cosa init --branch ${branch} https://github.com/${repo}")
-            shwrap("cosa buildprep ${BUILDS_BASE_HTTP_URL}/${branch}/builds")
+    def branch = params.STREAM
+    shwrap("cosa init --branch ${branch} https://github.com/${repo}")
+    shwrap("cosa buildprep ${BUILDS_BASE_HTTP_URL}/${branch}/builds")
 
-            def prevPkgChecksum = shwrapCapture("jq -c .packages src/config/manifest-lock.*.json | sha256sum")
+    def prevPkgChecksum = shwrapCapture("jq -c .packages src/config/manifest-lock.*.json | sha256sum")
 
-            // do a first fetch where we only fetch metadata; no point in
-            // importing RPMs if nothing actually changed
-            stage("Fetch Metadata") {
-                shwrap("cosa fetch --update-lockfile --dry-run")
-            }
+    // do a first fetch where we only fetch metadata; no point in
+    // importing RPMs if nothing actually changed
+    stage("Fetch Metadata") {
+        shwrap("cosa fetch --update-lockfile --dry-run")
+    }
 
-            def newPkgChecksum = shwrapCapture("jq -c .packages src/config/manifest-lock.*.json | sha256sum")
-            if (newPkgChecksum == prevPkgChecksum) {
-                println("No changes")
-                return
-            }
+    def newPkgChecksum = shwrapCapture("jq -c .packages src/config/manifest-lock.*.json | sha256sum")
+    if (newPkgChecksum == prevPkgChecksum) {
+        println("No changes")
+        currentBuild.description = "[${params.STREAM}] 💤 (no change)"
+        return
+    }
 
-            // sanity-check only base lockfiles were changed
-            shwrap("""
-              # do this separately so set -e kicks in if it fails
-              files=\$(git -C src/config ls-files --modified --deleted)
-              for f in \${files}; do
-                if ! [[ \${f} =~ ^manifest-lock\\.[0-9a-z_]+\\.json ]]; then
-                  echo "Unexpected modified file \${f}"
-                  exit 1
-                fi
-              done
-            """)
+    // sanity-check only base lockfiles were changed
+    shwrap("""
+      # do this separately so set -e kicks in if it fails
+      files=\$(git -C src/config ls-files --modified --deleted)
+      for f in \${files}; do
+        if ! [[ \${f} =~ ^manifest-lock\\.[0-9a-z_]+\\.json ]]; then
+          echo "Unexpected modified file \${f}"
+          exit 1
+        fi
+      done
+    """)
 
-            stage("Fetch") {
-                // XXX: hack around subtle lockfile bug (jlebon to submit an
-                // rpm-ostree issue or patch about this)
-                shwrap("cp src/config/fedora-coreos-pool.repo{,.bak}")
-                shwrap("echo cost=500 >> src/config/fedora-coreos-pool.repo")
-                shwrap("cosa fetch --strict")
-                shwrap("cp src/config/fedora-coreos-pool.repo{.bak,}")
-            }
+    stage("Fetch") {
+        // XXX: hack around subtle lockfile bug (jlebon to submit an
+        // rpm-ostree issue or patch about this)
+        shwrap("cp src/config/fedora-coreos-pool.repo{,.bak}")
+        shwrap("echo cost=500 >> src/config/fedora-coreos-pool.repo")
+        shwrap("cosa fetch --strict")
+        shwrap("cp src/config/fedora-coreos-pool.repo{.bak,}")
+    }
 
-            stage("Build") {
-                shwrap("cosa build --strict")
-            }
+    stage("Build") {
+        shwrap("cosa build --strict")
+    }
 
-            // need to run this in the workspace context because `fcosKola()`
-            // archives directly there but archiveArtifacts is dir-sensitive
-            dir(env.WORKSPACE) {
-                fcosKola(cosaDir: branch)
-            }
+    fcosKola()
 
-            stage("Build Metal") {
-                shwrap("cosa buildextend-metal")
-                shwrap("cosa buildextend-metal4k")
-            }
+    stage("Build Metal") {
+        shwrap("cosa buildextend-metal")
+        shwrap("cosa buildextend-metal4k")
+    }
 
-            stage("Build Live") {
-                shwrap("cosa buildextend-live --fast")
-                // Test metal4k with an uncompressed image and metal with a
-                // compressed one
-                shwrap("cosa compress --artifact=metal")
-            }
+    stage("Build Live") {
+        shwrap("cosa buildextend-live --fast")
+        // Test metal4k with an uncompressed image and metal with a
+        // compressed one
+        shwrap("cosa compress --artifact=metal")
+    }
 
-            try {
-                parallel metal: {
-                    shwrap("kola testiso -S --scenarios pxe-install,iso-install,iso-offline-install --output-dir tmp/kola-testiso-metal")
-                }, metal4k: {
-                    shwrap("kola testiso -S --scenarios iso-install,iso-offline-install --qemu-native-4k --output-dir tmp/kola-testiso-metal4k")
-                }
-            } finally {
-                shwrap("tar -cf - tmp/kola-testiso-metal/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal.tar.xz")
-                shwrap("tar -cf - tmp/kola-testiso-metal4k/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal4k.tar.xz")
-                archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-testiso*.tar.xz'
-            }
-
-            // OK, it passed kola: just push to the branch. In the future, we might be
-            // fancier here; e.g. if tests fail, just open a PR, or if tests passed but a
-            // package was added or removed.
-            stage("Push") {
-                shwrap("git -C src/config commit -am 'lockfiles: bump to latest' -m 'Job URL: ${env.BUILD_URL}' -m 'Job definition: https://github.com/coreos/fedora-coreos-pipeline/blob/master/jobs/bump-lockfile.Jenkinsfile'")
-                withCredentials([usernamePassword(credentialsId: botCreds,
-                                                  usernameVariable: 'GHUSER',
-                                                  passwordVariable: 'GHTOKEN')]) {
-                  // should gracefully handle race conditions here
-                  sh("git -C src/config push https://\${GHUSER}:\${GHTOKEN}@github.com/${repo} ${branch}")
-                }
-            }
+    try {
+        parallel metal: {
+            shwrap("kola testiso -S --scenarios pxe-install,iso-install,iso-offline-install --output-dir tmp/kola-testiso-metal")
+        }, metal4k: {
+            shwrap("kola testiso -S --scenarios iso-install,iso-offline-install --qemu-native-4k --output-dir tmp/kola-testiso-metal4k")
         }
-    }] }
+    } finally {
+        shwrap("tar -cf - tmp/kola-testiso-metal/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal.tar.xz")
+        shwrap("tar -cf - tmp/kola-testiso-metal4k/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal4k.tar.xz")
+        archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-testiso*.tar.xz'
+    }
+
+    // OK, it passed kola: just push to the branch. In the future, we might be
+    // fancier here; e.g. if tests fail, just open a PR, or if tests passed but a
+    // package was added or removed.
+    stage("Push") {
+        shwrap("git -C src/config commit -am 'lockfiles: bump to latest' -m 'Job URL: ${env.BUILD_URL}' -m 'Job definition: https://github.com/coreos/fedora-coreos-pipeline/blob/master/jobs/bump-lockfile.Jenkinsfile'")
+        withCredentials([usernamePassword(credentialsId: botCreds,
+                                          usernameVariable: 'GHUSER',
+                                          passwordVariable: 'GHTOKEN')]) {
+          // should gracefully handle race conditions here
+          sh("git -C src/config push https://\${GHUSER}:\${GHTOKEN}@github.com/${repo} ${branch}")
+        }
+    }
+    currentBuild.description = "[${params.STREAM}] ⚡ (pushed)"
     currentBuild.result = 'SUCCESS'
-}}} catch (e) {
+}}}} catch (e) {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {

--- a/jobs/bump-lockfiles.Jenkinsfile
+++ b/jobs/bump-lockfiles.Jenkinsfile
@@ -1,0 +1,19 @@
+@Library('github.com/coreos/coreos-ci-lib') _
+
+properties([
+    pipelineTriggers([
+        // we don't need to bump lockfiles any more often than daily
+        cron("H H * * *")
+    ])
+])
+
+node {
+    checkout scm
+    def streams = load("streams.groovy")
+
+    parallel streams.development.collectEntries { stream -> [stream, {
+        build job: 'bump-lockfile', wait: false, parameters: [
+            string(name: 'STREAM', value: stream)
+        ]
+    }] }
+}


### PR DESCRIPTION
Right now, the job tries to update both `testing-devel` and `next-devel`
in parallel, but this makes the output messy and hard to follow. It also
makes it harder to tell from the job status page which of the two
branches failed (and the BlueOcean UI isn't much help either).

Instead, let's make `bump-lockfile` focus on a single stream, and have a
driver job which simply triggers `bump-lockfile` once per stream so that
they're separate jobs. This mirrors how the main pipeline jobs
themselves are set up.

Patch best viewed with whitespace ignored.

Closes: #331