### PR TITLE
plugins: bump configuration-as-code to v1.49

### DIFF
--- a/jenkins/master/plugins.txt
+++ b/jenkins/master/plugins.txt
@@ -1,5 +1,5 @@
 github-oauth:0.33
-configuration-as-code:1.39
+configuration-as-code:1.49
 slack:2.34
 job-dsl:1.76
 matrix-auth:2.4.2


### PR DESCRIPTION
Latest Jenkins requires this.