### PR TITLE
jobs/bump-lockfile: explicitly set SUCCESS status in no-op case

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -49,6 +49,7 @@ try { lock(resource: "bump-${params.STREAM}") { timeout(time: 120, unit: 'MINUTE
     def newPkgChecksum = shwrapCapture("jq -c .packages src/config/manifest-lock.*.json | sha256sum")
     if (newPkgChecksum == prevPkgChecksum) {
         println("No changes")
+        currentBuild.result = 'SUCCESS'
         currentBuild.description = "[${params.STREAM}] 💤 (no change)"
         return
     }


### PR DESCRIPTION
Otherwise, the Slack notifier code will think that the job failed and
emit a trashfire message.