### PR TITLE
jenkins.yaml: use `fsGroup: 0` for Jenkins

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -111,6 +111,9 @@ objects:
           securityContext:
             capabilities: {}
             privileged: false
+            # DELTA: This is important to ensure the local PVC is chown'ed to a
+            # gid we have access to.
+            fsGroup: 0
           terminationMessagePath: /dev/termination-log
           volumeMounts:
           - mountPath: /var/lib/jenkins


### PR DESCRIPTION
Jenkins already runs as gid 0, but we need to specify `fsGroup: 0` in
the pod definition too so that Kubernetes will make sure that the local
PVC mounted in will be chown'ed to the root gid so we can access it.