### PR TITLE
Revert "COSA image: use :latest tag to ease migration"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,9 +41,9 @@ BUILDS_BASE_HTTP_URL = "https://builds.coreos.fedoraproject.org/prod/streams"
 
 def coreos_assembler_image
 if (official) {
-    coreos_assembler_image = "coreos-assembler:latest"
+    coreos_assembler_image = "coreos-assembler:main"
 } else {
-    coreos_assembler_image = "${developer_prefix}-coreos-assembler:latest"
+    coreos_assembler_image = "${developer_prefix}-coreos-assembler:main"
 }
 
 properties([

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -31,7 +31,7 @@ properties([
              description: 'Force AWS AMI replication'),
       string(name: 'COREOS_ASSEMBLER_IMAGE',
              description: 'Override coreos-assembler image to use',
-             defaultValue: "coreos-assembler:latest",
+             defaultValue: "coreos-assembler:main",
              trim: true)
     ])
 ])

--- a/Jenkinsfile.stream.metadata.generator
+++ b/Jenkinsfile.stream.metadata.generator
@@ -22,7 +22,7 @@ properties([
 
 currentBuild.description = "[${params.STREAM}] - ${params.VERSION}"
 
-pod = pod.replace("COREOS_ASSEMBLER_IMAGE", "coreos-assembler:latest")
+pod = pod.replace("COREOS_ASSEMBLER_IMAGE", "coreos-assembler:main")
 
 // shouldn't need more than 256Mi for this job
 pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "256Mi")

--- a/deploy
+++ b/deploy
@@ -8,7 +8,7 @@
         ./deploy --update \
             --pipeline https://github.com/jlebon/fedora-coreos-pipeline \
             --config https://github.com/jlebon/fedora-coreos-config@wip \
-            --cosa-img quay.io/jlebon/coreos-assembler:latest
+            --cosa-img quay.io/jlebon/coreos-assembler:main
             # OR
             --cosa https://github.com/jlebon/coreos-assembler
 

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -27,7 +27,7 @@ properties([
              trim: true),
       string(name: 'COREOS_ASSEMBLER_IMAGE',
              description: 'Override the coreos-assembler image to use',
-             defaultValue: "coreos-assembler:latest",
+             defaultValue: "coreos-assembler:main",
              trim: true)
     ])
 ])

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -27,7 +27,7 @@ properties([
              trim: true),
       string(name: 'COREOS_ASSEMBLER_IMAGE',
              description: 'Override the coreos-assembler image to use',
-             defaultValue: "coreos-assembler:latest",
+             defaultValue: "coreos-assembler:main",
              trim: true)
     ])
 ])

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -27,7 +27,7 @@ properties([
              trim: true),
       string(name: 'COREOS_ASSEMBLER_IMAGE',
              description: 'Override the coreos-assembler image to use',
-             defaultValue: "coreos-assembler:latest",
+             defaultValue: "coreos-assembler:main",
              trim: true)
     ])
 ])

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -35,9 +35,9 @@ parameters:
     value: 100Gi
   - description: Image of coreos-assembler to use
     name: COREOS_ASSEMBLER_IMAGE
-    # for now we just follow :latest, but we may start freezing if things become
+    # for now we just follow :main, but we may start freezing if things become
     # too unstable
-    value: quay.io/coreos-assembler/coreos-assembler:latest
+    value: quay.io/coreos-assembler/coreos-assembler:main
   - description: AWS S3 bucket in which to store builds (or blank for none)
     name: S3_BUCKET
     value: fcos-builds
@@ -153,7 +153,7 @@ objects:
         imageChange:
           from:
             kind: ImageStreamTag
-            name: coreos-assembler:latest
+            name: coreos-assembler:main
       source:
         type: Git
         git:
@@ -184,7 +184,7 @@ objects:
         imageChange:
           from:
             kind: ImageStreamTag
-            name: coreos-assembler:latest
+            name: coreos-assembler:main
       source:
         type: Git
         git:

--- a/manifests/sleep.yaml
+++ b/manifests/sleep.yaml
@@ -7,7 +7,7 @@ kind: Pod
 spec:
   containers:
    - name: coreos-assembler-sleep
-     image: coreos-assembler:latest
+     image: coreos-assembler:main
      imagePullPolicy: Always
      workingDir: /srv/
      command: ['/usr/bin/dumb-init']


### PR DESCRIPTION
This reverts commit 0f8cf3a.

The `:latest` tag has fuzzy semantics. Let's be more explicit here and
use the actual branch-derived name.

