### PR TITLE
jobs/sync-stream-metadata: specify `main` branch when cloning fedora-coreos-streams

### DIFF
--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -15,7 +15,7 @@ properties([
 ])
 
 cosaPod(configMaps: ["fedora-messaging-cfg"], secrets: ["fedora-messaging-coreos-key"]) {
-    git(url: 'https://github.com/coreos/fedora-coreos-streams', credentialsId: 'github-coreosbot-token')
+    git(url: 'https://github.com/coreos/fedora-coreos-streams', branch: 'main', credentialsId: 'github-coreosbot-token')
     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-fcos-builds-bot']]) {
         // XXX: eventually we want this as part of the pod or built into the image we use
         shwrap("git clone --depth=1 https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng")


### PR DESCRIPTION
Otherwise, surprisingly the `git` step defaults to `master` instead of
whatever the default branch upstream is.