### PR TITLE
utils: stop archiving the QEMU image on failure

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -71,10 +71,6 @@ boolean checkKolaSuccess(dir, currentBuild) {
     def result = report["result"]
     print("kola result: ${result}")
     if (result != "PASS") {
-        if (report["platform"] == "qemu-unpriv") {
-            shwrap("coreos-assembler compress --compressor xz")
-            archiveArtifacts "builds/latest/**/*.qcow2.xz"
-        }
         currentBuild.result = 'FAILURE'
         return false
     }


### PR DESCRIPTION
This is a heavy I/O operation because it requires copying the qcow2 from
the pod's workspace back to the controller.

I think it may have contributed to a recent job timing out because
compressing and then copying takes time. We also noticed that the kola
test results archived just before calling this function didn't make it,
which I suspect could be a result of Jenkins being interrupted while
archiving the qcow2 image.

Anyway, in practice we haven't used this a lot to investigate failures,
because in the end one tends to rebuild it locally for easier hacking.
So let's drop it.