### PR TITLE
jobs/kola-openstack: disable concurrent builds

### DIFF
--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -7,6 +7,8 @@ node {
 }
 
 properties([
+    // we only want to run one test at a time so we don't hit VexxHost resource limits
+    disableConcurrentBuilds(),
     pipelineTriggers([]),
     parameters([
       choice(name: 'STREAM',


### PR DESCRIPTION
Run them one at a time so we don't hit VexxHost resource limits.