### PR TITLE
pipeline: Ship Azure Stack

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -391,7 +391,7 @@ lock(resource: "build-${params.STREAM}") {
 
             // parallel build these artifacts
             def pbuilds = [:]
-            ["Aliyun", "AWS", "Azure", "DigitalOcean", "Exoscale", "GCP", "IBMCloud", "OpenStack", "VMware", "Vultr"].each {
+            ["Aliyun", "AWS", "Azure", "AzureStack", "DigitalOcean", "Exoscale", "GCP", "IBMCloud", "OpenStack", "VMware", "Vultr"].each {
                 pbuilds[it] = {
                     def cmd = it.toLowerCase()
                     utils.shwrap("""


### PR DESCRIPTION
This was added in https://github.com/coreos/coreos-assembler/pull/1566
and recently enabled for RHCOS.  Let's ship it here too to keep
things aligned upstream/downstream.