### PR TITLE
bump-lockfile: force gangplank to not upload artifacts

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -133,6 +133,7 @@ stages:
   build_artifacts: [base]
   post_commands:
     - cosa kola run --basic-qemu-scenarios
+    - rm -f builds/builds.json # https://github.com/coreos/coreos-assembler/issues/2317
 delay_meta_merge: false
 EOF
                    """)


### PR DESCRIPTION
We don't want the bits, we just need to know if they passed tests or
not. Currently Gangplank doesn't support this [1] but we can force
it by just deleting the builds.json in a post command.

[1] https://github.com/coreos/coreos-assembler/issues/2317