### PR TITLE
Jenkinsfile.{development,mechanical,production}: stop loading utils.groovy

### DIFF
--- a/Jenkinsfile.development
+++ b/Jenkinsfile.development
@@ -1,7 +1,6 @@
-def utils, streams
+def streams
 node {
     checkout scm
-    utils = load("utils.groovy")
     streams = load("streams.groovy")
 }
 

--- a/Jenkinsfile.mechanical
+++ b/Jenkinsfile.mechanical
@@ -1,7 +1,6 @@
-def utils, streams
+def streams
 node {
     checkout scm
-    utils = load("utils.groovy")
     streams = load("streams.groovy")
 }
 

--- a/Jenkinsfile.production
+++ b/Jenkinsfile.production
@@ -1,7 +1,6 @@
-def utils, streams
+def streams
 node {
     checkout scm
-    utils = load("utils.groovy")
     streams = load("streams.groovy")
 }
 


### PR DESCRIPTION
It's not used anywhere and I'm seeing a library load error right
now so let's just clear them to help debug since they're not being
used.