### PR TITLE
Jenkinsfile: serialize access to builds.json

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,10 +211,13 @@ lock(resource: "build-${params.STREAM}") {
                 if (utils.pathExists("tmp/releases.json")) {
                     def releases = readJSON file: "tmp/releases.json"
                     // check if there's a previous release we should use as parent
-                    if (releases["releases"].size() > 0) {
-                        def commit_obj = releases["releases"][-1]["commits"].find{ commit -> commit["architecture"] == basearch }
-                        parent_commit = commit_obj["checksum"]
-                        parent_version = releases["releases"][-1]["version"]
+                    for (release in releases["releases"].reverse()) {
+                        def commit_obj = release["commits"].find{ commit -> commit["architecture"] == basearch }
+                        if (commit_obj != null) {
+                            parent_commit = commit_obj["checksum"]
+                            parent_version = release["version"]
+                            break
+                        }
                     }
                 }
 


### PR DESCRIPTION
```
commit d577d969cf45f3c89cb675e3ef99a4321a390ce6
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Aug 6 09:50:26 2021 -0400

    Jenkinsfile: iterate through releases until finding parent

    In the case there was no previous release for an architecture
    it can be null. In the case there were releases where some
    architectures were skipped, we need to go through the list.
    Handle both of those cases here.

commit 979427e265d6b49084fb6d378ef5b605b4ffc1b9
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Aug 6 09:35:26 2021 -0400

    Jenkinsfile: serialize access to builds.json

    Since we are about to start forking off pipeline runs for
    multiple architectures at the same time we need to add some
    locking and higher level logic around builds.json. We only
    want a single job accessing it at the same time and we only
    want to add to it and never remove any build entries.

    Create a new shared `bump_builds_json()` function that can
    be used to implement this locking/logic.

    We also add an early archive stage to the pipeline where we
    buildupload the ostree and various metadata early on; and
    bump the builds.json. This has the desired effect of "reserving"
    our build ID earlier since after this point in the near future
    we'll be forking off multiple other pipelines any of which
    could fail (including x86_64). This means we're more like to
    have build IDs from failed runs in our history, but that's OK.
```
