### PR TITLE
Add multi-arch-pipeline job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -494,12 +494,6 @@ lock(resource: "build-${params.STREAM}") {
             cosa compress --compressor xz
             """)
 
-            // Run the coreos-meta-translator against the most recent build,
-            // which will generate a release.json from the meta.json files
-            shwrap("""
-            cosa generate-release-meta --workdir .
-            """)
-
             if (s3_stream_dir) {
               // just upload as public-read for now, but see discussions in
               // https://github.com/coreos/fedora-coreos-tracker/issues/189


### PR DESCRIPTION
This is the first attempt at adding a multi-arch pipeline. We'll
call the multi-arch-pipeline job from the main pipeline after QEMU
tests have passed.

This is currently mostly a copy/paste of the original pipeline. In
the future we want to factor out these bits and re-use them between
the main pipeline and the multi-arch-pipeline job.
