### PR TITLE
pipelines: add --build --arch to robosignatory call

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -301,7 +301,8 @@ lock(resource: "build-${params.STREAM}") {
             stage('Sign OSTree') {
                 shwrap("""
                 export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
-                cosa sign robosignatory --s3 ${s3_stream_dir}/builds \
+                cosa sign --build=${newBuildID} --arch=${basearch} \
+                    robosignatory --s3 ${s3_stream_dir}/builds \
                     --extra-fedmsg-keys stream=${params.STREAM} \
                     --ostree --gpgkeypath /etc/pki/rpm-gpg \
                     --fedmsg-conf /etc/fedora-messaging-cfg/fedmsg.toml
@@ -532,7 +533,8 @@ lock(resource: "build-${params.STREAM}") {
             stage('Sign Images') {
                 shwrap("""
                 export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
-                cosa sign robosignatory --s3 ${s3_stream_dir}/builds \
+                cosa sign --build=${newBuildID} --arch=${basearch} \
+                    robosignatory --s3 ${s3_stream_dir}/builds \
                     --extra-fedmsg-keys stream=${params.STREAM} \
                     --images --gpgkeypath /etc/pki/rpm-gpg \
                     --fedmsg-conf /etc/fedora-messaging-cfg/fedmsg.toml

--- a/jobs/multi-arch-pipeline.Jenkinsfile
+++ b/jobs/multi-arch-pipeline.Jenkinsfile
@@ -263,7 +263,8 @@ EOF
             stage('Sign OSTree') {
                 shwrap("""
                 export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
-                cosa sign robosignatory --s3 ${s3_stream_dir}/builds \
+                cosa sign --build=${newBuildID} --arch=${basearch} \
+                    robosignatory --s3 ${s3_stream_dir}/builds \
                     --extra-fedmsg-keys stream=${params.STREAM} \
                     --ostree --arch=${basearch} \
                     --gpgkeypath /etc/pki/rpm-gpg \
@@ -389,7 +390,8 @@ EOF
             stage('Sign Images') {
                 shwrap("""
                 export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
-                cosa sign robosignatory --s3 ${s3_stream_dir}/builds \
+                cosa sign --build=${newBuildID} --arch=${basearch} \
+                    robosignatory --s3 ${s3_stream_dir}/builds \
                     --extra-fedmsg-keys stream=${params.STREAM} \
                     --images --arch=${basearch} \
                     --gpgkeypath /etc/pki/rpm-gpg \

--- a/jobs/multi-arch-pipeline.Jenkinsfile
+++ b/jobs/multi-arch-pipeline.Jenkinsfile
@@ -123,7 +123,7 @@ echo "Final podspec: ${pod}"
 def pod_label = "cosa-${UUID.randomUUID().toString()}"
 
 
-echo "Waiting for build-${params.STREAM} lock"
+echo "Waiting for build-${params.STREAM}-${params.ARCH} lock"
 currentBuild.description = "[${params.STREAM}][${params.ARCH}] Waiting"
 
 lock(resource: "build-${params.STREAM}-${params.ARCH}") {


### PR DESCRIPTION
```
commit a543624c7e50d5bce43d7de8bd383f3c2cdfeae6
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Aug 11 14:14:43 2021 -0400

    multi-arch-pipeline: fixup echo about what lock we're waiting on
    
    This was confusing because the lock is "build-${params.STREAM}-${params.ARCH}".

commit 4f489ac38ffd3b718c8d9a6d1423f51db81d5360
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Aug 11 14:13:45 2021 -0400

    pipelines: add --build --arch to robosignatory call
    
    Let's be more explicit about the build and architecture we want signed
    so there's never any opportunity for the wrong thing to get signed.
```
