### PR TITLE
Jenkinsfile.release: limit buildupload artifacts

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -140,11 +140,17 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
         stage('Publish') {
             // Since some of the earlier operations (like AWS replication) only modify
             // the individual meta.json files we need to re-generate the release metadata
-            // to get the new info and upload it back to s3
+            // to get the new info and upload it back to s3.
+            //
+            // Pass --artifact=ostree to buildupload to prevent it from trying to
+            // upload the qcow2 for x86_64. This happens because we early archive
+            // just the ostree in the x86_64 pipeline, but the qemu qcow is in the
+            // meta.json
             shwrap("""
             export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
             cosa generate-release-meta --build-id ${params.VERSION} --workdir .
-            cosa buildupload --build=${params.VERSION} --skip-builds-json s3 --acl=public-read ${s3_stream_dir}/builds
+            cosa buildupload --build=${params.VERSION} --skip-builds-json \
+                --artifact=ostree s3 --acl=public-read ${s3_stream_dir}/builds
             """)
 
             // Run plume to publish official builds; This will handle modifying


### PR DESCRIPTION
In the x86_64 pipeline we early archive the ostree but the meta.json
that gets uploaded includes the qemu qcow. Right now the aarch64
pipeline is finishing before the x86_64 pipeline does and when we
go to buildupload it's complaining because the x86_64 qemu qcow
doesn't exist either locally or in s3.

```
Exception: builds/36.20210812.91.0/x86_64/fedora-coreos-36.20210812.91.0-qemu.x86_64.qcow2 not found locally or in the s3 destination!
```

Since we shouldn't be uploading image artifacts in the release step
anyway, let's just pass --artifact=ostree, which will essentially
give us what we want. It won't re-upload the ostree because it already
exists in s3, and it won't try any other artifact, including qemu qcow.