### PR TITLE
seed: fix call to get_annotation

### DIFF
--- a/jenkins/config/seed.yaml
+++ b/jenkins/config/seed.yaml
@@ -18,8 +18,8 @@ jobs:
                 // XXX: hack, should put this in coreos-ci-lib
                 sh("curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-pipeline/main/utils.groovy")
                 def pipeutils = load("utils.groovy")
-                def url = pipeutils.get_annotation("jenkins", "jenkins-jobs-url")
-                def ref = pipeutils.get_annotation("jenkins", "jenkins-jobs-ref")
+                def url = pipeutils.get_annotation("jenkins-jobs-url")
+                def ref = pipeutils.get_annotation("jenkins-jobs-ref")
                 shwrap("rm -rf source")
                 shwrap("git clone -b ^${ref} ^${url} source")
 


### PR DESCRIPTION
The call interface changed in 13b9d25 to just take one argument.