### PR TITLE
streams: re-enable `branched` stream

### DIFF
--- a/streams.groovy
+++ b/streams.groovy
@@ -2,7 +2,7 @@
 
 production = ['testing', 'stable', 'next']
 development = ['testing-devel' /* 'next-devel' */]
-mechanical = ['rawhide' /* 'branched', 'bodhi-updates', 'bodhi-updates-testing' */]
+mechanical = ['rawhide', 'branched' /* 'bodhi-updates', 'bodhi-updates-testing' */]
 
 all_streams = production + development + mechanical
 


### PR DESCRIPTION
Fedora 35 has branched now, so let's track it.