### PR TITLE
kola-aws,kola-gcp: support arch, let kola inspect meta.json

### DIFF
--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -17,6 +17,10 @@ properties([
              description: 'Fedora CoreOS Build ID to test',
              defaultValue: '',
              trim: true),
+      string(name: 'ARCH',
+             description: 'Target architecture',
+             defaultValue: 'x86_64',
+             trim: true),
       string(name: 'S3_STREAM_DIR',
              description: 'Override the Fedora CoreOS S3 stream directory',
              defaultValue: '',
@@ -32,7 +36,7 @@ properties([
     ])
 ])
 
-currentBuild.description = "[${params.STREAM}] - ${params.VERSION}"
+currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSION}"
 
 def s3_stream_dir = params.S3_STREAM_DIR
 if (s3_stream_dir == "") {
@@ -43,31 +47,22 @@ cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
         memory: "256Mi", kvm: false,
         secrets: ["aws-fcos-builds-bot-config", "gcp-kola-tests-config"]) {
 
-    def gcp_image, gcp_image_project, gcp_project
+    def gcp_project
     stage('Fetch Metadata') {
         shwrap("""
         export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}/config
         cosa init --branch ${params.STREAM} https://github.com/coreos/fedora-coreos-config
-        cosa buildprep --ostree --build=${params.VERSION} s3://${s3_stream_dir}/builds
+        cosa buildprep --ostree --build=${params.VERSION} --arch=${params.ARCH} s3://${s3_stream_dir}/builds
         """)
-
-        def basearch = shwrapCapture("cosa basearch")
-        def meta = readJSON file: "builds/${params.VERSION}/${basearch}/meta.json"
-        if (meta.gcp.image) {
-            gcp_image = meta.gcp.image
-            gcp_image_project = meta.gcp.project
-        } else {
-            throw new Exception("No GCP image found in metadata for ${params.VERSION}")
-        }
 
         // pick up the project to use from the config
         gcp_project = shwrapCapture("jq -r .project_id \${GCP_KOLA_TESTS_CONFIG}/config")
     }
 
-    fcosKola(cosaDir: env.WORKSPACE, parallel: 5, build: params.VERSION,
+    fcosKola(cosaDir: env.WORKSPACE, parallel: 5,
+             build: params.VERSION, arch: params.ARCH,
              extraArgs: params.KOLA_TESTS,
              platformArgs: """-p=gce \
                 --gce-json-key=\${GCP_KOLA_TESTS_CONFIG}/config \
-                --gce-project=${gcp_project} \
-                --gce-image=projects/${gcp_image_project}/global/images/${gcp_image}""")
+                --gce-project=${gcp_project}""")
 }


### PR DESCRIPTION
```
commit 3af893efef8095bf58e92f01298c7e02a6502f0e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Aug 19 16:49:52 2021 -0400

    kola-gcp: support arch, get image from meta.json
    
    Similar to what we just did for AWS let's support passing in the
    architecture (even though GCP only supports one) and also let kola
    pick up the image from the meta.json rather than digging for it here
    in the job.

commit 475f622705ba80d4327f849d48c19c2f65d8e407
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Aug 10 15:53:36 2021 -0400

    kola-aws: allow kola to introspect instance type and AMI
    
    kola recently gained the ability to pick up the AMI ID from
    the specified build metadata and also switch the instance type
    based on the target architecture. Let kola do the heavy lifting
    here for us.
    
    See https://github.com/coreos/coreos-assembler/pull/2353

commit 32d349bf5372082dfca4be614cb98d870436023c
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Aug 9 17:12:34 2021 -0400

    kola-aws: support passed in architecture
    
    Also manually override the instance type for aarch64 because the
    default m5.large won't work.
```
