### PR TITLE
Jenkinsfile: limit multi-arch-pipeline to non production builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -371,14 +371,18 @@ lock(resource: "build-${params.STREAM}") {
             }
         }
 
-        stage('Fork AARCH64 Pipeline') {
-            build job: 'multi-arch-pipeline', wait: false, parameters: [
-                booleanParam(name: 'FORCE', value: params.FORCE),
-                booleanParam(name: 'MINIMAL', value: params.MINIMAL),
-                string(name: 'STREAM', value: params.STREAM),
-                string(name: 'VERSION', value: newBuildID),
-                string(name: 'ARCH', value: 'aarch64')
-            ]
+        // Don't run the multi-arch-pipeline for prod streams just
+        // yet. We're still working out all the details.
+        if (!official || !(params.STREAM in streams.production)) {
+            stage('Fork AARCH64 Pipeline') {
+                build job: 'multi-arch-pipeline', wait: false, parameters: [
+                    booleanParam(name: 'FORCE', value: params.FORCE),
+                    booleanParam(name: 'MINIMAL', value: params.MINIMAL),
+                    string(name: 'STREAM', value: params.STREAM),
+                    string(name: 'VERSION', value: newBuildID),
+                    string(name: 'ARCH', value: 'aarch64')
+                ]
+            }
         }
 
         if (!params.MINIMAL) {


### PR DESCRIPTION
We're not quite ready for them on the production streams just yet.