### PR TITLE
release: Copy oscontainer to quay.io

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -83,9 +83,20 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
             shwrap("""
             export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
             cosa init --branch ${params.STREAM} https://github.com/coreos/fedora-coreos-config
-            cosa buildprep --build=${params.VERSION} \
+            cosa buildprep --ostree --build=${params.VERSION} \
                 --arch=all s3://${s3_stream_dir}/builds
             """)
+        }
+
+        def oscontainer_secret = "/run/kubernetes/secrets/oscontainer-registry/dockercfg";
+        if (utils.pathExists(oscontainer_secret)) {
+        stage('Sync oscontainer to quay.io') {
+            shwrap("""ociarchive=\$(cosa meta --image-path ostree)
+                    case \${ociarchive} in
+                      *ociarchive) skopeo copy --authfile=$oscontainer_secret oci-archive://\${ociarchive} docker://quay.io/cgwalters/fcos:${params.STREAM};;
+                      *) echo Build not configured as oci ;;
+                    esac""")
+        }
         }
 
         for (basearch in params.ARCHES.split()) {

--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -54,6 +54,9 @@ spec:
      - name: fedora-messaging-coreos-key
        mountPath: /run/kubernetes/secrets/fedora-messaging-coreos-key
        readOnly: true
+     - name: oscontainer-registry
+       mountPath: /run/kubernetes/secrets/oscontainer-registry
+       readOnly: true
      securityContext:
        privileged: false
      resources:
@@ -102,4 +105,8 @@ spec:
   - name: fedora-messaging-coreos-key
     secret:
       secretName: fedora-messaging-coreos-key
+      optional: true
+  - name: oscontainer-registry
+    secret:
+      secretName: oscontainer-registry
       optional: true


### PR DESCRIPTION
This is a bit hacky but should work.  My initial goal here
is just automated uploads of our builds, so that we can
start getting a better feel for managing "ostree-in-container"
releases.

We should sync to `quay.io/coreos` but that needs someone to set that up.

Also, I'd like to make the destination configurable in the same
way as the S3 bucket, proposal PR in https://github.com/coreos/fedora-coreos-config/pull/1175

Closes: https://github.com/coreos/fedora-coreos-pipeline/issues/359