### PR TITLE
multi-arch-pipeline: drive exact config git commit for arch pipeline runs

### DIFF
--- a/jobs/multi-arch-pipeline.Jenkinsfile
+++ b/jobs/multi-arch-pipeline.Jenkinsfile
@@ -302,8 +302,8 @@ stages:
     - cosa buildextend-aws
     - cosa buildextend-openstack
   post_commands:
-    - ls -d tmp/kola{,-basic,-metal,-metal4k} 2>/dev/null | xargs tar --xz -cf tmp/kola.tar.xz
     - cosa compress --compressor xz
+    - tar --xz -cf tmp/kola{-basic,,-metal,-metal4k} || true
   post_always: true
 delay_meta_merge: false
 EOF

--- a/jobs/multi-arch-pipeline.Jenkinsfile
+++ b/jobs/multi-arch-pipeline.Jenkinsfile
@@ -82,6 +82,10 @@ properties([
              description: 'The target architecture',
              defaultValue: 'aarch64',
              trim: true),
+      string(name: 'CONFIG_GIT_COMMIT',
+             description: 'The exact config repo git commit to build against',
+             defaultValue: '',
+             trim: true),
     ]),
     buildDiscarder(logRotator(
         numToKeepStr: '60',
@@ -177,8 +181,12 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
                 ref = src_config_ref
             }
 
+            def commitopt = ''
+            if (params.CONFIG_GIT_COMMIT != '') {
+                commitopt = "--commit=${params.CONFIG_GIT_COMMIT}"
+            }
             shwrap("""
-            cosa init --force --branch ${ref} ${src_config_url}
+            cosa init --force --branch ${ref} ${commitopt} ${src_config_url}
             """)
 
         }
@@ -235,6 +243,7 @@ job:
 recipe:
   git_ref: ${params.STREAM}
   git_url: https://github.com/${repo}
+  git_commit: ${params.CONFIG_GIT_COMMIT}
 stages:
 - id: ExecOrder 1 Stage
   execution_order: 1
@@ -283,6 +292,7 @@ job:
 recipe:
   git_ref: ${params.STREAM}
   git_url: https://github.com/${repo}
+  git_commit: ${params.CONFIG_GIT_COMMIT}
 stages:
 - id: ExecOrder 1 Stage
   execution_order: 1


### PR DESCRIPTION
multi-arch pipeline runs execute some time after the x86_64 pipeline
runs. Let's make sure they run from the same config git version to
mitigate any drift that could have happened.

This is mostly useful for the devel branches that change often. It's
less likely to affect the prod branches that don't really change much
(especially over time course of a release).

It also isn't really that useful for our mechanical refs that don't have
full lockfile definitions as a change on the yum repo side would still
creep in. Either way it's at least useful for a development refs/branches.
