### PR TITLE
multi-arch-pipeline: fix tar call to create kola.tar.xz

### DIFF
--- a/jobs/multi-arch-pipeline.Jenkinsfile
+++ b/jobs/multi-arch-pipeline.Jenkinsfile
@@ -313,7 +313,7 @@ stages:
     - cosa buildextend-openstack
   post_commands:
     - cosa compress --compressor xz
-    - tar --xz -cf tmp/kola{-basic,,-metal,-metal4k} || true
+    - tar --xz -cf tmp/kola.tar.xz tmp/kola{-basic,,-metal,-metal4k} || true
   post_always: true
 delay_meta_merge: false
 EOF


### PR DESCRIPTION
Messed this up in the last refactor.