### PR TITLE
multi-arch-pipeline: final enablement bits for aarch64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -375,19 +375,15 @@ lock(resource: "build-${params.STREAM}") {
             }
         }
 
-        // Don't run the multi-arch-pipeline for prod streams just
-        // yet. We're still working out all the details.
-        if (!official || !(params.STREAM in streams.production)) {
-            stage('Fork AARCH64 Pipeline') {
-                build job: 'multi-arch-pipeline', wait: false, parameters: [
-                    booleanParam(name: 'FORCE', value: params.FORCE),
-                    booleanParam(name: 'MINIMAL', value: params.MINIMAL),
-                    string(name: 'CONFIG_GIT_COMMIT', value: config_git_commit),
-                    string(name: 'STREAM', value: params.STREAM),
-                    string(name: 'VERSION', value: newBuildID),
-                    string(name: 'ARCH', value: 'aarch64')
-                ]
-            }
+        stage('Fork AARCH64 Pipeline') {
+            build job: 'multi-arch-pipeline', wait: false, parameters: [
+                booleanParam(name: 'FORCE', value: params.FORCE),
+                booleanParam(name: 'MINIMAL', value: params.MINIMAL),
+                string(name: 'CONFIG_GIT_COMMIT', value: config_git_commit),
+                string(name: 'STREAM', value: params.STREAM),
+                string(name: 'VERSION', value: newBuildID),
+                string(name: 'ARCH', value: 'aarch64')
+            ]
         }
 
         if (!params.MINIMAL) {

--- a/jobs/multi-arch-pipeline.Jenkinsfile
+++ b/jobs/multi-arch-pipeline.Jenkinsfile
@@ -309,8 +309,9 @@ stages:
     - cosa buildextend-live
     - kola testiso -S --output-dir tmp/kola-metal
     - kola testiso -SP --qemu-native-4k --scenarios iso-install --output-dir tmp/kola-metal4k
-    - cosa buildextend-aws
     - cosa buildextend-openstack
+    - echo 'ZGlmZiAtLWdpdCBhL3Vzci9saWIvY29yZW9zLWFzc2VtYmxlci9nZi1wbGF0Zm9ybWlkIGIvdXNyL2xpYi9jb3Jlb3MtYXNzZW1ibGVyL2dmLXBsYXRmb3JtaWQKaW5kZXggMjkxMmIzMjJjLi4zNmQwODk2NTEgMTAwNzU1Ci0tLSBhL3Vzci9saWIvY29yZW9zLWFzc2VtYmxlci9nZi1wbGF0Zm9ybWlkCisrKyBiL3Vzci9saWIvY29yZW9zLWFzc2VtYmxlci9nZi1wbGF0Zm9ybWlkCkBAIC00Niw3ICs0NiwxMSBAQCBibHNjZmdfcGF0aD0kKGNvcmVvc19nZiBnbG9iLWV4cGFuZCAvYm9vdC9sb2FkZXIvZW50cmllcy9vc3RyZWUtKi5jb25mKQogY29yZW9zX2dmIGRvd25sb2FkICIke2Jsc2NmZ19wYXRofSIgIiR7dG1wZH0iL2Jscy5jb25mCiAjIFJlbW92ZSBhbnkgcGxhdGZvcm1pZCBjdXJyZW50bHkgdGhlcmUKIHNlZCAtaSAtZSAncywgaWduaXRpb24ucGxhdGZvcm0uaWQ9W2EtekEtWjAtOV0qLCxnJyAiJHt0bXBkfSIvYmxzLmNvbmYKLXNlZCAtaSAtZSAncyxeXChvcHRpb25zIC4qXCksXDEgaWduaXRpb24ucGxhdGZvcm0uaWQ9JyIke3BsYXRmb3JtaWR9IicsJyAiJHt0bXBkfSIvYmxzLmNvbmYKK2lmIFsgIiR7cGxhdGZvcm1pZH0iID09ICdhd3MnIF07IHRoZW4KKyAgICBzZWQgLWkgLWUgJ3N8Xlwob3B0aW9ucyAuKlwpfFwxIGlnbml0aW9uLnBsYXRmb3JtLmlkPSciJHtwbGF0Zm9ybWlkfSInIGNvbnNvbGU9dHR5UzAsMTE1MjAwbjh8JyAiJHt0bXBkfSIvYmxzLmNvbmYKK2Vsc2UKKyAgICBzZWQgLWkgLWUgJ3MsXlwob3B0aW9ucyAuKlwpLFwxIGlnbml0aW9uLnBsYXRmb3JtLmlkPSciJHtwbGF0Zm9ybWlkfSInLCcgIiR7dG1wZH0iL2Jscy5jb25mCitmaQogY29yZW9zX2dmIHVwbG9hZCAiJHt0bXBkfSIvYmxzLmNvbmYgIiR7YmxzY2ZnX3BhdGh9IgogCiBpZiBbICIkYmFzZWFyY2giID0gInMzOTB4IiBdIDsgdGhlbiAK' | base64 --decode | sudo patch /usr/lib/coreos-assembler/gf-platformid
+    - cosa buildextend-aws
   post_commands:
     - cosa compress --compressor xz
     - tar --xz -cf tmp/kola.tar.xz tmp/kola{-basic,,-metal,-metal4k} || true

--- a/jobs/multi-arch-pipeline.Jenkinsfile
+++ b/jobs/multi-arch-pipeline.Jenkinsfile
@@ -334,8 +334,7 @@ EOF
         // Key off of s3_stream_dir: i.e. if we're configured to upload artifacts
         // to S3, we also take that to mean we should upload an AMI. We could
         // split this into two separate developer knobs in the future.
-        // XXX disable AWS upload for now until AMI boot issue is fixed
-        if (false && s3_stream_dir && !is_mechanical) {
+        if (s3_stream_dir && !is_mechanical) {
             stage('Upload AWS') {
                 def suffix = official ? "" : "--name-suffix ${developer_prefix}"
                 // pick up the AWS compressed vmdk and uncompress it
@@ -439,8 +438,7 @@ EOF
         }
 
         // Now that the metadata is uploaded go ahead and kick off some tests
-        // XXX disable AWS testing for now until AMI boot issue is fixed
-        if (false && !params.MINIMAL && s3_stream_dir &&
+        if (!params.MINIMAL && s3_stream_dir &&
                 utils.pathExists("\${AWS_FCOS_KOLA_BOT_CONFIG}") && !is_mechanical) {
             stage('Kola:AWS') {
                 // We consider the AWS kola tests to be a followup job, so we use `wait: false` here.


### PR DESCRIPTION
```
commit 3cdd1f846019e2883989a0557454aaa6fb207db9
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Sep 6 00:09:59 2021 -0400

    Revert "Jenkinsfile: limit multi-arch-pipeline to non production builds"
    
    This reverts commit 431f7e8ad33ed3e56d9f8c9fd740c9c0d79f9272.
    We want them for production builds now too.

commit 869a78cc49ca232a2dff160870d90aad0e5319f0
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sun Sep 5 16:28:20 2021 -0400

    multi-arch-pipeline: re-enable aws upload/testing
    
    Now that we've hacked in console=ttyS0 (see [1]) now we can
    start to upload/test there again.
    
    [1] https://github.com/coreos/fedora-coreos-tracker/issues/920

commit 2307ae760222e8c3d1cca369e1ded8beaf851f73
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sun Sep 5 16:23:20 2021 -0400

    multi-arch-pipeline: hack in ttyS0 for aarch64 aws image
    
    This is a workaround to get console=ttyS0,115200n8 into the
    aarch64 AWS image. It does so by applying the following patch
    to gf-platformid:
    
    ```diff
    diff --git a/usr/lib/coreos-assembler/gf-platformid b/usr/lib/coreos-assembler/gf-platformid
    index 2912b322c..36d089651 100755
    --- a/usr/lib/coreos-assembler/gf-platformid
    +++ b/usr/lib/coreos-assembler/gf-platformid
    @@ -46,7 +46,11 @@ blscfg_path=$(coreos_gf glob-expand /boot/loader/entries/ostree-*.conf)
     coreos_gf download "${blscfg_path}" "${tmpd}"/bls.conf
     # Remove any platformid currently there
     sed -i -e 's, ignition.platform.id=[a-zA-Z0-9]*,,g' "${tmpd}"/bls.conf
    -sed -i -e 's,^\(options .*\),\1 ignition.platform.id='"${platformid}"',' "${tmpd}"/bls.conf
    +if [ "${platformid}" == 'aws' ]; then
    +    sed -i -e 's|^\(options .*\)|\1 ignition.platform.id='"${platformid}"' console=ttyS0,115200n8|' "${tmpd}"/bls.conf
    +else
    +    sed -i -e 's,^\(options .*\),\1 ignition.platform.id='"${platformid}"',' "${tmpd}"/bls.conf
    +fi
     coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
    
     if [ "$basearch" = "s390x" ] ; then
    ```
    
    Once https://github.com/coreos/fedora-coreos-config/pull/1181 and
    https://github.com/coreos/coreos-assembler/pull/2400 land then we
    won't need this any longer.
    
    This implements a fix for https://github.com/coreos/fedora-coreos-tracker/issues/920

```
