### PR TITLE
streams: turn next-devel back on

### DIFF
--- a/streams.groovy
+++ b/streams.groovy
@@ -1,7 +1,7 @@
 // Canonical definition of all our streams and their type.
 
 production = ['testing', 'stable', 'next']
-development = ['testing-devel' /* 'next-devel' */]
+development = ['testing-devel', 'next-devel']
 mechanical = ['rawhide', 'branched' /* 'bodhi-updates', 'bodhi-updates-testing' */]
 
 all_streams = production + development + mechanical


### PR DESCRIPTION
It's now diverged from testing-devel since it's tracking f35.