### PR TITLE
bump-lockfile: force build if we get there

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -149,7 +149,7 @@ EOF
             }
 
             stage("Build") {
-                shwrap("cosa build --strict")
+                shwrap("cosa build --force --strict")
             }
 
             fcosKola(cosaDir: env.WORKSPACE)


### PR DESCRIPTION
If we end up pushing an update even if no package changed
(see 544a2cc) then we may need to force the cosa build so it doesn't
re-use the previous iteration. If it does that then it will fail
because the previous build had been compressed already:

```
harness.go:1124: Cluster failed starting machines:
    lstat /home/jenkins/agent/workspace/bump-lockfile/builds/35.20210909.10.0/x86_64/fedora-coreos-35.20210909.10.0-qemu.x86_64.qcow2.xz:
    no such file or directory
```