### PR TITLE
kola-{aws,gcp,openstack}: don't run basic qemu tests

### DIFF
--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -58,6 +58,7 @@ cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
     fcosKola(cosaDir: env.WORKSPACE, parallel: 5,
              build: params.VERSION, arch: params.ARCH,
              extraArgs: params.KOLA_TESTS,
+             skipBasicScenarios: true,
              platformArgs: """-p=aws \
                 --aws-credentials-file=\${AWS_FCOS_KOLA_BOT_CONFIG}/config \
                 --aws-region=us-east-1""")

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -62,6 +62,7 @@ cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
     fcosKola(cosaDir: env.WORKSPACE, parallel: 5,
              build: params.VERSION, arch: params.ARCH,
              extraArgs: params.KOLA_TESTS,
+             skipBasicScenarios: true,
              platformArgs: """-p=gce \
                 --gce-json-key=\${GCP_KOLA_TESTS_CONFIG}/config \
                 --gce-project=${gcp_project}""")

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -102,6 +102,7 @@ cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
         fcosKola(cosaDir: env.WORKSPACE, parallel: 5,
                  build: params.VERSION, skipUpgrade: true,
                  extraArgs: params.KOLA_TESTS,
+                 skipBasicScenarios: true,
                  platformArgs: """-p=openstack                               \
                     --openstack-config-file=\${OPENSTACK_KOLA_TESTS_CONFIG}/config \
                     --openstack-flavor=v1-standard-4                         \


### PR DESCRIPTION
The fcosKola library function was changed to default to running basic
qemu tests in [1]. Let's skip those in our cloud provider tests because
obviously we're not testing in qemu.

[1] https://github.com/coreos/coreos-ci-lib/commit/33a06a663519315877e54c9e123627b03ff50826
