### PR TITLE
plugins: bump github to 1.33.1

### DIFF
--- a/jenkins/controller/plugins.txt
+++ b/jenkins/controller/plugins.txt
@@ -8,3 +8,4 @@ basic-branch-build-strategies:1.3.2
 configuration-as-code-groovy:1.1
 timestamper:1.11.8
 build-token-root:1.7
+github:1.33.1


### PR DESCRIPTION
It contains a fix for #352. Once the base Jenkins imagestream is updated
in our cluster, we can drop this so we don't lock on 1.33.1.