### PR TITLE
plugins: bump workflow-api to 2.46

### DIFF
--- a/jenkins/controller/plugins.txt
+++ b/jenkins/controller/plugins.txt
@@ -9,3 +9,4 @@ configuration-as-code-groovy:1.1
 timestamper:1.11.8
 build-token-root:1.7
 github:1.33.1
+workflow-api:2.46


### PR DESCRIPTION
Otherwise, the current version (2.40) is too old for the timestamper
plugin to work with.