### PR TITLE
kola-openstack: switch to v3-starter-4 openstack flavor

### DIFF
--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -105,7 +105,7 @@ cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
                  skipBasicScenarios: true,
                  platformArgs: """-p=openstack                               \
                     --openstack-config-file=\${OPENSTACK_KOLA_TESTS_CONFIG}/config \
-                    --openstack-flavor=v1-standard-4                         \
+                    --openstack-flavor=v3-starter-4                          \
                     --openstack-network=private                              \
                     --openstack-floating-ip-network=public                   \
                     --openstack-image=${openstack_image_name}""")


### PR DESCRIPTION
Despite extending the timeout to 10 minutes we're still hitting
timeouts waiting for nodes to come up in vexxhost. Reaching out
to the CEO he suggested trying the v3 instances (newer infra) to
see if that helped.

If this doesn't work we can use the equivalent of `--boot-from-volume`
to get EBS like instances (shouldn't take time to copy image to local
compute nodes).