### PR TITLE
Use PERFORMANCE_OPTIMIZED for all jobs

### DIFF
--- a/Jenkinsfile.development
+++ b/Jenkinsfile.development
@@ -5,7 +5,8 @@ node {
 }
 
 properties([
-    pipelineTriggers(streams.get_push_trigger())
+    pipelineTriggers(streams.get_push_trigger()),
+    durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 
 node {

--- a/Jenkinsfile.mechanical
+++ b/Jenkinsfile.mechanical
@@ -8,7 +8,8 @@ properties([
     pipelineTriggers([
         // run every 24h only for now
         cron("H H * * *")
-    ])
+    ]),
+    durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 
 node {

--- a/Jenkinsfile.production
+++ b/Jenkinsfile.production
@@ -6,7 +6,8 @@ node {
 
 properties([
     // no triggers; we'll drive production releases manually in the short-term
-    pipelineTriggers([])
+    pipelineTriggers([]),
+    durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 
 node {

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -39,7 +39,8 @@ properties([
              description: 'Override coreos-assembler image to use',
              defaultValue: "coreos-assembler:main",
              trim: true)
-    ])
+    ]),
+    durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 
 // no way to make a parameter required directly so manually check

--- a/jenkins/config/seed.yaml
+++ b/jenkins/config/seed.yaml
@@ -19,7 +19,8 @@ jobs:
                   booleanParam(name: 'FORCE',
                                defaultValue: false,
                                description: 'Whether to redefine existing jobs (make sure to rerun all jobs with triggers to re-activate them)'),
-                ])
+                ]),
+                durabilityHint('PERFORMANCE_OPTIMIZED')
               ])
 
               node {

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -20,7 +20,8 @@ properties([
         choice(name: 'STREAM',
                choices: streams.development,
                description: 'Fedora CoreOS development stream to bump'),
-    ])
+    ]),
+    durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 
 echo "Waiting for bump-${params.STREAM} lock"

--- a/jobs/bump-lockfiles.Jenkinsfile
+++ b/jobs/bump-lockfiles.Jenkinsfile
@@ -4,7 +4,8 @@ properties([
     pipelineTriggers([
         // we don't need to bump lockfiles any more often than daily
         cron("H H * * *")
-    ])
+    ]),
+    durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 
 node {

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -33,7 +33,8 @@ properties([
              description: 'Override the coreos-assembler image to use',
              defaultValue: "coreos-assembler:main",
              trim: true)
-    ])
+    ]),
+    durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 
 currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSION}"

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -33,7 +33,8 @@ properties([
              description: 'Override the coreos-assembler image to use',
              defaultValue: "coreos-assembler:main",
              trim: true)
-    ])
+    ]),
+    durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 
 currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSION}"

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -31,7 +31,8 @@ properties([
              description: 'Override the coreos-assembler image to use',
              defaultValue: "coreos-assembler:main",
              trim: true)
-    ])
+    ]),
+    durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 
 currentBuild.description = "[${params.STREAM}] - ${params.VERSION}"

--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -11,7 +11,8 @@ properties([
         githubPush(),
         // also run every 15 mins as a fallback in case webhooks are down
         pollSCM('H/15 * * * *')
-    ])
+    ]),
+    durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 
 cosaPod(configMaps: ["fedora-messaging-cfg"], secrets: ["fedora-messaging-coreos-key"]) {


### PR DESCRIPTION
Otherwise, the default is to have Jenkins retain the state of jobs so
that it can resume them in the event of a loss of power/restart. But we
don't really need that feature because our jobs are designed to be
idempotent and e.g. we need to be able to handle restarting from
scratch.

So disable it so we can win the performance gains.

Prompted by recently-added (#365) code which breaks the job because
Jenkins isn't capable of serializing all the state to disk.