### PR TITLE
manifest/jenkins: bump HEARTBEAT_CHECK_INTERVAL to 15 mins

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -86,7 +86,7 @@ objects:
           # https://github.com/coreos/coreos-ci/issues/28
           - name: JENKINS_JAVA_OVERRIDES
             value: >-
-              -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=600
+              -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=900
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true
           image: ' '
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
We've been seeing the dreaded "process apparently never started" error
more frequently lately, which is likely due to the cluster being under
heavier load.

Let's bump the check interval to 15 minutes to be even more tolerant.