### PR TITLE
kola-{aws,gcp,openstack}: use a specific config git commit for tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -569,7 +569,8 @@ lock(resource: "build-${params.STREAM}") {
                 build job: 'kola-aws', wait: false, parameters: [
                     string(name: 'STREAM', value: params.STREAM),
                     string(name: 'VERSION', value: newBuildID),
-                    string(name: 'S3_STREAM_DIR', value: s3_stream_dir)
+                    string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
+                    string(name: 'CONFIG_GIT_COMMIT', value: config_git_commit)
                 ]
             }
         }
@@ -580,7 +581,8 @@ lock(resource: "build-${params.STREAM}") {
                 build job: 'kola-gcp', wait: false, parameters: [
                     string(name: 'STREAM', value: params.STREAM),
                     string(name: 'VERSION', value: newBuildID),
-                    string(name: 'S3_STREAM_DIR', value: s3_stream_dir)
+                    string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
+                    string(name: 'CONFIG_GIT_COMMIT', value: config_git_commit)
                 ]
             }
         }
@@ -591,7 +593,8 @@ lock(resource: "build-${params.STREAM}") {
                 build job: 'kola-openstack', wait: false, parameters: [
                     string(name: 'STREAM', value: params.STREAM),
                     string(name: 'VERSION', value: newBuildID),
-                    string(name: 'S3_STREAM_DIR', value: s3_stream_dir)
+                    string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
+                    string(name: 'CONFIG_GIT_COMMIT', value: config_git_commit)
                 ]
             }
         }

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -32,7 +32,11 @@ properties([
       string(name: 'COREOS_ASSEMBLER_IMAGE',
              description: 'Override the coreos-assembler image to use',
              defaultValue: "coreos-assembler:main",
-             trim: true)
+             trim: true),
+      string(name: 'CONFIG_GIT_COMMIT',
+             description: 'The exact config repo git commit to run tests against',
+             defaultValue: '',
+             trim: true),
     ]),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
@@ -50,9 +54,13 @@ try { timeout(time: 90, unit: 'MINUTES') {
             secrets: ["aws-fcos-builds-bot-config", "aws-fcos-kola-bot-config"]) {
 
         stage('Fetch Metadata') {
+            def commitopt = ''
+            if (params.CONFIG_GIT_COMMIT != '') {
+                commitopt = "--commit=${params.CONFIG_GIT_COMMIT}"
+            }
             shwrap("""
             export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}/config
-            cosa init --branch ${params.STREAM} https://github.com/coreos/fedora-coreos-config
+            cosa init --branch ${params.STREAM} ${commitopt} https://github.com/coreos/fedora-coreos-config
             cosa buildprep --ostree --build=${params.VERSION} --arch=${params.ARCH} s3://${s3_stream_dir}/builds
             """)
         }

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -32,7 +32,11 @@ properties([
       string(name: 'COREOS_ASSEMBLER_IMAGE',
              description: 'Override the coreos-assembler image to use',
              defaultValue: "coreos-assembler:main",
-             trim: true)
+             trim: true),
+      string(name: 'CONFIG_GIT_COMMIT',
+             description: 'The exact config repo git commit to run tests against',
+             defaultValue: '',
+             trim: true),
     ]),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
@@ -51,9 +55,13 @@ try { timeout(time: 30, unit: 'MINUTES') {
 
         def gcp_project
         stage('Fetch Metadata') {
+            def commitopt = ''
+            if (params.CONFIG_GIT_COMMIT != '') {
+                commitopt = "--commit=${params.CONFIG_GIT_COMMIT}"
+            }
             shwrap("""
             export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}/config
-            cosa init --branch ${params.STREAM} https://github.com/coreos/fedora-coreos-config
+            cosa init --branch ${params.STREAM} ${commitopt} https://github.com/coreos/fedora-coreos-config
             cosa buildprep --ostree --build=${params.VERSION} --arch=${params.ARCH} s3://${s3_stream_dir}/builds
             """)
 

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -34,7 +34,11 @@ properties([
       string(name: 'COREOS_ASSEMBLER_IMAGE',
              description: 'Override the coreos-assembler image to use',
              defaultValue: "coreos-assembler:main",
-             trim: true)
+             trim: true),
+      string(name: 'CONFIG_GIT_COMMIT',
+             description: 'The exact config repo git commit to run tests against',
+             defaultValue: '',
+             trim: true),
     ]),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
@@ -53,9 +57,13 @@ try { timeout(time: 60, unit: 'MINUTES') {
 
         def openstack_image_filename, openstack_image_name, openstack_image_sha256, openstack_image_filepath
         stage('Fetch Metadata/Image') {
+            def commitopt = ''
+            if (params.CONFIG_GIT_COMMIT != '') {
+                commitopt = "--commit=${params.CONFIG_GIT_COMMIT}"
+            }
             shwrap("""
             export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}/config
-            cosa init --branch ${params.STREAM} https://github.com/coreos/fedora-coreos-config
+            cosa init --branch ${params.STREAM} ${commitopt} https://github.com/coreos/fedora-coreos-config
             cosa buildprep --build=${params.VERSION} --arch=${params.ARCH} s3://${s3_stream_dir}/builds
             """)
 

--- a/jobs/multi-arch-pipeline.Jenkinsfile
+++ b/jobs/multi-arch-pipeline.Jenkinsfile
@@ -448,8 +448,8 @@ EOF
                     string(name: 'STREAM', value: params.STREAM),
                     string(name: 'VERSION', value: newBuildID),
                     string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-                    string(name: 'ARCH', value: basearch)
-
+                    string(name: 'ARCH', value: basearch),
+                    string(name: 'CONFIG_GIT_COMMIT', value: params.CONFIG_GIT_COMMIT)
                 ]
             }
         }


### PR DESCRIPTION
This will allow us to only run tests that were for the specific config
repo version that we built against. This prevents issues like what we saw
recently where tests got kicked off later and the config repo had merged
a new change that had a test. The test failed because the test was ran
but the corresponding needed change was not in the built FCOS version.