### PR TITLE
plugins: fast-track ssh-credentials v1.19

### DIFF
--- a/jenkins/controller/plugins.txt
+++ b/jenkins/controller/plugins.txt
@@ -10,3 +10,4 @@ timestamper:1.11.8
 build-token-root:1.7
 github:1.33.1
 workflow-api:2.46
+ssh-credentials:1.19


### PR DESCRIPTION
We're currently at v1.18.1. And while the changelogs don't mention
anything to that effect, let's fast-track the latest and see if it helps
https://github.com/jenkinsci/configuration-as-code-plugin/issues/1646.