### PR TITLE
kola-openstack: bump timeout to 90 minutes

### DIFF
--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -50,7 +50,7 @@ if (s3_stream_dir == "") {
     s3_stream_dir = "fcos-builds/prod/streams/${params.STREAM}"
 }
 
-try { timeout(time: 60, unit: 'MINUTES') {
+try { timeout(time: 90, unit: 'MINUTES') {
     cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
             memory: "256Mi", kvm: false,
             secrets: ["aws-fcos-builds-bot-config", "openstack-kola-tests-config"]) {


### PR DESCRIPTION
The switch to the new region is causing the upload and
image creation to take a lot longer.