### PR TITLE
Revert "kola-openstack: switch to sjc1 region"

### DIFF
--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -106,7 +106,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
         
         // In VexxHost we'll use the network called "private" for the
         // instance NIC, attach a floating IP from the "public" network and
-        // use the v2-highcpu-4 instance (ram=4GiB, CPUs=4).
+        // use the v3-starter-4 instance (ram=8GiB, CPUs=4).
         // The clouds.yaml config should be located at ${OPENSTACK_KOLA_TESTS_CONFIG}/config.
         //
         // Since we don't have permanent images uploaded to VexxHost we'll
@@ -119,8 +119,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
                      skipUpgrade: true,
                      platformArgs: """-p=openstack                               \
                         --openstack-config-file=\${OPENSTACK_KOLA_TESTS_CONFIG}/config \
-                        --openstack-flavor=v2-highcpu-4                          \
-                        --openstack-region=sjc1                                  \
+                        --openstack-flavor=v3-starter-4                          \
                         --openstack-network=private                              \
                         --openstack-floating-ip-network=public                   \
                         --openstack-image=${openstack_image_name}""")


### PR DESCRIPTION
The networking issues in the region have now been fixed. According
to the rep: " there was an issue in our internal BGP E-VPN control plane
that was causing this issue, this has been resolved and it's now
working".

Let's switch back to ca-ymq-1 since the infra is a little faster and
instances were less likely to time out there.

This reverts commit c4bdf1f42f70d9ac2bbd5a1ce2825c9d9581b854.