### PR TITLE
multi-arch-pipeline: tell gangplank to copy the parent build metadata

### DIFF
--- a/jobs/multi-arch-pipeline.Jenkinsfile
+++ b/jobs/multi-arch-pipeline.Jenkinsfile
@@ -244,6 +244,7 @@ recipe:
   git_ref: ${params.STREAM}
   git_url: https://github.com/${repo}
   git_commit: ${params.FCOS_CONFIG_COMMIT}
+copy-build: ${parent_version}
 stages:
 - id: ExecOrder 1 Stage
   execution_order: 1


### PR DESCRIPTION
This works around corner cases like described in:
https://github.com/coreos/coreos-assembler/issues/2380