### PR TITLE
plugins: add pipeline-github

### DIFF
--- a/jenkins/controller/plugins.txt
+++ b/jenkins/controller/plugins.txt
@@ -11,3 +11,4 @@ build-token-root:1.7
 github:1.33.1
 workflow-api:2.46
 ssh-credentials:1.19
+pipeline-github:2.8-138.d766e30bb08b


### PR DESCRIPTION
This plugin will make it easier to interact with GitHub. E.g. adding
comments, adding additional CI contexts, etc...

Planning to use this for
https://github.com/coreos/fedora-coreos-tracker/issues/990 but we could
also use this for enhancing other things, e.g. adding a comment with the
RPM diff, or having a separate CI context if a downgrade is detected to
make it easier to tell, etc...