### PR TITLE
aarch64 builder updates

### DIFF
--- a/multi-arch-builders/fcos-aarch64-builder.bu
+++ b/multi-arch-builders/fcos-aarch64-builder.bu
@@ -83,12 +83,11 @@ storage:
         inline: |
           [Unit]
           Description=Build COSA container
-          After=network-online.target
-          Wants=network-online.target
           [Service]
           # Give time for the build to complete
           TimeoutStartSec=180m
           Type=oneshot
+          ExecStartPre=nm-online --timeout=30
           ExecStartPre=mkdir -p /home/builder/coreos-assembler/
           ExecStartPre=-git clone --depth=1 https://github.com/coreos/coreos-assembler.git /home/builder/coreos-assembler/
           ExecStartPre=git -C /home/builder/coreos-assembler/ pull

--- a/multi-arch-builders/fcos-aarch64-builder.bu
+++ b/multi-arch-builders/fcos-aarch64-builder.bu
@@ -94,10 +94,7 @@ storage:
           ExecStartPre=-podman pull registry.fedoraproject.org/fedora:34
           ExecStartPre=podman build -t localhost/cosa-buildroot:latest -f ci/Dockerfile /home/builder/coreos-assembler/
           ExecStart=podman build -t localhost/coreos-assembler:latest --from localhost/cosa-buildroot:latest /home/builder/coreos-assembler/
-          # Can't use image prune yet because it prunes intermediate images
-          # (for caching) and we want to take advantage of caching.
-          # https://github.com/containers/podman/issues/10832
-          #ExecStartPost=-podman image prune --force
+          ExecStartPost=-podman image prune --force
     - path: /home/builder/.config/systemd/user/build-cosa-firstboot.service
       mode: 0644
       user:

--- a/multi-arch-builders/fcos-aarch64-builder.bu
+++ b/multi-arch-builders/fcos-aarch64-builder.bu
@@ -4,6 +4,7 @@
 # - Allow the builder user to log in with the associated ssh key
 #   which is shared with the pipeline. Used a ed25519 key so we
 #   don't have to worry about https://github.com/golang/go/issues/37278
+# - disable kernel mitigations (not a shared instance)
 # - Set up the podman socket for the builder user (podman remote)
 # - Build coreos-assembler on the first boot and once a day
 # - Configure zincati to allow updates at a specific time (early Monday)
@@ -13,7 +14,7 @@
 # - Configure zram
 #
 variant: fcos
-version: 1.3.0
+version: 1.4.0
 passwd:
   users:
     - name: core
@@ -23,6 +24,11 @@ passwd:
     - name: builder
       ssh_authorized_keys:
         - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILJJquUOL/NRZEIRrMLW0T8H/zmBQA4XMZxoI0ElwvGp builder@fcos-aarch64-builder
+kernel_arguments:
+  should_exist:
+    - mitigations=off
+  should_not_exist:
+    - mitigations=auto,nosmt
 storage:
   directories:
     - path: /home/builder/.config


### PR DESCRIPTION
```
commit e86e75db05391fc9a201012445e17b602ff833aa
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Oct 18 22:15:06 2021 -0400

    multi-arch-builders: we can call podman image prune again
    
    https://github.com/containers/podman/issues/10832 is fixed.

commit a4f54a43fe994b39c2a7452eb2409812f11c21d2
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Oct 18 22:12:21 2021 -0400

    multi-arch-builders: call nm-online directly to wait for network bringup
    
    Wants/After=network-online.target doesn't work in a user unit. See
    https://github.com/systemd/systemd/issues/3312#issuecomment-922096361

commit c17a22771823f30aa710a68077e02c8081edebca
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Oct 18 22:11:27 2021 -0400

    multi-arch-builders: disable kernel mitigations for aarch64 builder
    
    This isn't a shared instance so we might as well use all the horsepower.
```
