### PR TITLE
kola-aws: also run on m4.large

### DIFF
--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -73,6 +73,23 @@ try { timeout(time: 90, unit: 'MINUTES') {
                     --aws-credentials-file=\${AWS_FCOS_KOLA_BOT_CONFIG}/config \
                     --aws-region=us-east-1""")
 
+        if (params.ARCH == "x86_64") {
+            stage('Xen') {
+                def tests = params.KOLA_TESTS
+                if (tests == "") {
+                    tests = "basic"
+                }
+                fcosKola(cosaDir: env.WORKSPACE,
+                         build: params.VERSION, arch: params.ARCH,
+                         extraArgs: tests,
+                         skipUpgrade: true,
+                         skipBasicScenarios: true,
+                         platformArgs: """-p=aws \
+                            --aws-credentials-file=\${AWS_FCOS_KOLA_BOT_CONFIG}/config \
+                            --aws-region=us-east-1 --aws-type=m4.large""")
+            }
+        }
+
         currentBuild.result = 'SUCCESS'
     }
 }} catch (e) {


### PR DESCRIPTION
Likely this should live in a `fcosKolaAws` wrapper instead, but at least
for the short-term it's trivial to get coverage for Xen and Nitro types
so let's do that.

This would've caught
https://github.com/coreos/fedora-coreos-tracker/issues/997.

Closes: #414