### PR TITLE
jobs: add `LEAK_ON_FAIL` parameter to kola jobs

### DIFF
--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -1,9 +1,10 @@
 @Library('github.com/coreos/coreos-ci-lib@main') _
 
-def streams
+def streams, pipeutils
 node {
     checkout scm
     streams = load("streams.groovy")
+    pipeutils = load("utils.groovy")
 }
 
 properties([
@@ -37,11 +38,19 @@ properties([
              description: 'The exact config repo git commit to run tests against',
              defaultValue: '',
              trim: true),
+      string(name: 'LEAK_ON_FAIL',
+             description: 'Enable KOLA_LEAK_ON_FAIL to debug failures. You likely want to use this with `KOLA_TESTS`. Use "default" for CoreOS Debug key (available in OpenShift secret).',
+             defaultValue: '',
+             trim: true),
     ]),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 
 currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSION}"
+
+if (params.LEAK_ON_FAIL == 'default') {
+    params.LEAK_ON_FAIL = pipeutils.coreosDebugKey
+}
 
 def s3_stream_dir = params.S3_STREAM_DIR
 if (s3_stream_dir == "") {
@@ -69,6 +78,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
         fcosKola(cosaDir: env.WORKSPACE, parallel: 5,
                  build: params.VERSION, arch: params.ARCH,
                  extraArgs: params.KOLA_TESTS,
+                 leakOnFail: params.LEAK_ON_FAIL,
                  skipBasicScenarios: true,
                  platformArgs: """-p=aws \
                     --aws-credentials-file=\${AWS_FCOS_KOLA_BOT_CONFIG}/config \
@@ -83,6 +93,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
                 fcosKola(cosaDir: env.WORKSPACE,
                          build: params.VERSION, arch: params.ARCH,
                          extraArgs: tests,
+                         leakOnFail: params.LEAK_ON_FAIL,
                          skipUpgrade: true,
                          skipBasicScenarios: true,
                          platformArgs: """-p=aws \

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -1,9 +1,10 @@
 @Library('github.com/coreos/coreos-ci-lib@main') _
 
-def streams
+def streams, pipeutils
 node {
     checkout scm
     streams = load("streams.groovy")
+    pipeutils = load("utils.groovy")
 }
 
 properties([
@@ -39,11 +40,19 @@ properties([
              description: 'The exact config repo git commit to run tests against',
              defaultValue: '',
              trim: true),
+      string(name: 'LEAK_ON_FAIL',
+             description: 'Enable KOLA_LEAK_ON_FAIL to debug failures. You likely want to use this with `KOLA_TESTS`. Use "default" for CoreOS Debug key (available in OpenShift secret).',
+             defaultValue: '',
+             trim: true),
     ]),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 
 currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSION}"
+
+if (params.LEAK_ON_FAIL == 'default') {
+    params.LEAK_ON_FAIL = pipeutils.coreosDebugKey
+}
 
 def s3_stream_dir = params.S3_STREAM_DIR
 if (s3_stream_dir == "") {
@@ -109,6 +118,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
             fcosKola(cosaDir: env.WORKSPACE, parallel: 5,
                      build: params.VERSION, arch: params.ARCH,
                      extraArgs: params.KOLA_TESTS,
+                     leakOnFail: params.LEAK_ON_FAIL,
                      skipBasicScenarios: true,
                      skipUpgrade: true,
                      platformArgs: """-p=openstack                               \

--- a/utils.groovy
+++ b/utils.groovy
@@ -4,6 +4,7 @@ import org.yaml.snakeyaml.Yaml
 
 // Only add pipeline-specific things here. Otherwise add to coreos-ci-lib
 // instead.
+coreosDebugKey = 'ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAzvwSRhIh7x1lUerIbPeJQB1TsQLSHcBxk6V9ihQRzSgBMn8XR78KglW3hdt7OgNMYDt8el6hZVsg1DTdovpvU= core-debug@default'
 
 def get_annotation(anno) {
     // This works off the assumption that either there's only one


### PR DESCRIPTION
That way, we can run jobs targeting failing tests which we can then
manually debug into when it does fail. Likely we'll want a
"multiply"-like argument with this too for flaky tests.

For more information, see
https://github.com/coreos/coreos-assembler/pull/2511