### PR TITLE
multi-arch-builders: drop building buildroot image

### DIFF
--- a/multi-arch-builders/README.md
+++ b/multi-arch-builders/README.md
@@ -20,8 +20,6 @@ DISK='100'
 SUBNET='subnet-0732e4cda7466a2ae'
 SECURITY_GROUPS='sg-7d0b4c05'
 USERDATA="${PWD}/fcos-aarch64-builder.ign"
-EIP='18.233.54.49'
-EIPID='eipalloc-4305254a'
 aws ec2 run-instances                     \
     --output json                         \
     --image-id $AMI                       \
@@ -32,12 +30,52 @@ aws ec2 run-instances                     \
     --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=${NAME}}]" \
     --block-device-mappings "VirtualName=/dev/xvda,DeviceName=/dev/xvda,Ebs={VolumeSize=${DISK}}" \
     > out.json
+```
 
+Wait for the instance to come up (`a1.metal` instances can take 5-10 minutes to
+come up) and log in:
+
+```bash
+INSTANCE=$(jq --raw-output .Instances[0].InstanceId out.json)
+IP=$(aws ec2 describe-instances --instance-ids $INSTANCE --output json \
+     | jq -r '.Reservations[0].Instances[0].PublicIpAddress')
+ssh "core@${IP}"
+```
+
+Make sure the instance came up fine and wait for the COSA image build
+to complete:
+
+```bash
+systemctl --failed
+sudo machinectl builder@
+journalctl --user -f # to watch image build
+podman images # to view built image
+```
+
+Now that the instance is up and COSA is built we can re-assign the
+floating IP address. This removes the IP from the existing instance
+(if there is one) so you'll want to make sure no jobs are currently
+running on the existing instance by checking to make sure Jenkins is
+idle (i.e. no multi-arch aarch64 jobs are running).
+
+```bash
 # Grab the instance ID and associate the IP address
 INSTANCE=$(jq --raw-output .Instances[0].InstanceId out.json)
+EIP='18.233.54.49'
+EIPID='eipalloc-4305254a'
 aws ec2 associate-address --instance-id $INSTANCE --allow-reassociation --allocation-id $EIPID
+```
+
+Now you should be able to `ssh "core@${EIP}"`.
+
+NOTE: Just this once ignore the ssh host key changed warning if you see it.
 
 
-# ssh into the instance
-# NOTE: Just this once ignore the ssh host key changed warning if you see it.
-ssh core@18.233.54.49
+Once a build in Jenkins goes through the new builder we can tear down
+the old builder (if there is one). You can do it via the web interface
+or via CLI like so:
+
+```
+OLDINSTANCEID=<foo> # use `aws ec2 describe-instances` to find
+aws ec2 terminate-instances --instance-ids $OLDINSTANCEID
+```

--- a/multi-arch-builders/fcos-aarch64-builder.bu
+++ b/multi-arch-builders/fcos-aarch64-builder.bu
@@ -92,8 +92,7 @@ storage:
           ExecStartPre=-git clone --depth=1 https://github.com/coreos/coreos-assembler.git /home/builder/coreos-assembler/
           ExecStartPre=git -C /home/builder/coreos-assembler/ pull
           ExecStartPre=-podman pull registry.fedoraproject.org/fedora:34
-          ExecStartPre=podman build -t localhost/cosa-buildroot:latest -f ci/Dockerfile /home/builder/coreos-assembler/
-          ExecStart=podman build -t localhost/coreos-assembler:latest --from localhost/cosa-buildroot:latest /home/builder/coreos-assembler/
+          ExecStart=podman build -t localhost/coreos-assembler:latest /home/builder/coreos-assembler/
           ExecStartPost=-podman image prune --force
     - path: /home/builder/.config/systemd/user/build-cosa-firstboot.service
       mode: 0644

--- a/multi-arch-builders/fcos-aarch64-builder.bu
+++ b/multi-arch-builders/fcos-aarch64-builder.bu
@@ -91,8 +91,7 @@ storage:
           ExecStartPre=mkdir -p /home/builder/coreos-assembler/
           ExecStartPre=-git clone --depth=1 https://github.com/coreos/coreos-assembler.git /home/builder/coreos-assembler/
           ExecStartPre=git -C /home/builder/coreos-assembler/ pull
-          ExecStartPre=-podman pull registry.fedoraproject.org/fedora:34
-          ExecStart=podman build -t localhost/coreos-assembler:latest /home/builder/coreos-assembler/
+          ExecStart=podman build --pull-always -t localhost/coreos-assembler:latest /home/builder/coreos-assembler/
           ExecStartPost=-podman image prune --force
     - path: /home/builder/.config/systemd/user/build-cosa-firstboot.service
       mode: 0644


### PR DESCRIPTION
```
commit 26e8238fb3ac27607cb270c39224b88a05924899
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Nov 10 10:43:36 2021 -0500

    multi-arch-builders: use pull-always in container build
    
    This way we don't need the preceding line in the systemd service that
    consistently needs to be updated when the Fedora version changes.

commit 169db2da922b034f9a6a077e442c10e59758a54e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Nov 10 10:34:14 2021 -0500

    multi-arch-builders: drop building buildroot image
    
    It was dropped from COSA in:
    https://github.com/coreos/coreos-assembler/pull/2550
```
