### PR TITLE
streams: disable next-devel stream

### DIFF
--- a/streams.groovy
+++ b/streams.groovy
@@ -1,7 +1,7 @@
 // Canonical definition of all our streams and their type.
 
 production = ['testing', 'stable', 'next']
-development = ['testing-devel', 'next-devel']
+development = ['testing-devel' /* 'next-devel' */]
 mechanical = ['rawhide' /* 'branched', 'bodhi-updates', 'bodhi-updates-testing' */]
 
 all_streams = production + development + mechanical


### PR DESCRIPTION
Now that `testing-devel` is moved over to Fedora 35 there is no
difference in `testing-devel` and `next-devel`. Disable the
`next-devel` pipeline so we can avoid doing useless work.