### PR TITLE
multi-arch-pipeline: fix COREOS_ASSEMBLER_IMAGE image passing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -380,6 +380,7 @@ lock(resource: "build-${params.STREAM}") {
                 booleanParam(name: 'FORCE', value: params.FORCE),
                 booleanParam(name: 'MINIMAL', value: params.MINIMAL),
                 string(name: 'FCOS_CONFIG_COMMIT', value: fcos_config_commit),
+                string(name: 'COREOS_ASSEMBLER_IMAGE', params.COREOS_ASSEMBLER_IMAGE),
                 string(name: 'STREAM', value: params.STREAM),
                 string(name: 'VERSION', value: newBuildID),
                 string(name: 'ARCH', value: 'aarch64')

--- a/jobs/multi-arch-pipeline.Jenkinsfile
+++ b/jobs/multi-arch-pipeline.Jenkinsfile
@@ -157,10 +157,13 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
         // This assumes that the desired tagged image has been built
         // on the multi-arch builder already, which most likely means
         // someone did it manually.
-        def image = params.COREOS_ASSEMBLER_IMAGE.replaceAll(
+        def image = "localhost/coreos-assembler:latest"
+        if (params.COREOS_ASSEMBLER_IMAGE.startsWith("quay.io/coreos-assembler/coreos-assembler:")) {
+            image = params.COREOS_ASSEMBLER_IMAGE.replaceAll(
                 "quay.io/coreos-assembler/coreos-assembler:",
                 "localhost/coreos-assembler:"
-        )
+            )
+        }
 
         try { timeout(time: 240, unit: 'MINUTES') {
 


### PR DESCRIPTION
This commit has two changes:

- Pass the COREOS_ASSEMBLER_IMAGE parameter from the main pipeline
  when forking off the multi-arch pipeline.
- Default to "localhost/coreos-assembler:latest" in the multi-arch
  pipeline when a full quay.io COSA image isn't given. i.e. we don't
  want `coreos-assembler:main` to fall through to the multi-arch
  builder.