### PR TITLE
plugins: configuration-as-code and pipeline-utility-steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,3 @@
-@Library('github.com/coreos/coreos-ci-lib@main') _
-
 import org.yaml.snakeyaml.Yaml;
 
 def pipeutils, streams, official, official_jenkins, developer_prefix

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -1,5 +1,3 @@
-@Library('github.com/coreos/coreos-ci-lib@main') _
-
 def pipeutils, streams, s3_bucket
 node {
     checkout scm

--- a/jenkins/config/coreos-ci-lib.yaml
+++ b/jenkins/config/coreos-ci-lib.yaml
@@ -1,0 +1,11 @@
+unclassified:
+  globalLibraries:
+    libraries:
+      - name: "coreos-ci-lib"
+        defaultVersion: main
+        implicit: true
+        retriever:
+          modernSCM:
+            scm:
+              git:
+                remote: "https://github.com/coreos/coreos-ci-lib.git"

--- a/jenkins/config/seed.yaml
+++ b/jenkins/config/seed.yaml
@@ -12,8 +12,6 @@ jobs:
           cps {
             sandbox(true)
             script('''
-              @Library('github.com/coreos/coreos-ci-lib@main') _
-
               properties([
                 parameters([
                   booleanParam(name: 'FORCE',

--- a/jenkins/controller/plugins.txt
+++ b/jenkins/controller/plugins.txt
@@ -1,5 +1,5 @@
 github-oauth:0.33
-configuration-as-code:1.49
+configuration-as-code:1.54
 slack:2.34
 job-dsl:1.76
 matrix-auth:2.4.2
@@ -12,3 +12,4 @@ github:1.33.1
 workflow-api:2.46
 ssh-credentials:1.19
 pipeline-github:2.8-138.d766e30bb08b
+pipeline-utility-steps:2.9.0

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -1,5 +1,3 @@
-@Library('github.com/coreos/coreos-ci-lib@main') _
-
 def streams, gp
 node {
     checkout scm

--- a/jobs/bump-lockfiles.Jenkinsfile
+++ b/jobs/bump-lockfiles.Jenkinsfile
@@ -1,5 +1,3 @@
-@Library('github.com/coreos/coreos-ci-lib@main') _
-
 properties([
     pipelineTriggers([
         // we don't need to bump lockfiles any more often than daily

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -1,5 +1,3 @@
-@Library('github.com/coreos/coreos-ci-lib@main') _
-
 def streams
 node {
     checkout scm

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -1,5 +1,3 @@
-@Library('github.com/coreos/coreos-ci-lib@main') _
-
 def streams
 node {
     checkout scm

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -1,5 +1,3 @@
-@Library('github.com/coreos/coreos-ci-lib@main') _
-
 def streams
 node {
     checkout scm

--- a/jobs/multi-arch-pipeline.Jenkinsfile
+++ b/jobs/multi-arch-pipeline.Jenkinsfile
@@ -1,5 +1,3 @@
-@Library('github.com/coreos/coreos-ci-lib@main') _
-
 import org.yaml.snakeyaml.Yaml;
 
 def pipeutils, streams, official, developer_prefix, repo, src_config_url, src_config_ref, s3_bucket, gp

--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -1,5 +1,3 @@
-@Library('github.com/coreos/coreos-ci-lib@main') _
-
 def streams
 node {
     checkout scm

--- a/utils.groovy
+++ b/utils.groovy
@@ -1,5 +1,3 @@
-@Library('github.com/coreos/coreos-ci-lib@main') _
-
 import org.yaml.snakeyaml.Yaml
 
 // Only add pipeline-specific things here. Otherwise add to coreos-ci-lib


### PR DESCRIPTION
Update configuration-as-code to 1.54 as it prevented the
Credentials Plugin as others from loading.

Adding pipeline-utility-steps 2.9.0 as is required for the current
Jenkins version to run the pipelines.

Add the coreos-ci-lib global library to the configmap.