### PR TITLE
manifest/pipeline: set cosa referencePolicy to `local`

### DIFF
--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -68,6 +68,8 @@ objects:
             name: ${COREOS_ASSEMBLER_IMAGE}
           importPolicy:
             scheduled: true
+          referencePolicy:
+            type: local
 
   ### PVC ###
 


### PR DESCRIPTION
That way we use the latest pulled cosa image in the internal registry,
which shouldn't be very out of date. This also avoids race conditions
during quay.io rebuilds.