### PR TITLE
kola-kubernetes: also disable upgrade testing

### DIFF
--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -65,6 +65,7 @@ try { timeout(time: 60, unit: 'MINUTES') {
         fcosKola(cosaDir: env.WORKSPACE,
                  build: params.VERSION, arch: params.ARCH,
                  extraArgs: "--tag k8s",
+                 skipUpgrade: true,
                  skipBasicScenarios: true,
                  platformArgs: """-p=aws \
                     --aws-credentials-file=\${AWS_FCOS_KOLA_BOT_CONFIG}/config \


### PR DESCRIPTION
We only want to run the k8s test in this job.