### PR TITLE
kola-openstack: use ca-ymq-1 region for everything

### DIFF
--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -46,12 +46,9 @@ lock(resource: "kola-openstack-${params.ARCH}") {
 
     currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSION}"
 
-    def region = "ams1"
-    if (params.ARCH == "x86_64") {
-        region = "ams1"
-    } else if (params.ARCH == "aarch64") {
-        region = "ca-ymq-1"
-    }
+    // Use ca-ymq-1 for everything right now since we're having trouble with
+    // image uploads to ams1.
+    def region = "ca-ymq-1"
 
     def s3_stream_dir = params.S3_STREAM_DIR
     if (s3_stream_dir == "") {


### PR DESCRIPTION
I've got an open ticket with VexxHost about our issues with uploading
images to ams1 and they've bumped our quota in ca-ymq-1 to unblock us
while we figure things out. Let's use ca-ymq-1 for everything for now.