### PR TITLE
Jenkinsfile: disable kola-kubernetes test for now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -572,15 +572,17 @@ lock(resource: "build-${params.STREAM}") {
                     string(name: 'FCOS_CONFIG_COMMIT', value: fcos_config_commit)
                 ]
             }
-            stage('Kola:Kubernetes') {
-                // We consider the Kubernetes kola tests to be a followup job, so we use `wait: false` here.
-                build job: 'kola-kubernetes', wait: false, parameters: [
-                    string(name: 'STREAM', value: params.STREAM),
-                    string(name: 'VERSION', value: newBuildID),
-                    string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-                    string(name: 'FCOS_CONFIG_COMMIT', value: fcos_config_commit)
-                ]
-            }
+          // XXX: This is failing right now. Disable until the New
+          // Year when someone can dig into the problem.
+          //stage('Kola:Kubernetes') {
+          //    // We consider the Kubernetes kola tests to be a followup job, so we use `wait: false` here.
+          //    build job: 'kola-kubernetes', wait: false, parameters: [
+          //        string(name: 'STREAM', value: params.STREAM),
+          //        string(name: 'VERSION', value: newBuildID),
+          //        string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
+          //        string(name: 'FCOS_CONFIG_COMMIT', value: fcos_config_commit)
+          //    ]
+          //}
         }
         if (!params.MINIMAL && s3_stream_dir &&
                 utils.pathExists("\${GCP_KOLA_TESTS_CONFIG}") && !is_mechanical) {


### PR DESCRIPTION
This is failing and needs to be looked at but that won't happen
for a few weeks so let's disable it for now.