### PR TITLE
kola-aws: run m4.large and m6i.large tests in parallel

### DIFF
--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -84,6 +84,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
                          extraArgs: tests,
                          skipUpgrade: true,
                          skipBasicScenarios: true,
+                         marker: "kola-m4",
                          platformArgs: """-p=aws \
                             --aws-credentials-file=\${AWS_FCOS_KOLA_BOT_CONFIG}/config \
                             --aws-region=us-east-1 --aws-type=m4.large""")
@@ -94,6 +95,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
                          extraArgs: tests,
                          skipUpgrade: true,
                          skipBasicScenarios: true,
+                         marker: "kola-m6i",
                          platformArgs: """-p=aws \
                             --aws-credentials-file=\${AWS_FCOS_KOLA_BOT_CONFIG}/config \
                             --aws-region=us-east-1 --aws-type=m6i.large""")

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -77,7 +77,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
             if (tests == "") {
                 tests = "basic"
             }
-            stage('Xen') {
+            parallel Xen: {
                 // https://github.com/coreos/fedora-coreos-tracker/issues/997
                 fcosKola(cosaDir: env.WORKSPACE,
                          build: params.VERSION, arch: params.ARCH,
@@ -87,8 +87,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
                          platformArgs: """-p=aws \
                             --aws-credentials-file=\${AWS_FCOS_KOLA_BOT_CONFIG}/config \
                             --aws-region=us-east-1 --aws-type=m4.large""")
-            }
-            stage('m6i') {
+            }, m6i: {
                 // https://github.com/coreos/fedora-coreos-tracker/issues/1004
                 fcosKola(cosaDir: env.WORKSPACE,
                          build: params.VERSION, arch: params.ARCH,


### PR DESCRIPTION
Now that https://github.com/coreos/coreos-ci-lib/issues/95 is fixed
we can run these in parallel.