### PR TITLE
streams: re-enable next-devel

### DIFF
--- a/next-devel/badge.json
+++ b/next-devel/badge.json
@@ -2,6 +2,6 @@
     "schemaVersion": 1,
     "style": "for-the-badge",
     "label": "next-devel",
-    "message": "closed",
-    "color": "lightgrey"
+    "message": "open",
+    "color": "green"
 }

--- a/next-devel/status.json
+++ b/next-devel/status.json
@@ -1,3 +1,3 @@
 {
-    "enabled": false
+    "enabled": true
 }

--- a/streams.groovy
+++ b/streams.groovy
@@ -2,7 +2,7 @@
 
 // Contains 'next-devel' when that stream is enabled.
 // Automatically edited by next-devel/manage.py.
-next_devel = []
+next_devel = ['next-devel']
 
 production = ['testing', 'stable', 'next']
 development = ['testing-devel'] + next_devel


### PR DESCRIPTION
We want to ship microdnf there only, and we'd also like to roll out the
iptables-nft migration there first.

See: https://github.com/coreos/fedora-coreos-tracker/issues/676
See: https://github.com/coreos/fedora-coreos-tracker/issues/1050