### PR TITLE
jenkins/config: fix oscontainer-secret formatting

### DIFF
--- a/jenkins/config/oscontainer-secret.yaml
+++ b/jenkins/config/oscontainer-secret.yaml
@@ -7,6 +7,6 @@ credentials:
             fileName: oscontainer-secret
             id: oscontainer-secret
             # See: https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables
-            secretBytes: "${base64:${readFile:${oscontainer-secret/dockerconfig}}}"
+            secretBytes: "${base64:${readFile:${oscontainer-secret/dockercfg}}}"
             description: Push secret for quay.io/coreos-assembler/fcos
 

--- a/jenkins/config/oscontainer-secret.yaml
+++ b/jenkins/config/oscontainer-secret.yaml
@@ -6,8 +6,7 @@ credentials:
             scope: GLOBAL
             fileName: oscontainer-secret
             id: oscontainer-secret
-            # Secret must be base64-encoded
-            # See: https://github.com/jenkinsci/configuration-as-code-plugin/issues/884
-            secretBytes: "${base64:${oscontainer-secret/dockerconfig}}"
+            # See: https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables
+            secretBytes: "${base64:${readFile:${oscontainer-secret/dockerconfig}}}"
             description: Push secret for quay.io/coreos-assembler/fcos
 


### PR DESCRIPTION
We want to base64-encode the contents of a file, not the path of the
file itself.