### PR TITLE
Revert "jenkins/config: fix oscontainer-secret formatting"

### DIFF
--- a/jenkins/config/oscontainer-secret.yaml
+++ b/jenkins/config/oscontainer-secret.yaml
@@ -6,7 +6,9 @@ credentials:
             scope: GLOBAL
             fileName: oscontainer-secret
             id: oscontainer-secret
+            # Secret must be base64-encoded. `${oscontainer-secret/dockercfg}`
+            # expands to the *contents* of that file, not its path.
             # See: https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables
-            secretBytes: "${base64:${readFile:${oscontainer-secret/dockercfg}}}"
+            secretBytes: "${base64:${oscontainer-secret/dockercfg}}"
             description: Push secret for quay.io/coreos-assembler/fcos
 


### PR DESCRIPTION
This reverts commit db97d5674fd82fda76826355a1be9b0a351c2173.

Lessons learned:
- `${oscontainer-secret/dockercfg}` expands to the *contents* of the
  path at `/run/secrets/oscontainer-secret/dockercfg`
- therefore, `${readFile:${oscontainer-secret/dockercfg}}` will ask
  jcasc to read the file at `$CONTENTS`, which is of course not what we
  want.

So the only issue was actually the path typo, which was fixed in #461.
As such, this is not a perfect revert. I also kept the updated
documentation link and added some details to the comment.