### PR TITLE
Jenkinsfile.release: pass --build to cosa meta

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -93,9 +93,11 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
         }
 
         stage('Sync oscontainer to quay.io') {
+            def image_path = shwrapCapture("cosa meta --build=${params.VERSION} --image-path ostree")
             withCredentials([file(credentialsId: 'oscontainer-secret', variable: 'OSCONTAINER_SECRET')]) {
-                withEnv(["DEST_IMAGE=docker://${quay_registry}:${params.STREAM}"]) {
-                    sh('skopeo copy --authfile=${OSCONTAINER_SECRET} oci-archive://$(cosa meta --image-path ostree) ${DEST_IMAGE}')
+                withEnv(["SRC_IMAGE=${image_path}",
+                         "DEST_IMAGE=docker://${quay_registry}:${params.STREAM}"]) {
+                    sh('skopeo copy --authfile=${OSCONTAINER_SECRET} oci-archive://${SRC_IMAGE} ${DEST_IMAGE}')
                 }
             }
         }


### PR DESCRIPTION
We hit this issue where one pipeline run kicked off immediately after
another one had finished. So we had something like:

- next-devel-x86_64#1
- next-devel-aarch64#1
- next-devel-x86_64-release#1
- next-devel-x86_64#2
- next-devel-aarch64-release#1

At the point that the release job runs for `#1` after the aarch64
pipeline is done the builds.json has already been updated with build
ID from the `#2` run. In this case `cosa meta` will look at the meta.json
from the wrong build.

To work around this we need to just be explicit and pass the build
ID directly to `cosa meta`.