### PR TITLE
jobs: Add buildDiscarder property to the build pipelines

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -19,6 +19,10 @@ properties([
                choices: streams.development,
                description: 'Fedora CoreOS development stream to bump'),
     ]),
+    buildDiscarder(logRotator(
+        numToKeepStr: '100',
+        artifactNumToKeepStr: '100'
+    )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 

--- a/jobs/bump-lockfiles.Jenkinsfile
+++ b/jobs/bump-lockfiles.Jenkinsfile
@@ -3,6 +3,10 @@ properties([
         // we don't need to bump lockfiles any more often than daily
         cron("H H * * *")
     ]),
+    buildDiscarder(logRotator(
+        numToKeepStr: '100',
+        artifactNumToKeepStr: '100'
+    )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -36,6 +36,10 @@ properties([
              defaultValue: '',
              trim: true),
     ]),
+    buildDiscarder(logRotator(
+        numToKeepStr: '100',
+        artifactNumToKeepStr: '100'
+    )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -36,6 +36,10 @@ properties([
              defaultValue: '',
              trim: true),
     ]),
+    buildDiscarder(logRotator(
+        numToKeepStr: '100',
+        artifactNumToKeepStr: '100'
+    )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -32,6 +32,10 @@ properties([
              defaultValue: '',
              trim: true),
     ]),
+    buildDiscarder(logRotator(
+        numToKeepStr: '100',
+        artifactNumToKeepStr: '100'
+    )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -36,6 +36,10 @@ properties([
              defaultValue: '',
              trim: true),
     ]),
+    buildDiscarder(logRotator(
+        numToKeepStr: '100',
+        artifactNumToKeepStr: '100'
+    )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 

--- a/jobs/multi-arch-pipeline.Jenkinsfile
+++ b/jobs/multi-arch-pipeline.Jenkinsfile
@@ -87,8 +87,8 @@ properties([
              trim: true),
     ]),
     buildDiscarder(logRotator(
-        numToKeepStr: '60',
-        artifactNumToKeepStr: '20'
+        numToKeepStr: '100',
+        artifactNumToKeepStr: '100'
     )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])

--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -10,6 +10,10 @@ properties([
         // also run every 15 mins as a fallback in case webhooks are down
         pollSCM('H/15 * * * *')
     ]),
+    buildDiscarder(logRotator(
+        numToKeepStr: '100',
+        artifactNumToKeepStr: '100'
+    )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 


### PR DESCRIPTION
Adds the buildDiscarder property to the the jobs to prevent the builds to store unlimited logs and artifacts.