### PR TITLE
manifests/jenkins-s2i: drop deploy-default references and migrate more annotations to configmap

### DIFF
--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -40,12 +40,6 @@ objects:
     apiVersion: v1
     metadata:
       name: jenkins
-      annotations:
-        # These annotations will allow Jenkins to know from where to seed its
-        # jobs once it comes up. Note that it can be from a different git repo
-        # than where the S2I repo is defined.
-        coreos.com/jenkins-jobs-url: ${JENKINS_JOBS_URL}
-        coreos.com/jenkins-jobs-ref: ${JENKINS_JOBS_REF}
     # Note no triggers: we don't want e.g. git pushes/config changes to restart
     # Jenkins. Let's just require manual restarts here. XXX: Should investigate
     # if there's an easy way to auto-redeploy during downtimes.

--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -36,14 +36,11 @@ objects:
     kind: ImageStream
     metadata:
       name: jenkins
-      annotations:
-        coreos.com/deploy-default: "true"
   - kind: BuildConfig
     apiVersion: v1
     metadata:
       name: jenkins
       annotations:
-        coreos.com/deploy-default: "true"
         # These annotations will allow Jenkins to know from where to seed its
         # jobs once it comes up. Note that it can be from a different git repo
         # than where the S2I repo is defined.
@@ -82,8 +79,6 @@ objects:
     kind: ImageStream
     metadata:
       name: jenkins-slave-base-centos7
-      annotations:
-        coreos.com/deploy-default: "true"
     spec:
       lookupPolicy:
         # this allows e.g. the pipeline to directly reference the imagestream

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -78,3 +78,5 @@ objects:
       developer-prefix: ${DEVELOPER_PREFIX}
       s3-bucket: ${S3_BUCKET}
       gcp-gs-bucket: ${GCP_GS_BUCKET}
+      jenkins-jobs-url: ${JENKINS_JOBS_URL}
+      jenkins-jobs-ref: ${JENKINS_JOBS_REF}


### PR DESCRIPTION
See individual commits.