### PR TITLE
jobs/release: set SUCCESS if we didn't fail

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -220,6 +220,7 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
                 }
             }
         }
+        currentBuild.result = 'SUCCESS'
     } catch (e) {
         currentBuild.result = 'FAILURE'
         throw e


### PR DESCRIPTION
This will make it so we won't send a slack message if we succeeded.