### PR TITLE
jobs/release: make AWS_REPLICATION a bool

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -27,12 +27,9 @@ properties([
       // where we are running the job by hand is when we're doing a
       // production release and we want to replicate there. Defaulting
       // to true means there is less opportunity for human error.
-      //
-      // use a string here because passing booleans via `oc start-build -e`
-      // is non-trivial
-      choice(name: 'AWS_REPLICATION',
-             choices: (['true', 'false']),
-             description: 'Force AWS AMI replication'),
+      booleanParam(name: 'AWS_REPLICATION',
+                   defaultValue: true,
+                   description: 'Force AWS AMI replication'),
       string(name: 'COREOS_ASSEMBLER_IMAGE',
              description: 'Override coreos-assembler image to use',
              defaultValue: "coreos-assembler:main",


### PR DESCRIPTION
The jobs which trigger this job were changed to pass in a boolean, but
the parameter on this job itself was still a string choice. Adapt.

Fixes 4058b24 ("Jenkinsfile.release: move to regular job `release`").