### PR TITLE
streams: re-enable `branched` stream

### DIFF
--- a/streams.groovy
+++ b/streams.groovy
@@ -6,7 +6,7 @@ next_devel = ['next-devel']
 
 production = ['testing', 'stable', 'next']
 development = ['testing-devel'] + next_devel
-mechanical = ['rawhide' /* 'branched', 'bodhi-updates', 'bodhi-updates-testing' */]
+mechanical = ['rawhide', 'branched' /* 'bodhi-updates', 'bodhi-updates-testing' */]
 
 all_streams = production + development + mechanical
 


### PR DESCRIPTION
Fedora 36 has branched now, so let's track it.