### PR TITLE
manifests/jenkins-s2i: drop unused template parameters

### DIFF
--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -21,12 +21,6 @@ parameters:
   - description: Git branch/tag reference for Jenkins S2I
     name: JENKINS_S2I_REF
     value: main
-  - description: Git source URI for Jenkins jobs
-    name: JENKINS_JOBS_URL
-    value: https://github.com/coreos/fedora-coreos-pipeline
-  - description: Git branch/tag reference for Jenkins jobs
-    name: JENKINS_JOBS_REF
-    value: main
 
 objects:
 


### PR DESCRIPTION
Fixes c72b00ce021a ("manifests/jenkins-s2i: migrate more annotations to
configmap").