### PR TITLE
bump-lockfile: rebase before pushing to git repo

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -206,7 +206,8 @@ EOF
         withCredentials([usernamePassword(credentialsId: botCreds,
                                           usernameVariable: 'GHUSER',
                                           passwordVariable: 'GHTOKEN')]) {
-          // should gracefully handle race conditions here
+          // Sometimes other commits have come in; rebase if needed and then push.
+          sh("git -C src/config pull --rebase")
           sh("git -C src/config push https://\${GHUSER}:\${GHTOKEN}@github.com/${repo} ${branch}")
         }
     }


### PR DESCRIPTION
We often hit an issue where a new upstream commit has landed and
the git push will fail. It could be the case that the new upstream
commit causes an issue and it would be more correct for bump-lockfile
to just fail (as it currently does), but I think practically it's not
often that the new commits coming in would conflict with the changes
tested as part of the bump-lockfile run. Even if it did, the next
`testing-devel` pipeline run would catch it. Let's just rebase and
push.