### PR TITLE
Move from Quay.io to app.ci

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -161,6 +161,12 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
                 "localhost/coreos-assembler:"
             )
         }
+        if (params.COREOS_ASSEMBLER_IMAGE.startsWith("registry.ci.openshift.org/coreos/coreos-assembler:")) {
+            image = params.COREOS_ASSEMBLER_IMAGE.replaceAll(
+                "registry.ci.openshift.org/coreos/coreos-assembler:",
+                "localhost/coreos-assembler:"
+            )
+        }
 
         try { timeout(time: 240, unit: 'MINUTES') {
 

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -32,9 +32,9 @@ parameters:
     value: # empty -> based on stream
   - description: Image of coreos-assembler to use
     name: COREOS_ASSEMBLER_IMAGE
-    # for now we just follow :main, but we may start freezing if things become
+    # for now we just follow :latest, but we may start freezing if things become
     # too unstable
-    value: quay.io/coreos-assembler/coreos-assembler:main
+    value: registry.ci.openshift.org/coreos/coreos-assembler:latest
   - description: AWS S3 bucket in which to store builds (or blank for none)
     name: S3_BUCKET
     value: fcos-builds
@@ -47,7 +47,7 @@ objects:
   ### COREOS-ASSEMBLER ###
 
   # keep a local copy of coreos-assembler so we're not constantly pulling it
-  # each time from quay.io
+  # each time from app.ci
   - apiVersion: v1
     kind: ImageStream
     metadata:
@@ -57,7 +57,7 @@ objects:
         # this allows e.g. the pipeline to directly reference the imagestream
         local: true
       tags:
-        - name: main
+        - name: latest
           from:
             kind: DockerImage
             name: ${COREOS_ASSEMBLER_IMAGE}


### PR DESCRIPTION
The latter mirrors to the former, but it's a periodic that runs every
hour. So let's just use the images directly from app.ci for faster
iteration.

Related: https://github.com/coreos/coreos-ci-lib/pull/107