### PR TITLE
jobs/build: also early archive QEMU image

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -360,16 +360,16 @@ lock(resource: "build-${params.STREAM}") {
             return
         }
 
-        // Do an Early Archive of just the OSTree. This has the
-        // desired side effect of reserving our build ID before
-        // we fork off multi-arch builds.
+        // Do an early archive of just the OSTree and the QEMU image. This has
+        // the desired side effect of reserving our build ID before we fork off
+        // multi-arch builds.
         stage('Archive OSTree') {
             if (s3_stream_dir) {
               // run with --force here in case the previous run of the
               // pipeline died in between buildupload and bump_builds_json()
               shwrap("""
               export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
-              cosa buildupload --force --skip-builds-json --artifact=ostree \
+              cosa buildupload --force --skip-builds-json \
                   s3 --acl=public-read ${s3_stream_dir}/builds
               """)
               pipeutils.bump_builds_json(


### PR DESCRIPTION
It's already in `meta.json` so we can't *not* upload it. Otherwise if
there's a build failure before the full upload, it can cause issues.
E.g. a broken link in the build browser and throwing off upgrade tests.
We could remove it from the JSON but that seems unnecessary.