### PR TITLE
Revert "jobs/build: also early archive QEMU image"

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -360,16 +360,16 @@ lock(resource: "build-${params.STREAM}") {
             return
         }
 
-        // Do an early archive of just the OSTree and the QEMU image. This has
-        // the desired side effect of reserving our build ID before we fork off
-        // multi-arch builds.
+        // Do an Early Archive of just the OSTree. This has the
+        // desired side effect of reserving our build ID before
+        // we fork off multi-arch builds.
         stage('Archive OSTree') {
             if (s3_stream_dir) {
               // run with --force here in case the previous run of the
               // pipeline died in between buildupload and bump_builds_json()
               shwrap("""
               export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
-              cosa buildupload --force --skip-builds-json \
+              cosa buildupload --force --skip-builds-json --artifact=ostree \
                   s3 --acl=public-read ${s3_stream_dir}/builds
               """)
               pipeutils.bump_builds_json(


### PR DESCRIPTION
This reverts commit 29e179bcfc3f52a110d867d06c50446de3ff7a99.

This uploads the QEMU image uncompressed, which is not what we want.
See discussions in
https://github.com/coreos/fedora-coreos-pipeline/pull/484.