### PR TITLE
jobs: only run release job once per build

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -77,7 +77,7 @@ properties([
              trim: true),
       string(name: 'ARCH',
              description: 'The target architecture',
-             defaultValue: 'aarch64',
+             choices: streams.additional_arches,
              trim: true),
       string(name: 'FCOS_CONFIG_COMMIT',
              description: 'The exact config repo git commit to build against',

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -56,7 +56,7 @@ properties([
              choices: (streams.development + streams.production + streams.mechanical),
              description: 'Fedora CoreOS stream to build'),
       string(name: 'VERSION',
-             description: 'Override default versioning mechanism',
+             description: 'Build version',
              defaultValue: '',
              trim: true),
       booleanParam(name: 'FORCE',
@@ -139,6 +139,7 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
         """)
 
         // declare these early so we can use them in `finally` block
+        assert params.VERSION != ""
         def newBuildID = params.VERSION
         def basearch = params.ARCH
 

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -386,16 +386,18 @@ lock(resource: "build-${params.STREAM}") {
             }
         }
 
-        stage('Fork AARCH64 Pipeline') {
-            build job: 'build-arch', wait: false, parameters: [
-                booleanParam(name: 'FORCE', value: params.FORCE),
-                booleanParam(name: 'MINIMAL', value: params.MINIMAL),
-                string(name: 'FCOS_CONFIG_COMMIT', value: fcos_config_commit),
-                string(name: 'COREOS_ASSEMBLER_IMAGE', value: params.COREOS_ASSEMBLER_IMAGE),
-                string(name: 'STREAM', value: params.STREAM),
-                string(name: 'VERSION', value: newBuildID),
-                string(name: 'ARCH', value: 'aarch64')
-            ]
+        stage('Fork Multi-Arch Builds') {
+            for (arch in streams.additional_arches) {
+                build job: 'build-arch', wait: false, parameters: [
+                    booleanParam(name: 'FORCE', value: params.FORCE),
+                    booleanParam(name: 'MINIMAL', value: params.MINIMAL),
+                    string(name: 'FCOS_CONFIG_COMMIT', value: fcos_config_commit),
+                    string(name: 'COREOS_ASSEMBLER_IMAGE', value: params.COREOS_ASSEMBLER_IMAGE),
+                    string(name: 'STREAM', value: params.STREAM),
+                    string(name: 'VERSION', value: newBuildID),
+                    string(name: 'ARCH', value: arch)
+                ]
+            }
         }
 
         if (!params.MINIMAL) {

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -21,7 +21,7 @@ properties([
              trim: true),
       string(name: 'ARCHES',
              description: 'Space-separated list of target architectures',
-             defaultValue: 'x86_64 aarch64',
+             defaultValue: '',
              trim: true),
       // Default to true for AWS_REPLICATION because the only case
       // where we are running the job by hand is when we're doing a
@@ -94,7 +94,12 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
             """)
         }
 
-        def basearches = params.ARCHES.split()
+        def basearches = ""
+        if (params.ARCHES == '') {
+            basearches = shwrapCapture("jq -r '.builds | map(select(.id == \"${params.VERSION}\"))[].arches[]' builds/builds.json").split()
+        } else {
+            basearches = params.ARCHES.split()
+        }
 
         for (basearch in basearches) {
             def meta_json = "builds/${params.VERSION}/${basearch}/meta.json"

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -64,7 +64,9 @@ def quay_registry = "quay.io/coreos-assembler/fcos"
 // We just lock here out of an abundance of caution in case somehow two release
 // jobs run for the same stream, but that really shouldn't happen. Anyway, if it
 // *does*, this makes sure they're run serially.
-lock(resource: "release-${params.STREAM}") {
+// Also lock version-arch-specific locks to make sure these builds are finished.
+def locks = streams.additional_arches.each {[resource: "release-${params.VERSION}-${it}"]}
+lock(resource: "release-${params.STREAM}", extra: locks) {
 podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
     node(pod_label) { container('coreos-assembler') { try {
 

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -68,6 +68,11 @@ lock(resource: "release-${params.STREAM}") {
 podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
     node(pod_label) { container('coreos-assembler') { try {
 
+        // print out details of the cosa image to help debugging
+        shwrap("""
+        cat /cosa/coreos-assembler-git.json
+        """)
+
         def s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
         def gcp_image = ""
         def ostree_prod_refs = [:]

--- a/streams.groovy
+++ b/streams.groovy
@@ -8,6 +8,9 @@ production = ['testing', 'stable', 'next']
 development = ['testing-devel'] + next_devel
 mechanical = ['rawhide', 'branched' /* 'bodhi-updates', 'bodhi-updates-testing' */]
 
+// list of secondary architectures we support
+additional_arches = ['aarch64']
+
 all_streams = production + development + mechanical
 
 // Maps a list of streams to a list of GitSCM branches.


### PR DESCRIPTION
Before, we were running the release job multiple times per build: once
for each architecture. This was done by triggering it at the end of both
the x86_64 build and multi-arch builds.

However, it's possible that the x86_64 build fails while the multi-arch
build succeeds. In that case, we don't want to release just for e.g.
aarch64 if the x86_64 build is missing or broken.

Fix this by making only the x86_64 build trigger the release job. This
way, it'll only be triggered once and only if the x86_64 build
succeeded. Add locking in the release job and the multi-arch job to
ensure that the release job cannot execute until the multi-arch job has
completed, whether successfully or not.

This also allows us to hack around issues in the tools used by the
release job which don't fully support releasing for a single
architecture only. These are gaps that we should still fix regardless.