### PR TITLE
build: don't pass ARCHES parameter to release job

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -635,7 +635,6 @@ lock(resource: "build-${params.STREAM}") {
             stage('Publish') {
                 build job: 'release', wait: false, parameters: [
                     string(name: 'STREAM', value: params.STREAM),
-                    string(name: 'ARCHES', value: basearch),
                     string(name: 'VERSION', value: newBuildID),
                     booleanParam(name: 'AWS_REPLICATION', value: params.AWS_REPLICATION)
                 ]


### PR DESCRIPTION
It was changed recently so that if you don't pass in any ARCHES
it will release all built architectures. By passing in `x86_64`
here we're limiting it artificially.