### PR TITLE
build/release: allow passing arches from toplevel build job

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -59,6 +59,10 @@ properties([
              description: 'Override default versioning mechanism',
              defaultValue: '',
              trim: true),
+      string(name: 'ADDITIONAL_ARCHES',
+             description: 'Space-separated list of additional target architectures',
+             defaultValue: streams.additional_arches.join(" "),
+             trim: true),
       booleanParam(name: 'FORCE',
                    defaultValue: false,
                    description: 'Whether to force a rebuild'),
@@ -390,7 +394,7 @@ lock(resource: "build-${params.STREAM}") {
         }
 
         stage('Fork Multi-Arch Builds') {
-            for (arch in streams.additional_arches) {
+            for (arch in params.ADDITIONAL_ARCHES.split()) {
                 build job: 'build-arch', wait: false, parameters: [
                     booleanParam(name: 'FORCE', value: params.FORCE),
                     booleanParam(name: 'MINIMAL', value: params.MINIMAL),
@@ -638,6 +642,7 @@ lock(resource: "build-${params.STREAM}") {
             stage('Publish') {
                 build job: 'release', wait: false, parameters: [
                     string(name: 'STREAM', value: params.STREAM),
+                    string(name: 'ARCHES', value: basearch + " " + params.ADDITIONAL_ARCHES),
                     string(name: 'VERSION', value: newBuildID),
                     booleanParam(name: 'AWS_REPLICATION', value: params.AWS_REPLICATION)
                 ]

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -636,14 +636,14 @@ lock(resource: "build-${params.STREAM}") {
         //
         // Since we are only running this stage for non-production (i.e. mechanical
         // and development) builds we'll default to not doing AWS AMI replication.
-        // That can be overridden by the user setting the AWS_REPLICATION parameter
-        // to true, overriding the default (false).
+        // We'll also default to allowing failures for additonal architectures.
         if (official && !(params.STREAM in streams.production)) {
             stage('Publish') {
                 build job: 'release', wait: false, parameters: [
                     string(name: 'STREAM', value: params.STREAM),
                     string(name: 'ARCHES', value: basearch + " " + params.ADDITIONAL_ARCHES),
                     string(name: 'VERSION', value: newBuildID),
+                    booleanParam(name: 'ALLOW_MISSING_ARCHES', value: true),
                     booleanParam(name: 'AWS_REPLICATION', value: params.AWS_REPLICATION)
                 ]
             }


### PR DESCRIPTION
This will allow us to specify ADDITIONAL_ARCHES to the toplevel build
job and have it filter all the way through the cascading secondary jobs.
It also means that we're using a single source of truth (the parameter)
for each job rather than mixing the paramater and the additional_arches
definition from `streams.groovy`.