### PR TITLE
Add `notify-slack` knob to configmap

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -536,18 +536,17 @@ EOF
                 message = "${message} (${newBuildID})"
             }
 
-            try {
-                if (official) {
-                    slackSend(color: color, message: message)
-                    shwrap("""
-                    /var/tmp/fcos-releng/scripts/broadcast-fedmsg.py --fedmsg-conf=/etc/fedora-messaging-cfg/fedmsg.toml \
-                        build.state.change --build ${newBuildID} --basearch ${basearch} --stream ${params.STREAM} \
-                        --build-dir ${BUILDS_BASE_HTTP_URL}/${params.STREAM}/builds/${newBuildID}/${basearch} \
-                        --state FINISHED --result ${currentBuild.result}
-                    """)
-                }
-            } finally {
-                echo message
+            echo message
+            if (pipeutils.get_config('notify-slack') == "yes") {
+                slackSend(color: color, message: message)
+            }
+            if (official) {
+                shwrap("""
+                /var/tmp/fcos-releng/scripts/broadcast-fedmsg.py --fedmsg-conf=/etc/fedora-messaging-cfg/fedmsg.toml \
+                    build.state.change --build ${newBuildID} --basearch ${basearch} --stream ${params.STREAM} \
+                    --build-dir ${BUILDS_BASE_HTTP_URL}/${params.STREAM}/builds/${newBuildID}/${basearch} \
+                    --state FINISHED --result ${currentBuild.result}
+                """)
             }
         }
     }}

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -667,18 +667,17 @@ lock(resource: "build-${params.STREAM}") {
                 message = "${message} (${newBuildID})"
             }
 
-            try {
-                if (official) {
-                    slackSend(color: color, message: message)
-                    shwrap("""
-                    /var/tmp/fcos-releng/scripts/broadcast-fedmsg.py --fedmsg-conf=/etc/fedora-messaging-cfg/fedmsg.toml \
-                        build.state.change --build ${newBuildID} --basearch ${basearch} --stream ${params.STREAM} \
-                        --build-dir ${BUILDS_BASE_HTTP_URL}/${params.STREAM}/builds/${newBuildID}/${basearch} \
-                        --state FINISHED --result ${currentBuild.result}
-                    """)
-                }
-            } finally {
-                echo message
+            echo message
+            if (pipeutils.get_config('notify-slack') == "yes") {
+                slackSend(color: color, message: message)
+            }
+            if (official)
+                shwrap("""
+                /var/tmp/fcos-releng/scripts/broadcast-fedmsg.py --fedmsg-conf=/etc/fedora-messaging-cfg/fedmsg.toml \
+                    build.state.change --build ${newBuildID} --basearch ${basearch} --stream ${params.STREAM} \
+                    --build-dir ${BUILDS_BASE_HTTP_URL}/${params.STREAM}/builds/${newBuildID}/${basearch} \
+                    --state FINISHED --result ${currentBuild.result}
+                """)
             }
         }
     }}

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -1,6 +1,7 @@
-def streams, gp
+def pipeutils, streams, gp
 node {
     checkout scm
+    pipeutils = load("utils.groovy")
     streams = load("streams.groovy")
     gp = load("gp.groovy")
 }
@@ -235,7 +236,7 @@ EOF
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    if (currentBuild.result != 'SUCCESS') {
+    if (currentBuild.result != 'SUCCESS' && pipeutils.get_config('notify-slack') == "yes") {
         slackSend(color: 'danger', message: ":fcos: :trashfire: <${env.BUILD_URL}|bump-lockfile #${env.BUILD_NUMBER} (${params.STREAM})>")
     }
 }

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -1,6 +1,7 @@
-def streams
+def pipeutils, streams
 node {
     checkout scm
+    pipeutils = load("utils.groovy")
     streams = load("streams.groovy")
 }
 
@@ -112,7 +113,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    if (currentBuild.result != 'SUCCESS') {
+    if (currentBuild.result != 'SUCCESS' && pipeutils.get_config('notify-slack') == "yes") {
         slackSend(color: 'danger', message: ":fcos: :aws: :trashfire: kola-aws <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
     }
 }

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -1,7 +1,8 @@
-def streams
+def pipeutils, streams
 node {
     checkout scm
     streams = load("streams.groovy")
+    pipeutils = load("utils.groovy")
 }
 
 properties([
@@ -86,7 +87,7 @@ try { timeout(time: 30, unit: 'MINUTES') {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    if (currentBuild.result != 'SUCCESS') {
+    if (currentBuild.result != 'SUCCESS' && pipeutils.get_config('notify-slack') == "yes") {
         slackSend(color: 'danger', message: ":fcos: :gcp: :trashfire: kola-gcp <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
     }
 }

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -1,7 +1,8 @@
-def streams
+def pipeutils, streams
 node {
     checkout scm
     streams = load("streams.groovy")
+    pipeutils = load("utils.groovy")
 }
 
 properties([
@@ -81,7 +82,7 @@ try { timeout(time: 60, unit: 'MINUTES') {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    if (currentBuild.result != 'SUCCESS') {
+    if (currentBuild.result != 'SUCCESS' && pipeutils.get_config('notify-slack') == "yes") {
         slackSend(color: 'danger', message: ":fcos: :k8s: :trashfire: kola-kubernetes <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
     }
 }

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -1,7 +1,8 @@
-def streams
+def pipeutils, streams
 node {
     checkout scm
     streams = load("streams.groovy")
+    pipeutils = load("utils.groovy")
 }
 
 properties([
@@ -138,7 +139,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
         currentBuild.result = 'FAILURE'
         throw e
     } finally {
-        if (currentBuild.result != 'SUCCESS') {
+        if (currentBuild.result != 'SUCCESS' && pipeutils.get_config('notify-slack') == "yes") {
             slackSend(color: 'danger', message: ":fcos: :openstack: :trashfire: kola-openstack <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
         }
     }

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -235,7 +235,7 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
         currentBuild.result = 'FAILURE'
         throw e
     } finally {
-        if (currentBuild.result != 'SUCCESS') {
+        if (currentBuild.result != 'SUCCESS' && pipeutils.get_config('notify-slack') == "yes") {
             slackSend(color: 'danger', message: ":fcos: :bullettrain_front: :trashfire: release <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCHES}] (${params.VERSION})")
         }
     }}}

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -41,6 +41,9 @@ parameters:
   - description: GCP GS bucket to use for image uploads (or blank for none)
     name: GCP_GS_BUCKET
     value: fedora-coreos-cloud-image-uploads
+  - description: Whether Slack notifications are enabled
+    name: NOTIFY_SLACK
+    value: yes
 
 objects:
 
@@ -80,3 +83,4 @@ objects:
       gcp-gs-bucket: ${GCP_GS_BUCKET}
       jenkins-jobs-url: ${JENKINS_JOBS_URL}
       jenkins-jobs-ref: ${JENKINS_JOBS_REF}
+      notify-slack: ${NOTIFY_SLACK}


### PR DESCRIPTION
This makes it easier for developers to turn off Slack notifications. In
addition, it allows us to drop the try/catch blocks since we know it
should always succeed if attempted.