### PR TITLE
jobs: load pipeline configmap once upfront

### DIFF
--- a/jenkins/config/seed.yaml
+++ b/jenkins/config/seed.yaml
@@ -25,8 +25,9 @@ jobs:
                 // XXX: hack, should put this in coreos-ci-lib
                 sh("curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-pipeline/main/utils.groovy")
                 def pipeutils = load("utils.groovy")
-                def url = pipeutils.get_config("jenkins-jobs-url")
-                def ref = pipeutils.get_config("jenkins-jobs-ref")
+                def pipecfg = pipeutils.load_config()
+                def url = pipecfg["jenkins-jobs-url"]
+                def ref = pipecfg["jenkins-jobs-ref"]
                 shwrap("rm -rf source")
                 shwrap("git clone -b ^${ref} ^${url} source")
 

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -1,7 +1,7 @@
 import org.yaml.snakeyaml.Yaml;
 
-def pipeutils, streams, official, official_jenkins, developer_prefix
-def src_config_url, src_config_ref, s3_bucket, fcos_config_commit
+def pipeutils, streams, official, developer_prefix
+def src_config_url, src_config_ref, s3_bucket, gcp_gs_bucket, notify_slack
 node {
     checkout scm
     pipeutils = load("utils.groovy")
@@ -18,11 +18,13 @@ node {
         echo "Running in developer mode on ${env.JENKINS_URL}."
     }
 
-    developer_prefix = pipeutils.get_config('developer-prefix')
-    src_config_url = pipeutils.get_config('source-config-url')
-    src_config_ref = pipeutils.get_config('source-config-ref')
-    s3_bucket = pipeutils.get_config('s3-bucket')
-    gcp_gs_bucket = pipeutils.get_config('gcp-gs-bucket')
+    def pipecfg = pipeutils.load_config()
+    developer_prefix = pipecfg['developer-prefix']
+    src_config_url = pipecfg['source-config-url']
+    src_config_ref = pipecfg['source-config-ref']
+    s3_bucket = pipecfg['s3-bucket']
+    gcp_gs_bucket = pipecfg['gcp_gs_bucket']
+    notify_slack = pipecfg['notify-slack']
 
     // sanity check that a valid prefix is provided if in devel mode and drop
     // the trailing '-' in the devel prefix
@@ -170,11 +172,12 @@ lock(resource: "build-${params.STREAM}") {
         }
 
         def developer_builddir = "/srv/devel/${developer_prefix}/build"
+        def fcos_config_commit
 
         stage('Init') {
 
             def ref = params.STREAM
-            if (src_config_ref != "") {
+            if (src_config_ref != null) {
                 assert !official : "Asked to override ref in official mode"
                 ref = src_config_ref
             }
@@ -194,7 +197,7 @@ lock(resource: "build-${params.STREAM}") {
             """)
 
             // Capture the exact git commit used. Will pass to multi-arch pipeline runs.
-            fcos_config_commit=shwrapCapture("git -C src/config rev-parse HEAD")
+            fcos_config_commit = shwrapCapture("git -C src/config rev-parse HEAD")
 
             // If the cache img is larger than 7G, then nuke it. Otherwise
             // it'll just keep growing and we'll hit ENOSPC. It'll get rebuilt.
@@ -668,7 +671,7 @@ lock(resource: "build-${params.STREAM}") {
             }
 
             echo message
-            if (pipeutils.get_config('notify-slack') == "yes") {
+            if (notify_slack == "yes") {
                 slackSend(color: color, message: message)
             }
             if (official) {

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -1,9 +1,12 @@
 def pipeutils, streams, gp
+def notify_slack
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     streams = load("streams.groovy")
     gp = load("gp.groovy")
+    def pipecfg = pipeutils.load_config()
+    notify_slack = pipecfg['notify-slack']
 }
 
 repo = "coreos/fedora-coreos-config"
@@ -236,7 +239,7 @@ EOF
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    if (currentBuild.result != 'SUCCESS' && pipeutils.get_config('notify-slack') == "yes") {
+    if (currentBuild.result != 'SUCCESS' && notify_slack == "yes") {
         slackSend(color: 'danger', message: ":fcos: :trashfire: <${env.BUILD_URL}|bump-lockfile #${env.BUILD_NUMBER} (${params.STREAM})>")
     }
 }

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -1,8 +1,11 @@
 def pipeutils, streams
+def notify_slack
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     streams = load("streams.groovy")
+    def pipecfg = pipeutils.load_config()
+    notify_slack = pipecfg['notify-slack']
 }
 
 properties([
@@ -113,7 +116,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    if (currentBuild.result != 'SUCCESS' && pipeutils.get_config('notify-slack') == "yes") {
+    if (currentBuild.result != 'SUCCESS' && notify_slack == "yes") {
         slackSend(color: 'danger', message: ":fcos: :aws: :trashfire: kola-aws <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
     }
 }

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -1,8 +1,11 @@
 def pipeutils, streams
+def notify_slack
 node {
     checkout scm
-    streams = load("streams.groovy")
     pipeutils = load("utils.groovy")
+    streams = load("streams.groovy")
+    def pipecfg = pipeutils.load_config()
+    notify_slack = pipecfg['notify-slack']
 }
 
 properties([
@@ -87,7 +90,7 @@ try { timeout(time: 30, unit: 'MINUTES') {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    if (currentBuild.result != 'SUCCESS' && pipeutils.get_config('notify-slack') == "yes") {
+    if (currentBuild.result != 'SUCCESS' && notify_slack == "yes") {
         slackSend(color: 'danger', message: ":fcos: :gcp: :trashfire: kola-gcp <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
     }
 }

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -1,8 +1,11 @@
 def pipeutils, streams
+def notify_slack
 node {
     checkout scm
-    streams = load("streams.groovy")
     pipeutils = load("utils.groovy")
+    streams = load("streams.groovy")
+    def pipecfg = pipeutils.load_config()
+    notify_slack = pipecfg['notify-slack']
 }
 
 properties([
@@ -82,7 +85,7 @@ try { timeout(time: 60, unit: 'MINUTES') {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    if (currentBuild.result != 'SUCCESS' && pipeutils.get_config('notify-slack') == "yes") {
+    if (currentBuild.result != 'SUCCESS' && notify_slack == "yes") {
         slackSend(color: 'danger', message: ":fcos: :k8s: :trashfire: kola-kubernetes <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
     }
 }

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -1,8 +1,11 @@
 def pipeutils, streams
+def notify_slack
 node {
     checkout scm
-    streams = load("streams.groovy")
     pipeutils = load("utils.groovy")
+    streams = load("streams.groovy")
+    def pipecfg = pipeutils.load_config()
+    notify_slack = pipecfg['notify-slack']
 }
 
 properties([
@@ -139,7 +142,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
         currentBuild.result = 'FAILURE'
         throw e
     } finally {
-        if (currentBuild.result != 'SUCCESS' && pipeutils.get_config('notify-slack') == "yes") {
+        if (currentBuild.result != 'SUCCESS' && notify_slack == "yes") {
             slackSend(color: 'danger', message: ":fcos: :openstack: :trashfire: kola-openstack <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
         }
     }

--- a/utils.groovy
+++ b/utils.groovy
@@ -3,9 +3,9 @@ import org.yaml.snakeyaml.Yaml
 // Only add pipeline-specific things here. Otherwise add to coreos-ci-lib
 // instead.
 
-def get_config(key) {
-    return shwrapCapture("""
-        oc get configmap -n ${env.PROJECT_NAME} -o json pipeline-config | jq -r '.data["${key}"]'
+def load_config() {
+    return readJSON text: shwrapCapture("""
+        oc get configmap -n ${env.PROJECT_NAME} -o json pipeline-config | jq .data
     """)
 }
 


### PR DESCRIPTION
Rather than shelling out to `oc` multiple times to read configmap knobs,
just read the whole configmap once upfront and parse it into a variable.

This is not only more efficient but also avoids issues with the current
execution environment not necessarily having `oc` available.

I left `developer_prefix` alone for now since we're going to nuke it
anyway.