### PR TITLE
utils: fix load_config syntax error

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -4,9 +4,9 @@ import org.yaml.snakeyaml.Yaml
 // instead.
 
 def load_config() {
-    return readJSON text: shwrapCapture("""
+    return readJSON(text: shwrapCapture("""
         oc get configmap -n ${env.PROJECT_NAME} -o json pipeline-config | jq .data
-    """)
+    """))
 }
 
 // Parse and handle the result of Kola


### PR DESCRIPTION
I think in the return position like this, Jenkins wants us to be
explicit and add the usually implied parentheses.

Fixes 72406a1 ("jobs: load pipeline configmap once upfront").