### PR TITLE
jobs: fix comparison for `src_config_ref`

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -208,7 +208,7 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}", extra: [[resource: "rele
         stage('Init') {
 
             def ref = params.STREAM
-            if (src_config_ref != null) {
+            if (src_config_ref != "") {
                 assert !official : "Asked to override ref in official mode"
                 ref = src_config_ref
             }

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -181,7 +181,7 @@ lock(resource: "build-${params.STREAM}") {
         stage('Init') {
 
             def ref = params.STREAM
-            if (src_config_ref != null) {
+            if (src_config_ref != "") {
                 assert !official : "Asked to override ref in official mode"
                 ref = src_config_ref
             }


### PR DESCRIPTION
I erroneously thought in 72406a1 that we should change those comparisons
to `null` since `pipecfg['nonexistent']` returns `null`. But actually
the configmap template will always define the key anyway and the default
value is the empty string.