### PR TITLE
Drop logic for developer_prefix in pipelines

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -284,24 +284,12 @@ oc create configmap jenkins-casc-cfg --from-file=jenkins/config
 If working on the production pipeline, you may simply do:
 
 ```
-./deploy --official --update
-```
-
-If working in a different namespace/cluster, the command is the same,
-but without the `--official` switch:
-
-
-```
-./deploy --update
+./deploy --official
 ```
 
 You may also want to provide additional switches depending on the
 circumstances. Here are some of them:
 
-- `--prefix PREFIX`
-    - The prefix to prepend to created developer-specific resources. By
-      default, this will be your username, but you can provide a
-      specific prefix as well.
 - `--pipeline <URL>[@REF]`
     - Git source URL and optional git ref for pipeline Jenkinsfile.
 - `--config <URL>[@REF]`
@@ -315,7 +303,7 @@ For example, to target a specific combination of pipeline, FCOS config,
 cosa image, and bucket:
 
 ```
-./deploy --update \
+./deploy \
     --pipeline https://github.com/jlebon/fedora-coreos-pipeline     \
     --config https://github.com/jlebon/fedora-coreos-config@feature \
     --cosa-img quay.io/jlebon/coreos-assembler:random-tag           \
@@ -360,7 +348,7 @@ The procedure is the same for updating the pipeline:
 
 
 ```
-./deploy --update
+./deploy
 ```
 
 Note any value you don't pass to `deploy` will be reset to its default

--- a/deploy
+++ b/deploy
@@ -12,8 +12,6 @@
             # OR
             --cosa https://github.com/jlebon/coreos-assembler
 
-    Deleting developer pipeline:
-        ./deploy --delete-devel
 '''
 
 import os
@@ -33,19 +31,12 @@ def main():
     args = parse_args()
 
     if targeting_official_namespace(args) and not args.official:
-        eprint("Refusing to create developer resource in official namespace.")
-        eprint("Use --official to create official resources.")
+        eprint("Refusing to create resources in official namespace.")
+        eprint("Use --official to create resources there.")
         return 1
 
     resources = process_template(args)
-
-    if args.update:
-        update_resources(args, resources)
-    else:
-        assert args.delete_devel
-
-        delete_developer_resources(args, resources)
-
+    update_resources(args, resources)
 
 def targeting_official_namespace(args):
     ctx_name = subprocess.check_output([args.oc_cmd, 'config', 'current-context'],
@@ -70,20 +61,10 @@ def targeting_official_namespace(args):
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    action = parser.add_mutually_exclusive_group(required=True)
-    action.add_argument("--update", action='store_true',
-                        help="Create or update resources")
-    action.add_argument("--delete-devel", action='store_true',
-                        help="Delete developer resources")
     parser.add_argument("--official", action='store_true',
-                        help="Whether to update official resources "
-                             "(implies --all)")
-    parser.add_argument("--all", action='store_true',
-                        help="Whether to update all resources")
+                        help="Allows updating resources in official pipeline")
     parser.add_argument("--dry-run", action='store_true',
                         help="Only print what would happen")
-    parser.add_argument("--prefix", help="Developer prefix for resources",
-                        default=get_username())
     parser.add_argument("--pipeline", metavar='<URL>[@REF]',
                         help="Repo and ref to use for pipeline code")
     parser.add_argument("--config", metavar='<URL>[@REF]',
@@ -103,15 +84,6 @@ def parse_args():
 
     args = parser.parse_args()
 
-    if args.official:
-        args.all = True
-
-    # just sanity check we have a prefix
-    assert len(args.prefix)
-    assert not args.prefix.endswith('-'), "Prefix must not end with dash"
-
-    # e.g. jlebon --> jlebon-fedora-coreos-pipeline
-    args.prefix += '-'
 
     return args
 
@@ -123,8 +95,6 @@ def get_username():
 
 def process_template(args):
     params = {}
-    if not args.official:
-        params['DEVELOPER_PREFIX'] = args.prefix
     if args.pipeline:
         params.update(params_from_git_refspec(args.pipeline, 'JENKINS_S2I'))
         params.update(params_from_git_refspec(args.pipeline, 'JENKINS_JOBS'))
@@ -195,17 +165,6 @@ def resource_exists(args, resource):
                            stdout=subprocess.DEVNULL,
                            stderr=subprocess.DEVNULL) == 0
 
-
-def delete_developer_resources(args, resources):
-    # only delete prefixed resources
-    print("Deleting:")
-    for resource in resources:
-        if resource['metadata']['name'].startswith(args.prefix):
-            out = subprocess.run([args.oc_cmd, 'delete', '--filename', '-'],
-                                 input=json.dumps(resource), encoding='utf-8',
-                                 check=True, stdout=subprocess.PIPE)
-            print(f"  {out.stdout.strip()}")
-    print()
 
 
 def params_from_git_refspec(refspec, param_prefix):

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -1,7 +1,7 @@
 import org.yaml.snakeyaml.Yaml;
 
 def pipeutils, streams, official, repo, gp
-def src_config_url, src_config_ref, s3_bucket, notify_slack
+def src_config_url, src_config_ref, s3_bucket
 node {
     checkout scm
     pipeutils = load("utils.groovy")
@@ -15,7 +15,6 @@ node {
     src_config_url = pipecfg['source-config-url']
     src_config_ref = pipecfg['source-config-ref']
     s3_bucket = pipecfg['s3-bucket']
-    notify_slack = pipecfg['notify-slack']
 
     official = pipeutils.isOfficial()
     if (official) {
@@ -510,7 +509,7 @@ EOF
             }
 
             echo message
-            if (notify_slack == "yes") {
+            if (official) {
                 slackSend(color: color, message: message)
             }
             if (official) {

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -1,6 +1,6 @@
 import org.yaml.snakeyaml.Yaml;
 
-def pipeutils, streams, official, developer_prefix, repo, gp
+def pipeutils, streams, official, repo, gp
 def src_config_url, src_config_ref, s3_bucket, notify_slack
 node {
     checkout scm
@@ -11,29 +11,17 @@ node {
     repo = "coreos/fedora-coreos-config"
 
 
-    // just autodetect if we're in the official prod Jenkins or not; structure
-    // as a list to support migrations more easily
-    official = (env.JENKINS_URL in ['https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/'])
-
-    if (official) {
-        echo "Running in official (prod) mode."
-    } else {
-        echo "Running in developer mode on ${env.JENKINS_URL}."
-    }
-
     def pipecfg = pipeutils.load_config()
-    developer_prefix = pipecfg['developer-prefix']
     src_config_url = pipecfg['source-config-url']
     src_config_ref = pipecfg['source-config-ref']
     s3_bucket = pipecfg['s3-bucket']
     notify_slack = pipecfg['notify-slack']
 
-    // sanity check that a valid prefix is provided if in devel mode and drop
-    // the trailing '-' in the devel prefix
-    if (!official) {
-      assert developer_prefix.length() > 0 : "Missing developer prefix"
-      assert developer_prefix.endsWith("-") : "Missing trailing dash in developer prefix"
-      developer_prefix = developer_prefix[0..-2]
+    official = pipeutils.isOfficial()
+    if (official) {
+        echo "Running in official (prod) mode."
+    } else {
+        echo "Running in unofficial pipeline on ${env.JENKINS_URL}."
     }
 }
 
@@ -43,12 +31,6 @@ FEDORA_AWS_TESTING_USER_ID = "013116697141"
 // Base URL through which to download artifacts
 BUILDS_BASE_HTTP_URL = "https://builds.coreos.fedoraproject.org/prod/streams"
 
-def coreos_assembler_image
-if (official) {
-    coreos_assembler_image = "coreos-assembler:main"
-} else {
-    coreos_assembler_image = "${developer_prefix}-coreos-assembler:main"
-}
 
 properties([
     pipelineTriggers([]),
@@ -75,7 +57,7 @@ properties([
                    description: 'Force AWS AMI replication for non-production'),
       string(name: 'COREOS_ASSEMBLER_IMAGE',
              description: 'Override coreos-assembler image to use',
-             defaultValue: "${coreos_assembler_image}",
+             defaultValue: "coreos-assembler:main",
              trim: true),
       string(name: 'ARCH',
              description: 'The target architecture',
@@ -100,8 +82,7 @@ def strict_build_param = is_mechanical ? "" : "--strict"
 
 // Note that the heavy lifting is done on a remote node via gangplank
 // so we shouldn't need much memory.
-def cosa_memory_request_mb = 2.5 * 1024
-cosa_memory_request_mb = cosa_memory_request_mb as Integer
+def cosa_memory_request_mb = 2.5 * 1024 as Integer
 
 // substitute the right COSA image and mem request into the pod definition before spawning it
 pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "${cosa_memory_request_mb}Mi")
@@ -190,20 +171,11 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}", extra: [[resource: "rele
         def s3_stream_dir
 
         if (s3_bucket && utils.pathExists("\${AWS_FCOS_BUILDS_BOT_CONFIG}")) {
-          if (official) {
             // see bucket layout in https://github.com/coreos/fedora-coreos-tracker/issues/189
             s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
-          } else {
-            // One prefix = one pipeline = one stream; the deploy script is geared
-            // towards testing a specific combination of (cosa, pipeline, fcos config),
-            // not a full duplication of all the prod streams. One can always instantiate
-            // a second prefix to test a separate combination if more than 1 concurrent
-            // devel pipeline is needed.
-            s3_stream_dir = "${s3_bucket}/devel/streams/${developer_prefix}"
-          }
         }
 
-        def developer_builddir = "/srv/devel/${developer_prefix}/build"
+        def local_builddir = "/srv/devel/streams/${params.STREAM}"
 
         stage('Init') {
 
@@ -252,9 +224,9 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}", extra: [[resource: "rele
                     cosa buildfetch --url=s3://${s3_stream_dir}/builds --build ${parent_version} --arch=${basearch}
                     """)
                 }
-            } else if (!official && utils.pathExists(developer_builddir)) {
+            } else if (utils.pathExists(local_builddir)) {
                 shwrap("""
-                cosa buildfetch --url=${developer_builddir} --arch=${basearch}
+                cosa buildfetch --url=${local_builddir} --arch=${basearch}
                 """)
             }
         }
@@ -371,7 +343,6 @@ EOF
         // split this into two separate developer knobs in the future.
         if (s3_stream_dir && !is_mechanical) {
             stage('Upload AWS') {
-                def suffix = official ? "" : "--name-suffix ${developer_prefix}"
                 // pick up the AWS compressed vmdk and uncompress it
                 def meta = readJSON file: meta_json
                 def aws_image_filenamexz = meta.images.aws.path
@@ -391,7 +362,7 @@ EOF
                 // uploading first, and then pointing ore at our uploaded vmdk
                 shwrap("""
                 export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}
-                cosa buildextend-aws ${suffix} \
+                cosa buildextend-aws \
                     --upload \
                     --arch=${basearch} \
                     --build=${newBuildID} \
@@ -408,7 +379,7 @@ EOF
         }
 
 
-        // Generate KeyLime hashes for attestation on official builds
+        // Generate KeyLime hashes for attestation on builds
         // This is a POC setup and will be modified over time
         // See: https://github.com/keylime/enhancements/blob/master/16_remote_allowlist_retrieval.md
         stage('KeyLime Hash Generation') {
@@ -435,14 +406,14 @@ EOF
                   newBuildID,
                   basearch,
                   s3_stream_dir)
-            } else if (!official) {
-              // In devel mode without an S3 server, just archive into the PVC
+            } else {
+              // Without an S3 server, just archive into the PVC
               // itself. Otherwise there'd be no other way to retrieve the
               // artifacts. But note we only keep one build at a time.
               shwrap("""
-              rm -rf ${developer_builddir}
-              mkdir -p ${developer_builddir}
-              cp -aT builds ${developer_builddir}
+              rm -rf ${local_builddir}
+              mkdir -p ${local_builddir}
+              cp -aT builds ${local_builddir}
               """)
             }
         }

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -1,7 +1,7 @@
 import org.yaml.snakeyaml.Yaml;
 
 def pipeutils, streams, official
-def src_config_url, src_config_ref, s3_bucket, gcp_gs_bucket, notify_slack
+def src_config_url, src_config_ref, s3_bucket, gcp_gs_bucket
 node {
     checkout scm
     pipeutils = load("utils.groovy")
@@ -13,7 +13,6 @@ node {
     src_config_ref = pipecfg['source-config-ref']
     s3_bucket = pipecfg['s3-bucket']
     gcp_gs_bucket = pipecfg['gcp-gs-bucket']
-    notify_slack = pipecfg['notify-slack']
 
     official = pipeutils.isOfficial()
     if (official) {
@@ -638,7 +637,7 @@ lock(resource: "build-${params.STREAM}") {
             }
 
             echo message
-            if (notify_slack == "yes") {
+            if (official) {
                 slackSend(color: color, message: message)
             }
             if (official) {

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -1,12 +1,11 @@
-def pipeutils, streams, gp
-def notify_slack
+def pipeutils, streams, official, gp
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     streams = load("streams.groovy")
     gp = load("gp.groovy")
     def pipecfg = pipeutils.load_config()
-    notify_slack = pipecfg['notify-slack']
+    official = pipeutils.isOfficial()
 }
 
 repo = "coreos/fedora-coreos-config"
@@ -239,7 +238,7 @@ EOF
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    if (currentBuild.result != 'SUCCESS' && notify_slack == "yes") {
+    if (official && currentBuild.result != 'SUCCESS') {
         slackSend(color: 'danger', message: ":fcos: :trashfire: <${env.BUILD_URL}|bump-lockfile #${env.BUILD_NUMBER} (${params.STREAM})>")
     }
 }

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -1,11 +1,9 @@
-def pipeutils, streams
-def notify_slack
+def pipeutils, streams, official
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     streams = load("streams.groovy")
-    def pipecfg = pipeutils.load_config()
-    notify_slack = pipecfg['notify-slack']
+    official = pipeutils.isOfficial()
 }
 
 properties([
@@ -116,7 +114,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    if (currentBuild.result != 'SUCCESS' && notify_slack == "yes") {
+    if (official && currentBuild.result != 'SUCCESS') {
         slackSend(color: 'danger', message: ":fcos: :aws: :trashfire: kola-aws <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
     }
 }

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -1,11 +1,9 @@
-def pipeutils, streams
-def notify_slack
+def pipeutils, streams, official
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     streams = load("streams.groovy")
-    def pipecfg = pipeutils.load_config()
-    notify_slack = pipecfg['notify-slack']
+    official = pipeutils.isOfficial()
 }
 
 properties([
@@ -90,7 +88,7 @@ try { timeout(time: 30, unit: 'MINUTES') {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    if (currentBuild.result != 'SUCCESS' && notify_slack == "yes") {
+    if (official && currentBuild.result != 'SUCCESS') {
         slackSend(color: 'danger', message: ":fcos: :gcp: :trashfire: kola-gcp <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
     }
 }

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -1,11 +1,9 @@
-def pipeutils, streams
-def notify_slack
+def pipeutils, streams, official
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     streams = load("streams.groovy")
-    def pipecfg = pipeutils.load_config()
-    notify_slack = pipecfg['notify-slack']
+    official = pipeutils.isOfficial()
 }
 
 properties([
@@ -85,7 +83,7 @@ try { timeout(time: 60, unit: 'MINUTES') {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    if (currentBuild.result != 'SUCCESS' && notify_slack == "yes") {
+    if (official && currentBuild.result != 'SUCCESS') {
         slackSend(color: 'danger', message: ":fcos: :k8s: :trashfire: kola-kubernetes <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
     }
 }

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -1,11 +1,9 @@
-def pipeutils, streams
-def notify_slack
+def pipeutils, streams, official
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     streams = load("streams.groovy")
-    def pipecfg = pipeutils.load_config()
-    notify_slack = pipecfg['notify-slack']
+    official = pipeutils.isOfficial()
 }
 
 properties([
@@ -142,7 +140,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
         currentBuild.result = 'FAILURE'
         throw e
     } finally {
-        if (currentBuild.result != 'SUCCESS' && notify_slack == "yes") {
+        if (official && currentBuild.result != 'SUCCESS') {
             slackSend(color: 'danger', message: ":fcos: :openstack: :trashfire: kola-openstack <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
         }
     }

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -1,5 +1,4 @@
-def pipeutils, streams
-def s3_bucket, notify_slack
+def pipeutils, streams, official, s3_bucket
 node {
     checkout scm
     pipeutils = load("utils.groovy")
@@ -7,7 +6,7 @@ node {
     pod = readFile(file: "manifests/pod.yaml")
     pipecfg = pipeutils.load_config()
     s3_bucket = pipecfg['s3-bucket']
-    notify_slack = pipecfg['notify-slack']
+    official = pipeutils.isOfficial()
 }
 
 properties([
@@ -251,7 +250,7 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
         currentBuild.result = 'FAILURE'
         throw e
     } finally {
-        if (currentBuild.result != 'SUCCESS' && notify_slack == "yes") {
+        if (official && currentBuild.result != 'SUCCESS') {
             slackSend(color: 'danger', message: ":fcos: :bullettrain_front: :trashfire: release <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCHES}] (${params.VERSION})")
         }
     }}}

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -21,9 +21,6 @@ parameters:
   - description: Git branch/tag reference for Jenkins jobs
     name: JENKINS_JOBS_REF
     value: main
-  - description: Prefix to prepend to resources
-    name: DEVELOPER_PREFIX
-    value:
   - description: Git source URI for FCOS config
     name: FCOS_CONFIG_URL
     value: https://github.com/coreos/fedora-coreos-config
@@ -54,7 +51,7 @@ objects:
   - apiVersion: v1
     kind: ImageStream
     metadata:
-      name: ${DEVELOPER_PREFIX}coreos-assembler
+      name: coreos-assembler
     spec:
       lookupPolicy:
         # this allows e.g. the pipeline to directly reference the imagestream
@@ -74,11 +71,10 @@ objects:
   - kind: ConfigMap
     apiVersion: v1
     metadata:
-      name: ${DEVELOPER_PREFIX}pipeline-config
+      name: pipeline-config
     data:
       source-config-url: ${FCOS_CONFIG_URL}
       source-config-ref: ${FCOS_CONFIG_REF}
-      developer-prefix: ${DEVELOPER_PREFIX}
       s3-bucket: ${S3_BUCKET}
       gcp-gs-bucket: ${GCP_GS_BUCKET}
       jenkins-jobs-url: ${JENKINS_JOBS_URL}

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -38,9 +38,6 @@ parameters:
   - description: GCP GS bucket to use for image uploads (or blank for none)
     name: GCP_GS_BUCKET
     value: fedora-coreos-cloud-image-uploads
-  - description: Whether Slack notifications are enabled
-    name: NOTIFY_SLACK
-    value: "yes"
 
 objects:
 
@@ -79,4 +76,3 @@ objects:
       gcp-gs-bucket: ${GCP_GS_BUCKET}
       jenkins-jobs-url: ${JENKINS_JOBS_URL}
       jenkins-jobs-ref: ${JENKINS_JOBS_REF}
-      notify-slack: "${NOTIFY_SLACK}"

--- a/utils.groovy
+++ b/utils.groovy
@@ -9,6 +9,11 @@ def load_config() {
     """))
 }
 
+// Tells us if we're running if the official Jenkins for the FCOS pipeline
+boolean isOfficial() {
+    return (env.JENKINS_URL in ['https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/'])
+}
+
 // Parse and handle the result of Kola
 boolean checkKolaSuccess(dir, currentBuild) {
     // archive the image if the tests failed


### PR DESCRIPTION
The whole concept is a bit confusing and there is a decent amount of
conditional logic in there. If someone needs to do some hacking for
development we'll just give them their own project in openshift and
a fresh s3 bucket in another account. That way there's no risk of
messing with the official releases, but they are exercising similar
code paths.
