### PR TITLE
jobs/release: force some types to be a List

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -67,7 +67,7 @@ def pod_label = "cosa-${UUID.randomUUID().toString()}"
 def quay_registry = "quay.io/coreos-assembler/fcos"
 
 // Get the list of requested architectures to release
-def basearches = params.ARCHES.split()
+def basearches = params.ARCHES.split() as List
 
 // We just lock here out of an abundance of caution in case somehow two release
 // jobs run for the same stream, but that really shouldn't happen. Anyway, if it
@@ -104,7 +104,7 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
             """)
         }
 
-        def builtarches = shwrapCapture("jq -r '.builds | map(select(.id == \"${params.VERSION}\"))[].arches[]' builds/builds.json").split()
+        def builtarches = shwrapCapture("jq -r '.builds | map(select(.id == \"${params.VERSION}\"))[].arches[]' builds/builds.json").split() as List
         assert builtarches.contains("x86_64"): "The x86_64 architecture was not in builtarches."
         if (!builtarches.containsAll(basearches)) {
             if (params.ALLOW_MISSING_ARCHES) {


### PR DESCRIPTION
The .split() will give us a Ljava.lang.String where we need it to
be an java.util.ArrayList so we can run .containsAll() and .intersect()
on it. See https://stackoverflow.com/questions/27965351/groovy-arraylist-getting-confused-for-a-string

Fixes 102eec8