### PR TITLE
jobs/release: mark job as failed if returning early

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -114,6 +114,7 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
                 echo "ERROR: Some requested architectures did not successfully build"
                 echo "ERROR: Detected built architectures: $builtarches"
                 echo "ERROR: Requested base architectures: $basearches"
+                currentBuild.result = 'FAILURE'
                 return
             }
         }


### PR DESCRIPTION
We don't want a green check mark if we fail in a sanity check.

Fixes 8c30e1f