### PR TITLE
build.Jenkinsfile: include VirtualBox in build process

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -458,7 +458,7 @@ lock(resource: "build-${params.STREAM}") {
 
             // parallel build these artifacts
             def pbuilds = [:]
-            ["Aliyun", "AWS", "Azure", "AzureStack", "DigitalOcean", "Exoscale", "GCP", "IBMCloud", "Nutanix", "OpenStack", "VMware", "Vultr"].each {
+            ["Aliyun", "AWS", "Azure", "AzureStack", "DigitalOcean", "Exoscale", "GCP", "IBMCloud", "Nutanix", "OpenStack", "VirtualBox", "VMware", "Vultr"].each {
                 pbuilds[it] = {
                     def cmd = it.toLowerCase()
                     shwrap("""


### PR DESCRIPTION
Going through and adding a new supported build type for virtualbox to cosa.

as per https://github.com/coreos/fedora-coreos-tracker/issues/1008