### PR TITLE
jobs/sync-stream-metadata: also sync release notes

### DIFF
--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -45,6 +45,16 @@ cosaPod(configMaps: ["fedora-messaging-cfg"], secrets: ["fedora-messaging-coreos
                     stream.metadata.update --stream ${stream}
                 """)
             }
+            // Currently, we always re-upload release notes. We don't want to
+            // falsely emit a stream.metadata.update message when only release
+            // notes changed, and also the way change detection works above
+            // doesn't mesh well with freshly regenerated data.
+            shwrap("""
+                python -c 'import sys, yaml, json; json.dump(yaml.safe_load(sys.stdin.read()), sys.stdout)' \
+                    < release-notes/${stream}.yaml > release-notes/${stream}.json
+                aws s3 cp --acl public-read --cache-control 'max-age=60' \
+                    release-notes/${stream}.json s3://fcos-builds/release-notes/${stream}.json
+            """)
         }
     }
 }


### PR DESCRIPTION
Now that we have release notes in the streams repo, also start syncing
it to S3 from which the website will fetch it just like stream metadata.

This will trigger a `stream.metadata.update` message even if only
release notes changed. I'm not aware of any consumers of this today, but
still eventually we should probably split stream/updates/release notes
into separate messages.