### PR TITLE
Disable `branched` stream.

### DIFF
--- a/streams.groovy
+++ b/streams.groovy
@@ -6,7 +6,7 @@ next_devel = ['next-devel']
 
 production = ['testing', 'stable', 'next']
 development = ['testing-devel'] + next_devel
-mechanical = ['rawhide', 'branched' /* 'bodhi-updates', 'bodhi-updates-testing' */]
+mechanical = ['rawhide' /* 'branched', 'bodhi-updates', 'bodhi-updates-testing' */]
 
 // list of secondary architectures we support
 additional_arches = ['aarch64']


### PR DESCRIPTION
Now that `next-devel` is based on Fedora 36 there's no longer any value
to have `branched` around.