### PR TITLE
manifests/pod.yaml: add Azure secrets to pod definition

### DIFF
--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -24,6 +24,9 @@ spec:
          value: /.aws-fcos-builds-bot-config/config
        - name: AWS_FCOS_KOLA_BOT_CONFIG
          value: /.aws-fcos-kola-bot-config/config
+       # This one doesn't have a config subdirectory
+       - name: AZURE_KOLA_TESTS_CONFIG
+         value: /.azure-kola-tests-config
        - name: GCP_IMAGE_UPLOAD_CONFIG
          value: /.gcp-image-upload-config/config
        - name: GCP_KOLA_TESTS_CONFIG
@@ -38,6 +41,9 @@ spec:
        readOnly: true
      - name: aws-fcos-kola-bot-config
        mountPath: /.aws-fcos-kola-bot-config/
+       readOnly: true
+     - name: azure-kola-tests-config
+       mountPath: /.azure-kola-tests-config/
        readOnly: true
      - name: gcp-image-upload-config
        mountPath: /.gcp-image-upload-config/
@@ -74,6 +80,11 @@ spec:
   - name: aws-fcos-kola-bot-config
     secret:
       secretName: aws-fcos-kola-bot-config
+      optional: true
+  # This secret is used for running Azure kola tests
+  - name: azure-kola-tests-config
+    secret:
+      secretName: azure-kola-tests-config
       optional: true
   # This secret is used for uploading to GCP
   - name: gcp-image-upload-config


### PR DESCRIPTION
This is needed for jobs/build.Jenkinsfile so we can detect when
the Azure secret exists and behave accordingly. I guess this wasn't
needed for jobs/kola-azure.Jenkinsfile because we define the pod
differently with cosaPod() and specify the secret there [1].

This is a fixup to 72f2177.

[1] https://github.com/coreos/fedora-coreos-pipeline/blob/7dde485c8706afbf06ca7da5a6f64a4d2910b63b/jobs/kola-azure.Jenkinsfile#L71-L73