### PR TITLE
kola-azure: bump timeout to 60 minutes

### DIFF
--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -67,7 +67,7 @@ lock(resource: "kola-azure-${params.ARCH}") {
         s3_stream_dir = "fcos-builds/prod/streams/${params.STREAM}"
     }
 
-    try { timeout(time: 45, unit: 'MINUTES') {
+    try { timeout(time: 60, unit: 'MINUTES') {
         cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
                 memory: "256Mi", kvm: false,
                 secrets: ["aws-fcos-builds-bot-config", "azure-kola-tests-config"]) {


### PR DESCRIPTION
Even at 45 we're still getting close. Let's just move it to 60.