### PR TITLE
jobs/bump-lockfile: drop cost=500 hack

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -152,12 +152,7 @@ EOF
             gp.gangplankArchWrapper([spec: "spec.spec", arch: "aarch64"])
         }, x86_64: {
             stage("Fetch") {
-                // XXX: hack around subtle lockfile bug (jlebon to submit an
-                // rpm-ostree issue or patch about this)
-                shwrap("cp src/config/fedora-coreos-pool.repo{,.bak}")
-                shwrap("echo cost=500 >> src/config/fedora-coreos-pool.repo")
                 shwrap("cosa fetch --strict")
-                shwrap("cp src/config/fedora-coreos-pool.repo{.bak,}")
             }
 
             stage("Build") {


### PR DESCRIPTION
I don't quite recall the details of this hack, but I think it had to do
with RPM digests and signing. Though it's been a while now since we've
started stripping digests from lockfiles.

Anyway, let's just drop it for now. If we hit any errors from it, we'll
at least have something to debug.