### PR TITLE
Publish the KubeVirt image on quay

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -420,7 +420,7 @@ lock(resource: "build-${params.STREAM}") {
 
             // parallel build these artifacts
             def pbuilds = [:]
-            ["Aliyun", "AWS", "Azure", "AzureStack", "DigitalOcean", "Exoscale", "GCP", "IBMCloud", "Nutanix", "OpenStack", "VirtualBox", "VMware", "Vultr"].each {
+            ["Aliyun", "AWS", "Azure", "AzureStack", "DigitalOcean", "Exoscale", "GCP", "IBMCloud", "KubeVirt", "Nutanix", "OpenStack", "VirtualBox", "VMware", "Vultr"].each {
                 pbuilds[it] = {
                     def cmd = it.toLowerCase()
                     shwrap("""

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -477,6 +477,22 @@ lock(resource: "build-${params.STREAM}") {
                     """)
                 }
             }
+            if (!is_mechanical) {
+                stage("Push KubeVirt image") {
+                    withCredentials([file(credentialsId: 'oscontainer-secret', variable: 'OSCONTAINER_SECRET')]) {
+                            // Push the KubeVirt containerdisk to quay.io/coreos/fedora-coreos:{stream}.
+                            shwrap("""
+                            cosa buildextend-kubevirt \
+                                --log-level=INFO \
+                                --build=${newBuildID} \
+                                --upload \
+                                --registry quay.io/coreos
+                                --name fedora-coreos
+                                --tag ${params.STREAM}
+                            """)
+                    }
+                }
+            }
         }
 
         // Generate KeyLime hashes for attestation on builds


### PR DESCRIPTION
Follow up of #514 for discussing a final location of the KubeVirt container image on quay.

The idea is that people can reference the image directly based on the stream they want to select:

```
quay.io/coreos/fedora-coreos:stable
quay.io/coreos/fedora-coreos:testing
quay.io/coreos/fedora-coreos:next
```