### PR TITLE
multi-arch-builders: handle disk space issues for aarch64 builder

### DIFF
--- a/multi-arch-builders/README.md
+++ b/multi-arch-builders/README.md
@@ -16,7 +16,7 @@ cat fcos-aarch64-builder.bu | butane --pretty --strict > fcos-aarch64-builder.ig
 NAME='fcos-aarch64-builder'
 AMI='ami-0cd88be9379abf352'
 TYPE='a1.metal'
-DISK='100'
+DISK='200'
 SUBNET='subnet-0732e4cda7466a2ae'
 SECURITY_GROUPS='sg-7d0b4c05'
 USERDATA="${PWD}/fcos-aarch64-builder.ign"

--- a/multi-arch-builders/README.md
+++ b/multi-arch-builders/README.md
@@ -46,8 +46,8 @@ Make sure the instance came up fine and wait for the COSA image build
 to complete:
 
 ```bash
-systemctl --failed
-sudo machinectl builder@
+sudo systemctl --failed
+sudo machinectl shell builder@
 journalctl --user -f # to watch image build
 podman images # to view built image
 ```

--- a/multi-arch-builders/fcos-aarch64-builder.bu
+++ b/multi-arch-builders/fcos-aarch64-builder.bu
@@ -83,6 +83,21 @@ storage:
           length_minutes = 60
     - path: /var/lib/systemd/linger/builder
       mode: 0644
+    - path: /home/builder/.config/systemd/user/prune-container-resources.service
+      mode: 0644
+      user:
+        name: builder
+      group:
+        name: builder
+      contents:
+        inline: |
+          [Unit]
+          Description=Prune Dangling Container Resources
+          [Service]
+          Type=oneshot
+          ExecStart=podman image prune --force
+          ExecStart=podman container prune --force
+          ExecStart=podman volume prune --force
     - path: /home/builder/.config/systemd/user/build-cosa.service
       mode: 0644
       user:
@@ -102,7 +117,6 @@ storage:
           ExecStartPre=-git clone --depth=1 https://github.com/coreos/coreos-assembler.git /home/builder/coreos-assembler/
           ExecStartPre=git -C /home/builder/coreos-assembler/ pull
           ExecStart=podman build --pull-always -t localhost/coreos-assembler:latest /home/builder/coreos-assembler/
-          ExecStartPost=-podman image prune --force
     - path: /home/builder/.config/systemd/user/build-cosa-firstboot.service
       mode: 0644
       user:
@@ -122,6 +136,20 @@ storage:
             ExecStart=systemctl --user start build-cosa.service
             [Install]
             WantedBy=default.target
+    - path: /home/builder/.config/systemd/user/prune-container-resources.timer
+      mode: 0644
+      user:
+        name: builder
+      group:
+        name: builder
+      contents:
+        inline: |
+            [Timer]
+            OnCalendar=daily
+            AccuracySec=60m
+            Persistent=true
+            [Install]
+            WantedBy=timers.target
     - path: /home/builder/.config/systemd/user/build-cosa.timer
       mode: 0644
       user:
@@ -137,6 +165,12 @@ storage:
             [Install]
             WantedBy=timers.target
   links:
+    - path: /home/builder/.config/systemd/user/timers.target.wants/prune-container-resources.timer
+      target: /home/builder/.config/systemd/user/prune-container-resources.timer
+      user:
+        name: builder
+      group:
+        name: builder
     - path: /home/builder/.config/systemd/user/default.target.wants/build-cosa-firstboot.service
       target: /home/builder/.config/systemd/user/build-cosa-firstboot.service
       user:


### PR DESCRIPTION
```
commit 427c6161cf0556211acbd3cba6d0619e44fc68e0
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Apr 19 13:36:28 2022 -0400

    multi-arch-builders: double disk size for aarch64 builder
    
    We've run out of space on occasion. Let's double it to try
    to make sure we have plenty of room to wait for our prune
    jobs to clean things up.

commit e44d343c878e18a1608a0de9470353b0b7c45969
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Apr 19 13:34:29 2022 -0400

    multi-arch-builders: add service to prune dangling container resources
    
    This will allow for aborted builds to get cleaned up and not hog a
    bunch of resources.

```