### PR TITLE
manifests/pipeline: keep cosa tag as :main

### DIFF
--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -63,7 +63,7 @@ objects:
         # this allows e.g. the pipeline to directly reference the imagestream
         local: true
       tags:
-        - name: latest
+        - name: main
           from:
             kind: DockerImage
             name: ${COREOS_ASSEMBLER_IMAGE}


### PR DESCRIPTION
In #483, we updated the imagestream tag from `main` to `latest`, but all
the jobs still refer to the imagestream with the former tag. Rather than
updating all the references, just keep using `main`.