### PR TITLE
streams: disable next-devel

### DIFF
--- a/next-devel/badge.json
+++ b/next-devel/badge.json
@@ -2,6 +2,6 @@
     "schemaVersion": 1,
     "style": "for-the-badge",
     "label": "next-devel",
-    "message": "open",
-    "color": "green"
+    "message": "closed",
+    "color": "lightgrey"
 }

--- a/next-devel/status.json
+++ b/next-devel/status.json
@@ -1,3 +1,3 @@
 {
-    "enabled": true
+    "enabled": false
 }

--- a/streams.groovy
+++ b/streams.groovy
@@ -2,7 +2,7 @@
 
 // Contains 'next-devel' when that stream is enabled.
 // Automatically edited by next-devel/manage.py.
-next_devel = ['next-devel']
+next_devel = []
 
 production = ['testing', 'stable', 'next']
 development = ['testing-devel'] + next_devel


### PR DESCRIPTION
testing-devel and next-devel are now redundant after the Fedora 36
release. Disable next-devel until it becomes useful again.