### PR TITLE
kola-openstack.Jenkinsfile: Allow rerun success on openstack platform

### DIFF
--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -117,6 +117,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
                         skipBasicScenarios: true,
                         skipUpgrade: true,
                         platformArgs: """-p=openstack                               \
+                            --allow-rerun-success                                   \
                             --openstack-config-file=\${OPENSTACK_KOLA_TESTS_CONFIG}/config \
                             --openstack-flavor=v3-starter-4                          \
                             --openstack-network=private                              \


### PR DESCRIPTION
 Allow rerun success on openstack platform. The rerun success tag was implemented in https://github.com/coreos/coreos-assembler/pull/2857.
 
 Issue: https://github.com/coreos/coreos-assembler/issues/2853