### PR TITLE
jobs/bump-lockfile: fix retrigger logic

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -220,7 +220,7 @@ EOF
           sh("""
             rev=\$(git -C src/config rev-parse origin/${branch})
             if ! git -C src/config push https://\${GHUSER}:\${GHTOKEN}@github.com/${repo} ${branch}; then
-                git fetch origin
+                git -C src/config fetch origin
                 if [ "\$rev" != \$(git -C src/config rev-parse origin/${branch}) ]; then
                     touch ${env.WORKSPACE}/rerun
                 else


### PR DESCRIPTION
The git repo is under src/config. Without this we get an error
about not being in a git repo. Fixes 237a03b.