### PR TITLE
multi-arch-builders: force hostname; prune during the night

### DIFF
--- a/multi-arch-builders/fcos-aarch64-builder.bu
+++ b/multi-arch-builders/fcos-aarch64-builder.bu
@@ -64,6 +64,7 @@ storage:
   files:
     - path: /etc/hostname
       mode: 0644
+      overwrite: true
       contents:
         inline: fcos-aarch64-builder
     - path: /etc/systemd/zram-generator.conf

--- a/multi-arch-builders/fcos-aarch64-builder.bu
+++ b/multi-arch-builders/fcos-aarch64-builder.bu
@@ -146,8 +146,8 @@ storage:
       contents:
         inline: |
             [Timer]
-            OnCalendar=daily
-            AccuracySec=60m
+            OnCalendar=*-*-* 05:00:00 UTC
+            AccuracySec=30m
             Persistent=true
             [Install]
             WantedBy=timers.target
@@ -160,7 +160,7 @@ storage:
       contents:
         inline: |
             [Timer]
-            OnCalendar=daily
+            OnCalendar=*-*-* 04:00:00 UTC
             AccuracySec=30m
             Persistent=true
             [Install]


### PR DESCRIPTION
```
commit 3b8589daaff04eb1c95681641a7602f35f7c7a49
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue May 24 09:43:06 2022 -0400

    multi-arch-builders: build and prune at a different time of day.
    
    Rather than 00:00 UTC let's push it further back hopefully when
    most of our team is either still asleep or already asleep. I've
    seen a couple cases recently where the 00:00 UTC runs happen around
    the time the `testing-devel` is running for the day from the
    bump-lockfile bump and it ends up taking out an intermediate container
    and volume used by gangplank.

commit c4d44cfbc77ac96e6cfeeef52de38683751d9cf9
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue May 24 09:41:03 2022 -0400

    multi-arch-builders: Force writing /etc/hostname
    
    Force /etc/hostname even if the file already exists. I saw this on
    either the ppc64le or s390x builder where the hostname file had
    already been created.
```
