### PR TITLE
jobs/sync-stream-metadata: fix release notes extension

### DIFF
--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -51,7 +51,7 @@ cosaPod(configMaps: ["fedora-messaging-cfg"], secrets: ["fedora-messaging-coreos
             // doesn't mesh well with freshly regenerated data.
             shwrap("""
                 python -c 'import sys, yaml, json; json.dump(yaml.safe_load(sys.stdin.read()), sys.stdout)' \
-                    < release-notes/${stream}.yaml > release-notes/${stream}.json
+                    < release-notes/${stream}.yml > release-notes/${stream}.json
                 aws s3 cp --acl public-read --cache-control 'max-age=60' \
                     release-notes/${stream}.json s3://fcos-builds/release-notes/${stream}.json
             """)


### PR DESCRIPTION
It's `yml`, not `yaml`.