### PR TITLE
Reopen next-devel

### DIFF
--- a/next-devel/badge.json
+++ b/next-devel/badge.json
@@ -2,6 +2,6 @@
     "schemaVersion": 1,
     "style": "for-the-badge",
     "label": "next-devel",
-    "message": "closed",
-    "color": "lightgrey"
+    "message": "open",
+    "color": "green"
 }

--- a/next-devel/status.json
+++ b/next-devel/status.json
@@ -1,3 +1,3 @@
 {
-    "enabled": false
+    "enabled": true
 }

--- a/streams.groovy
+++ b/streams.groovy
@@ -2,7 +2,7 @@
 
 // Contains 'next-devel' when that stream is enabled.
 // Automatically edited by next-devel/manage.py.
-next_devel = []
+next_devel = ['next-devel']
 
 production = ['testing', 'stable', 'next']
 development = ['testing-devel'] + next_devel


### PR DESCRIPTION
We want to bake the console changes in next before they go to testing.

https://github.com/coreos/fedora-coreos-tracker/issues/567#issuecomment-1150275044

Hold until after the next release.