### PR TITLE
jobs/release: Use `cosa push-container`

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -125,11 +125,9 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
             // for now we only support pushing x86_64 images
             if (basearch == 'x86_64') {
                 stage("Push Container") {
-                    def image_path = shwrapCapture("cosa meta --build=${params.VERSION} --image-path ostree")
                     withCredentials([file(credentialsId: 'oscontainer-secret', variable: 'OSCONTAINER_SECRET')]) {
-                        withEnv(["SRC_IMAGE=${image_path}",
-                                 "DEST_IMAGE=docker://${quay_registry}:${params.STREAM}"]) {
-                            sh('skopeo copy --authfile=${OSCONTAINER_SECRET} oci-archive://${SRC_IMAGE} ${DEST_IMAGE}')
+                        withEnv(["DEST_IMAGE=${quay_registry}:${params.STREAM}"]) {
+                            shwrap('cosa push-container --authfile=${OSCONTAINER_SECRET} ${DEST_IMAGE}')
                         }
                     }
                 }


### PR DESCRIPTION
This way we're not reimplementing the "find the ostree container in meta.json"
bits, and we're also now mutating `meta.json` which could lead
in the future into having the base image also be in the stream
metadata.