### PR TITLE
jobs/release: drop use of `withEnv`

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -126,9 +126,7 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
             if (basearch == 'x86_64') {
                 stage("Push Container") {
                     withCredentials([file(credentialsId: 'oscontainer-secret', variable: 'OSCONTAINER_SECRET')]) {
-                        withEnv(["DEST_IMAGE=${quay_registry}:${params.STREAM}"]) {
-                            shwrap('cosa push-container --authfile=${OSCONTAINER_SECRET} ${DEST_IMAGE}')
-                        }
+                        shwrap("cosa push-container --authfile=\${OSCONTAINER_SECRET} ${quay_registry}:${params.STREAM}")
                     }
                 }
             }


### PR DESCRIPTION
Let's simplify this even further and drop the `withEnv` wrapper.

Note we're switching from single to double quotes here. As a result, we
need to escape the `OSCONTAINER_SECRET` variable since it's in the env
only.