### PR TITLE
jobs/build: fix error detection in parallel Kola:QEMU stages

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -329,7 +329,7 @@ lock(resource: "build-${params.STREAM}") {
             """)
             archiveArtifacts "kola-run-basic.tar.xz"
         }
-        if (!pipeutils.checkKolaSuccess("tmp/kola", currentBuild)) {
+        if (!pipeutils.checkKolaSuccess("tmp/kola")) {
             error('Kola:QEMU basic')
         }
 
@@ -345,7 +345,7 @@ lock(resource: "build-${params.STREAM}") {
             tar -cf - tmp/kola/ | xz -c9 > kola-run.tar.xz
             """)
             archiveArtifacts "kola-run.tar.xz"
-            if (!pipeutils.checkKolaSuccess("tmp/kola", currentBuild)) {
+            if (!pipeutils.checkKolaSuccess("tmp/kola")) {
                 error('Kola:QEMU')
             }
         }
@@ -361,13 +361,11 @@ lock(resource: "build-${params.STREAM}") {
                 tar -cf - tmp/kola-upgrade | xz -c9 > kola-run-upgrade.tar.xz
                 """)
                 archiveArtifacts "kola-run-upgrade.tar.xz"
-                if (!pipeutils.checkKolaSuccess("tmp/kola-upgrade", currentBuild)) {
+                if (!pipeutils.checkKolaSuccess("tmp/kola-upgrade")) {
                     error('Kola:QEMU Upgrade')
                 }
             } catch(e) {
                 if (params.ALLOW_KOLA_UPGRADE_FAILURE) {
-                    // reset result back to !FAILED and warn
-                    currentBuild.result = ''
                     warnError(message: 'Upgrade Failed') {
                         error(e)
                     }

--- a/utils.groovy
+++ b/utils.groovy
@@ -15,13 +15,12 @@ boolean isOfficial() {
 }
 
 // Parse and handle the result of Kola
-boolean checkKolaSuccess(dir, currentBuild) {
+boolean checkKolaSuccess(dir) {
     // archive the image if the tests failed
     def report = readJSON file: "${dir}/reports/report.json"
     def result = report["result"]
     print("kola result: ${result}")
     if (result != "PASS") {
-        currentBuild.result = 'FAILURE'
         return false
     }
     return true


### PR DESCRIPTION
jobs/build: fix error detection in parallel Kola:QEMU stages

Now that they are nested inside parallel, the `return` doesn't
effectively stop the pipeline run. Let's use `error` instead.

Also add in warnError in the case it fails but we want to continue.

Also add in some extra comments on why the try/catch is needed.

Fixup for 717d960
