### PR TITLE
jobs/build: Fix typo in description for NO_UPLOAD

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -65,7 +65,7 @@ properties([
                    description: 'Wait forever at kola tests stage. Implies NO_UPLOAD'),
       booleanParam(name: 'NO_UPLOAD',
                    defaultValue: false,
-                   description: 'Don't upload results to S3; for debugging purposes.'),
+                   description: 'Do not upload results to S3; for debugging purposes.'),
     ]),
     buildDiscarder(logRotator(
         numToKeepStr: '100',


### PR DESCRIPTION
The apostrophe in "Don't" ended my single quote early. Just change
it to "Do not".

Fixup for 45af871