### PR TITLE
jobs/build: add temporary iso-live-login UEFI test with rd.debug

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -452,6 +452,12 @@ lock(resource: "build-${params.STREAM}") {
                         shwrap("kola testiso -SP --qemu-native-4k --output-dir tmp/kola-metal4k")
                     }, uefi: {
                         shwrap("mkdir -p tmp/kola-uefi")
+                        shwrap("""
+                        mkdir tmp/iso-live-login-with-rd-debug
+                        iso=tmp/iso-live-login-with-rd-debug/test.iso
+                        coreos-installer iso kargs modify --append rd.debug builds/${newBuildID}/${basearch}/*.iso -o \$iso
+                        kola testiso -S --qemu-firmware=uefi --scenarios iso-live-login,iso-as-disk --qemu-iso \$iso --output-dir tmp/kola-uefi/rd-debug")
+                        """)
                         shwrap("kola testiso -S --qemu-firmware=uefi --scenarios iso-live-login,iso-as-disk --output-dir tmp/kola-uefi/insecure")
                         shwrap("kola testiso -S --qemu-firmware=uefi-secure --scenarios iso-live-login,iso-as-disk --output-dir tmp/kola-uefi/secure")
                     }


### PR DESCRIPTION
We're trying to debug
https://github.com/coreos/fedora-coreos-tracker/issues/1233 but logs
aren't helping much. We think adding `rd.debug` might help in case it's
e.g. a dracut initqueue issue.

Add a separate test for this on a separate ISO so that we don't affect
the official artifacts.