### PR TITLE
jobs/build: Remove unneeded ending quote delimiter

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -462,7 +462,7 @@ lock(resource: "build-${params.STREAM}") {
                         mkdir tmp/iso-live-login-with-rd-debug
                         iso=tmp/iso-live-login-with-rd-debug/test.iso
                         coreos-installer iso kargs modify --append rd.debug builds/${newBuildID}/${basearch}/*.iso -o \$iso
-                        kola testiso -S --qemu-firmware=uefi --scenarios iso-live-login,iso-as-disk --qemu-iso \$iso --output-dir tmp/kola-uefi/rd-debug")
+                        kola testiso -S --qemu-firmware=uefi --scenarios iso-live-login,iso-as-disk --qemu-iso \$iso --output-dir tmp/kola-uefi/rd-debug)
                         """)
                         shwrap("kola testiso -S --qemu-firmware=uefi --scenarios iso-live-login,iso-as-disk --output-dir tmp/kola-uefi/insecure")
                         shwrap("kola testiso -S --qemu-firmware=uefi-secure --scenarios iso-live-login,iso-as-disk --output-dir tmp/kola-uefi/secure")


### PR DESCRIPTION
Typo fix for b2f98c1a17eb2c42ffad9e5a6eb918adfa2d9924