### PR TITLE
multi-arch-builders: create a common butane config

### DIFF
--- a/multi-arch-builders/README.md
+++ b/multi-arch-builders/README.md
@@ -17,7 +17,8 @@ HISTCONTROL='ignoreboth'
 Create the Ignition config
 
 ```bash
-cat fcos-aarch64-builder.bu | butane --pretty --strict > fcos-aarch64-builder.ign
+cat builder-common.bu | butane --pretty --strict > builder-common.ign
+cat fcos-aarch64-builder.bu | butane --pretty --strict --files-dir=. > fcos-aarch64-builder.ign
 ```
 
 Bring the instance up with appropriate details:
@@ -109,7 +110,8 @@ Create the Ignition config in a separate terminal and copy it into the
 container where ibmcloud is running:
 
 ```bash
-cat fcos-s390x-builder.bu | butane --pretty --strict > fcos-s390x-builder.ign
+cat builder-common.bu | butane --pretty --strict > builder-common.ign
+cat fcos-s390x-builder.bu | butane --pretty --strict --files-dir=. > fcos-s390x-builder.ign
 podman cp fcos-s390x-builder.ign ibmcloud:/root/fcos-s390x-builder.ign
 ```
 

--- a/multi-arch-builders/builder-common.bu
+++ b/multi-arch-builders/builder-common.bu
@@ -1,0 +1,182 @@
+# This butane config will do the following:
+#
+# - Allow designated users to log in as the core user
+# - Disable kernel mitigations (not a shared instance)
+# - Set up the podman socket for the builder user (podman remote)
+# - Build coreos-assembler on the first boot and once a day
+# - Configure zincati to allow updates at a specific time (early Monday)
+# - Enable linger for builder (so processes can run even if user hasn't
+#   logged in)
+# - Configure zram
+#
+variant: fcos
+version: 1.4.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD2v0AVNJauAmerBvsbz/y2/lyTqkE0s71ZPd2MNRhYRlx7nn5fhIh7OptqUSbHUQXm+K2pBHWz5/cILGpcdWOpG97AwAsFvJP3EJqAMRLstLPuziBckkc6QV5ZSwfTW3fabKcU4gaF51LFQlDo/Fi2QfQ1O2lOCQDKWlHR5metN7iVdYzQGO9DWAYMX1RoRhdtVsrPU8+qLpx8zdBdeZDLXvou+gkrnI2taMptoi7afcfIR1KYNlYQGb1TlLG5reJPADHRqnjbpItbZ8IfWULedGjp7DhPYzCyv1g869XQerFRqR8T7WTppyfZLtrOUC2hB6pFtux8KdAVsIu0juWv dustymabe@fedoraproject.org
+        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC1IXvPWcfgEVhRCwZe5WZNemqsEL8zGUfKdoCA5ZSR557Oi/TnL/3v+oLvH1o2iKo69D/7nkSjP+PuHkjEBtyG7riIpTmsRsRNwJcMXS+wl3iWw855Bl97S1D9krY3D1szF0CI9E57EgDwccmAHixQMrFrzG3OBttzawhI2y74QdcGeJtIa/kENIziInM/sPwPL9M6eKeQjuMyb6ZyvkgaQlr7PJrHqs3Y0j6RFa/ns2ViOSZYIj0VxNy+hiTbCWnbE6qpzJJysB3YinwStmotrPk33XgBpDdEunhrEywk7eAc1ZoFvmVtYR/CcDktpAz9VhjQEz43nE6pZc0fjjGb jlebon@lux
+        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7OMAAunnoSsakYuUqWGHutt9EyafHfbUrZzzHYLdksBdL2mbarnRVqc3yl0iHIPx1g2l8p68iJ3ESkQjpOESAv51hEUWun1+vdJnCI9c22G9M+3mhL3DoDvzgcTx6ayhBChhIMg1sIhmvUMx0ZNC1HPdpJIkUTWiICY3JYlcnkh+IHlmBbaq0b/Rtrufd/utJRITeWQlK74Y+n+VQms0eMjTi0djEA/4mdUbBgAEPWmCeqQEsd8oZiHsHSVxlZ8ymkRsHniIZTMqSUJzVr+PrsxP1E8B3ruUdRs9vBvYjt7PXiGLoStwrgK/sFAR+j8Aerz4sPD6MeNHRBPLOE4BtxVe59IKLY9+LS/+01FRkFkRhJ4IcRzajf8xJn/KoBPv+mj45AWcL5l2g8gu7sFNbBohXhLlSFXjb/5mGyTN7TH3qmNkq58raG4faTUUO8om0AdqfuBHiSMeLl4l5Mt0eFrPzTiDf6EYzy7BwSec63Z9+EwQL1wh8/+hpjHaxoBXhqdRns1XFe4xOhowoVRpyYzU0Cz+k6ZXzownUp68aziytibPMw5vsRcyCm12I+t9AI5wuG4Vl34l308Ufzh6YWd/TX9Kw3pC+Fe7RE+XvTwixVNPEJi6U8WgamtRTN62lP369lnimzpIRpum8UiLco/bjbHD7TnygLFb6hSI1tQ== kevins-yubikey@scrye.com
+kernel_arguments:
+  should_exist:
+    - mitigations=off
+  should_not_exist:
+    - mitigations=auto,nosmt
+storage:
+  directories:
+    - path: /home/builder/.config
+      user:
+        name: builder
+      group:
+        name: builder
+    - path: /home/builder/.config/systemd
+      user:
+        name: builder
+      group:
+        name: builder
+    - path: /home/builder/.config/systemd/user
+      user:
+        name: builder
+      group:
+        name: builder
+    - path: /home/builder/.config/systemd/user/default.target.wants
+      user:
+        name: builder
+      group:
+        name: builder
+    - path: /home/builder/.config/systemd/user/timers.target.wants
+      user:
+        name: builder
+      group:
+        name: builder
+    - path: /home/builder/.config/systemd/user/sockets.target.wants
+      user:
+        name: builder
+      group:
+        name: builder
+  files:
+    - path: /etc/systemd/zram-generator.conf
+      mode: 0644
+      contents:
+        inline: |
+          # This config file enables a /dev/zram0 device with the default settings
+          [zram0]
+    - path: /etc/zincati/config.d/51-updates-early-monday-morning.toml
+      contents:
+        inline: |
+          [updates]
+          strategy = "periodic"
+          [[updates.periodic.window]]
+          days = [ "Mon" ]
+          start_time = "07:00"
+          length_minutes = 60
+    - path: /var/lib/systemd/linger/builder
+      mode: 0644
+    - path: /home/builder/.config/systemd/user/prune-container-resources.service
+      mode: 0644
+      user:
+        name: builder
+      group:
+        name: builder
+      contents:
+        inline: |
+          [Unit]
+          Description=Prune Dangling Container Resources
+          [Service]
+          Type=oneshot
+          ExecStart=podman image prune --force
+          ExecStart=podman container prune --force
+          ExecStart=podman volume prune --force
+    - path: /home/builder/.config/systemd/user/build-cosa.service
+      mode: 0644
+      user:
+        name: builder
+      group:
+        name: builder
+      contents:
+        inline: |
+          [Unit]
+          Description=Build COSA container
+          [Service]
+          # Give time for the build to complete
+          TimeoutStartSec=180m
+          Type=oneshot
+          ExecStartPre=nm-online --timeout=30
+          ExecStartPre=mkdir -p /home/builder/coreos-assembler/
+          ExecStartPre=-git clone --depth=1 https://github.com/coreos/coreos-assembler.git /home/builder/coreos-assembler/
+          ExecStartPre=git -C /home/builder/coreos-assembler/ pull
+          ExecStart=podman build --pull-always -t localhost/coreos-assembler:latest /home/builder/coreos-assembler/
+    - path: /home/builder/.config/systemd/user/build-cosa-firstboot.service
+      mode: 0644
+      user:
+        name: builder
+      group:
+        name: builder
+      contents:
+        inline: |
+            [Unit]
+            Description=Build COSA on first boot
+            ConditionFirstBoot=yes
+            [Service]
+            # Give time for the build to complete
+            TimeoutStartSec=180m
+            Type=oneshot
+            RemainAfterExit=yes
+            ExecStart=systemctl --user start build-cosa.service
+            [Install]
+            WantedBy=default.target
+    - path: /home/builder/.config/systemd/user/prune-container-resources.timer
+      mode: 0644
+      user:
+        name: builder
+      group:
+        name: builder
+      contents:
+        inline: |
+            [Timer]
+            OnCalendar=*-*-* 05:00:00 UTC
+            AccuracySec=30m
+            Persistent=true
+            [Install]
+            WantedBy=timers.target
+    - path: /home/builder/.config/systemd/user/build-cosa.timer
+      mode: 0644
+      user:
+        name: builder
+      group:
+        name: builder
+      contents:
+        inline: |
+            [Timer]
+            OnCalendar=*-*-* 04:00:00 UTC
+            AccuracySec=30m
+            Persistent=true
+            [Install]
+            WantedBy=timers.target
+  links:
+    - path: /home/builder/.config/systemd/user/timers.target.wants/prune-container-resources.timer
+      target: /home/builder/.config/systemd/user/prune-container-resources.timer
+      user:
+        name: builder
+      group:
+        name: builder
+    - path: /home/builder/.config/systemd/user/default.target.wants/build-cosa-firstboot.service
+      target: /home/builder/.config/systemd/user/build-cosa-firstboot.service
+      user:
+        name: builder
+      group:
+        name: builder
+    - path: /home/builder/.config/systemd/user/timers.target.wants/build-cosa.timer
+      target: /home/builder/.config/systemd/user/build-cosa.timer
+      user:
+        name: builder
+      group:
+        name: builder
+    # enable podman socket (used by podman remote) for the user
+    - path: /home/builder/.config/systemd/user/sockets.target.wants/podman.socket
+      target: /usr/lib/systemd/user/podman.socket
+      user:
+        name: builder
+      group:
+        name: builder

--- a/multi-arch-builders/fcos-aarch64-builder.bu
+++ b/multi-arch-builders/fcos-aarch64-builder.bu
@@ -1,193 +1,24 @@
 # This butane config will do the following:
 #
-# - Allow dustymabe and jlebon to log in as the core user
+# - Merge in the builder-common.ign Ignition file
 # - Allow the builder user to log in with the associated ssh key
-#   which is shared with the pipeline. Used a ed25519 key so we
-#   don't have to worry about https://github.com/golang/go/issues/37278
-# - disable kernel mitigations (not a shared instance)
-# - Set up the podman socket for the builder user (podman remote)
-# - Build coreos-assembler on the first boot and once a day
-# - Configure zincati to allow updates at a specific time (early Monday)
-# - Enable linger for builder (so processes can run even if user hasn't
-#   logged in)
 # - Set a hostname
-# - Configure zram
 #
 variant: fcos
 version: 1.4.0
+ignition:
+  config:
+    merge:
+      - local: builder-common.ign
 passwd:
   users:
-    - name: core
-      ssh_authorized_keys:
-        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD2v0AVNJauAmerBvsbz/y2/lyTqkE0s71ZPd2MNRhYRlx7nn5fhIh7OptqUSbHUQXm+K2pBHWz5/cILGpcdWOpG97AwAsFvJP3EJqAMRLstLPuziBckkc6QV5ZSwfTW3fabKcU4gaF51LFQlDo/Fi2QfQ1O2lOCQDKWlHR5metN7iVdYzQGO9DWAYMX1RoRhdtVsrPU8+qLpx8zdBdeZDLXvou+gkrnI2taMptoi7afcfIR1KYNlYQGb1TlLG5reJPADHRqnjbpItbZ8IfWULedGjp7DhPYzCyv1g869XQerFRqR8T7WTppyfZLtrOUC2hB6pFtux8KdAVsIu0juWv dustymabe@fedoraproject.org
-        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC1IXvPWcfgEVhRCwZe5WZNemqsEL8zGUfKdoCA5ZSR557Oi/TnL/3v+oLvH1o2iKo69D/7nkSjP+PuHkjEBtyG7riIpTmsRsRNwJcMXS+wl3iWw855Bl97S1D9krY3D1szF0CI9E57EgDwccmAHixQMrFrzG3OBttzawhI2y74QdcGeJtIa/kENIziInM/sPwPL9M6eKeQjuMyb6ZyvkgaQlr7PJrHqs3Y0j6RFa/ns2ViOSZYIj0VxNy+hiTbCWnbE6qpzJJysB3YinwStmotrPk33XgBpDdEunhrEywk7eAc1ZoFvmVtYR/CcDktpAz9VhjQEz43nE6pZc0fjjGb jlebon@lux
     - name: builder
       ssh_authorized_keys:
         - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILJJquUOL/NRZEIRrMLW0T8H/zmBQA4XMZxoI0ElwvGp builder@fcos-aarch64-builder
-kernel_arguments:
-  should_exist:
-    - mitigations=off
-  should_not_exist:
-    - mitigations=auto,nosmt
 storage:
-  directories:
-    - path: /home/builder/.config
-      user:
-        name: builder
-      group:
-        name: builder
-    - path: /home/builder/.config/systemd
-      user:
-        name: builder
-      group:
-        name: builder
-    - path: /home/builder/.config/systemd/user
-      user:
-        name: builder
-      group:
-        name: builder
-    - path: /home/builder/.config/systemd/user/default.target.wants
-      user:
-        name: builder
-      group:
-        name: builder
-    - path: /home/builder/.config/systemd/user/timers.target.wants
-      user:
-        name: builder
-      group:
-        name: builder
-    - path: /home/builder/.config/systemd/user/sockets.target.wants
-      user:
-        name: builder
-      group:
-        name: builder
   files:
     - path: /etc/hostname
       mode: 0644
       overwrite: true
       contents:
         inline: fcos-aarch64-builder
-    - path: /etc/systemd/zram-generator.conf
-      mode: 0644
-      contents:
-        inline: |
-          # This config file enables a /dev/zram0 device with the default settings
-          [zram0]
-    - path: /etc/zincati/config.d/51-updates-early-monday-morning.toml
-      contents:
-        inline: |
-          [updates]
-          strategy = "periodic"
-          [[updates.periodic.window]]
-          days = [ "Mon" ]
-          start_time = "07:00"
-          length_minutes = 60
-    - path: /var/lib/systemd/linger/builder
-      mode: 0644
-    - path: /home/builder/.config/systemd/user/prune-container-resources.service
-      mode: 0644
-      user:
-        name: builder
-      group:
-        name: builder
-      contents:
-        inline: |
-          [Unit]
-          Description=Prune Dangling Container Resources
-          [Service]
-          Type=oneshot
-          ExecStart=podman image prune --force
-          ExecStart=podman container prune --force
-          ExecStart=podman volume prune --force
-    - path: /home/builder/.config/systemd/user/build-cosa.service
-      mode: 0644
-      user:
-        name: builder
-      group:
-        name: builder
-      contents:
-        inline: |
-          [Unit]
-          Description=Build COSA container
-          [Service]
-          # Give time for the build to complete
-          TimeoutStartSec=180m
-          Type=oneshot
-          ExecStartPre=nm-online --timeout=30
-          ExecStartPre=mkdir -p /home/builder/coreos-assembler/
-          ExecStartPre=-git clone --depth=1 https://github.com/coreos/coreos-assembler.git /home/builder/coreos-assembler/
-          ExecStartPre=git -C /home/builder/coreos-assembler/ pull
-          ExecStart=podman build --pull-always -t localhost/coreos-assembler:latest /home/builder/coreos-assembler/
-    - path: /home/builder/.config/systemd/user/build-cosa-firstboot.service
-      mode: 0644
-      user:
-        name: builder
-      group:
-        name: builder
-      contents:
-        inline: |
-            [Unit]
-            Description=Build COSA on first boot
-            ConditionFirstBoot=yes
-            [Service]
-            # Give time for the build to complete
-            TimeoutStartSec=180m
-            Type=oneshot
-            RemainAfterExit=yes
-            ExecStart=systemctl --user start build-cosa.service
-            [Install]
-            WantedBy=default.target
-    - path: /home/builder/.config/systemd/user/prune-container-resources.timer
-      mode: 0644
-      user:
-        name: builder
-      group:
-        name: builder
-      contents:
-        inline: |
-            [Timer]
-            OnCalendar=*-*-* 05:00:00 UTC
-            AccuracySec=30m
-            Persistent=true
-            [Install]
-            WantedBy=timers.target
-    - path: /home/builder/.config/systemd/user/build-cosa.timer
-      mode: 0644
-      user:
-        name: builder
-      group:
-        name: builder
-      contents:
-        inline: |
-            [Timer]
-            OnCalendar=*-*-* 04:00:00 UTC
-            AccuracySec=30m
-            Persistent=true
-            [Install]
-            WantedBy=timers.target
-  links:
-    - path: /home/builder/.config/systemd/user/timers.target.wants/prune-container-resources.timer
-      target: /home/builder/.config/systemd/user/prune-container-resources.timer
-      user:
-        name: builder
-      group:
-        name: builder
-    - path: /home/builder/.config/systemd/user/default.target.wants/build-cosa-firstboot.service
-      target: /home/builder/.config/systemd/user/build-cosa-firstboot.service
-      user:
-        name: builder
-      group:
-        name: builder
-    - path: /home/builder/.config/systemd/user/timers.target.wants/build-cosa.timer
-      target: /home/builder/.config/systemd/user/build-cosa.timer
-      user:
-        name: builder
-      group:
-        name: builder
-    # enable podman socket (used by podman remote) for the user
-    - path: /home/builder/.config/systemd/user/sockets.target.wants/podman.socket
-      target: /usr/lib/systemd/user/podman.socket
-      user:
-        name: builder
-      group:
-        name: builder

--- a/multi-arch-builders/fcos-s390x-builder.bu
+++ b/multi-arch-builders/fcos-s390x-builder.bu
@@ -1,193 +1,24 @@
 # This butane config will do the following:
 #
-# - Allow dustymabe and jlebon to log in as the core user
+# - Merge in the builder-common.ign Ignition file
 # - Allow the builder user to log in with the associated ssh key
-#   which is shared with the pipeline. Used a ed25519 key so we
-#   don't have to worry about https://github.com/golang/go/issues/37278
-# - disable kernel mitigations (not a shared instance)
-# - Set up the podman socket for the builder user (podman remote)
-# - Build coreos-assembler on the first boot and once a day
-# - Configure zincati to allow updates at a specific time (early Monday)
-# - Enable linger for builder (so processes can run even if user hasn't
-#   logged in)
 # - Set a hostname
-# - Configure zram
 #
 variant: fcos
 version: 1.4.0
+ignition:
+  config:
+    merge:
+      - local: builder-common.ign
 passwd:
   users:
-    - name: core
-      ssh_authorized_keys:
-        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD2v0AVNJauAmerBvsbz/y2/lyTqkE0s71ZPd2MNRhYRlx7nn5fhIh7OptqUSbHUQXm+K2pBHWz5/cILGpcdWOpG97AwAsFvJP3EJqAMRLstLPuziBckkc6QV5ZSwfTW3fabKcU4gaF51LFQlDo/Fi2QfQ1O2lOCQDKWlHR5metN7iVdYzQGO9DWAYMX1RoRhdtVsrPU8+qLpx8zdBdeZDLXvou+gkrnI2taMptoi7afcfIR1KYNlYQGb1TlLG5reJPADHRqnjbpItbZ8IfWULedGjp7DhPYzCyv1g869XQerFRqR8T7WTppyfZLtrOUC2hB6pFtux8KdAVsIu0juWv dustymabe@fedoraproject.org
-        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC1IXvPWcfgEVhRCwZe5WZNemqsEL8zGUfKdoCA5ZSR557Oi/TnL/3v+oLvH1o2iKo69D/7nkSjP+PuHkjEBtyG7riIpTmsRsRNwJcMXS+wl3iWw855Bl97S1D9krY3D1szF0CI9E57EgDwccmAHixQMrFrzG3OBttzawhI2y74QdcGeJtIa/kENIziInM/sPwPL9M6eKeQjuMyb6ZyvkgaQlr7PJrHqs3Y0j6RFa/ns2ViOSZYIj0VxNy+hiTbCWnbE6qpzJJysB3YinwStmotrPk33XgBpDdEunhrEywk7eAc1ZoFvmVtYR/CcDktpAz9VhjQEz43nE6pZc0fjjGb jlebon@lux
     - name: builder
       ssh_authorized_keys:
         - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBYuN4Crt4kwszp25BPpNGc8xPiVyXwXAGILQmBOOvCq builder@fcos-s390x-builder
-kernel_arguments:
-  should_exist:
-    - mitigations=off
-  should_not_exist:
-    - mitigations=auto,nosmt
 storage:
-  directories:
-    - path: /home/builder/.config
-      user:
-        name: builder
-      group:
-        name: builder
-    - path: /home/builder/.config/systemd
-      user:
-        name: builder
-      group:
-        name: builder
-    - path: /home/builder/.config/systemd/user
-      user:
-        name: builder
-      group:
-        name: builder
-    - path: /home/builder/.config/systemd/user/default.target.wants
-      user:
-        name: builder
-      group:
-        name: builder
-    - path: /home/builder/.config/systemd/user/timers.target.wants
-      user:
-        name: builder
-      group:
-        name: builder
-    - path: /home/builder/.config/systemd/user/sockets.target.wants
-      user:
-        name: builder
-      group:
-        name: builder
   files:
     - path: /etc/hostname
       mode: 0644
       overwrite: true
       contents:
         inline: fcos-s390x-builder
-    - path: /etc/systemd/zram-generator.conf
-      mode: 0644
-      contents:
-        inline: |
-          # This config file enables a /dev/zram0 device with the default settings
-          [zram0]
-    - path: /etc/zincati/config.d/51-updates-early-monday-morning.toml
-      contents:
-        inline: |
-          [updates]
-          strategy = "periodic"
-          [[updates.periodic.window]]
-          days = [ "Mon" ]
-          start_time = "07:00"
-          length_minutes = 60
-    - path: /var/lib/systemd/linger/builder
-      mode: 0644
-    - path: /home/builder/.config/systemd/user/prune-container-resources.service
-      mode: 0644
-      user:
-        name: builder
-      group:
-        name: builder
-      contents:
-        inline: |
-          [Unit]
-          Description=Prune Dangling Container Resources
-          [Service]
-          Type=oneshot
-          ExecStart=podman image prune --force
-          ExecStart=podman container prune --force
-          ExecStart=podman volume prune --force
-    - path: /home/builder/.config/systemd/user/build-cosa.service
-      mode: 0644
-      user:
-        name: builder
-      group:
-        name: builder
-      contents:
-        inline: |
-          [Unit]
-          Description=Build COSA container
-          [Service]
-          # Give time for the build to complete
-          TimeoutStartSec=180m
-          Type=oneshot
-          ExecStartPre=nm-online --timeout=30
-          ExecStartPre=mkdir -p /home/builder/coreos-assembler/
-          ExecStartPre=-git clone --depth=1 https://github.com/coreos/coreos-assembler.git /home/builder/coreos-assembler/
-          ExecStartPre=git -C /home/builder/coreos-assembler/ pull
-          ExecStart=podman build --pull-always -t localhost/coreos-assembler:latest /home/builder/coreos-assembler/
-    - path: /home/builder/.config/systemd/user/build-cosa-firstboot.service
-      mode: 0644
-      user:
-        name: builder
-      group:
-        name: builder
-      contents:
-        inline: |
-            [Unit]
-            Description=Build COSA on first boot
-            ConditionFirstBoot=yes
-            [Service]
-            # Give time for the build to complete
-            TimeoutStartSec=180m
-            Type=oneshot
-            RemainAfterExit=yes
-            ExecStart=systemctl --user start build-cosa.service
-            [Install]
-            WantedBy=default.target
-    - path: /home/builder/.config/systemd/user/prune-container-resources.timer
-      mode: 0644
-      user:
-        name: builder
-      group:
-        name: builder
-      contents:
-        inline: |
-            [Timer]
-            OnCalendar=*-*-* 05:00:00 UTC
-            AccuracySec=30m
-            Persistent=true
-            [Install]
-            WantedBy=timers.target
-    - path: /home/builder/.config/systemd/user/build-cosa.timer
-      mode: 0644
-      user:
-        name: builder
-      group:
-        name: builder
-      contents:
-        inline: |
-            [Timer]
-            OnCalendar=*-*-* 04:00:00 UTC
-            AccuracySec=30m
-            Persistent=true
-            [Install]
-            WantedBy=timers.target
-  links:
-    - path: /home/builder/.config/systemd/user/timers.target.wants/prune-container-resources.timer
-      target: /home/builder/.config/systemd/user/prune-container-resources.timer
-      user:
-        name: builder
-      group:
-        name: builder
-    - path: /home/builder/.config/systemd/user/default.target.wants/build-cosa-firstboot.service
-      target: /home/builder/.config/systemd/user/build-cosa-firstboot.service
-      user:
-        name: builder
-      group:
-        name: builder
-    - path: /home/builder/.config/systemd/user/timers.target.wants/build-cosa.timer
-      target: /home/builder/.config/systemd/user/build-cosa.timer
-      user:
-        name: builder
-      group:
-        name: builder
-    # enable podman socket (used by podman remote) for the user
-    - path: /home/builder/.config/systemd/user/sockets.target.wants/podman.socket
-      target: /usr/lib/systemd/user/podman.socket
-      user:
-        name: builder
-      group:
-        name: builder


### PR DESCRIPTION
90% of the butane config is shared amongst the builders. Let's create
a builder-common.bu to share the common configuration.