### PR TITLE
jobs: set cpu request for pods

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -83,6 +83,10 @@ def strict_build_param = is_mechanical ? "" : "--strict"
 // so we shouldn't need much memory.
 def cosa_memory_request_mb = 2.5 * 1024 as Integer
 
+// the build-arch pod is mostly triggering the work on a remote node, so we
+// can be conservative with our request
+pod = pod.replace("COREOS_ASSEMBLER_CPU_REQUEST", "1")
+
 // substitute the right COSA image and mem request into the pod definition before spawning it
 pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "${cosa_memory_request_mb}Mi")
 pod = pod.replace("COREOS_ASSEMBLER_IMAGE", params.COREOS_ASSEMBLER_IMAGE)

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -86,6 +86,10 @@ def strict_build_param = is_mechanical ? "" : "--strict"
 // workflow, only the qemu image is built).
 def cosa_memory_request_mb = 6.5 * 1024 as Integer
 
+// the build pod runs most frequently and does the majority of the computation
+// so give it some healthy CPU shares
+pod = pod.replace("COREOS_ASSEMBLER_CPU_REQUEST", "4")
+
 // substitute the right COSA image and mem request into the pod definition before spawning it
 pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "${cosa_memory_request_mb}Mi")
 pod = pod.replace("COREOS_ASSEMBLER_IMAGE", params.COREOS_ASSEMBLER_IMAGE)

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -56,6 +56,9 @@ pod = pod.replace("COREOS_ASSEMBLER_IMAGE", params.COREOS_ASSEMBLER_IMAGE)
 // shouldn't need more than 256Mi for this job
 pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "256Mi")
 
+// single CPU should be enough for this job
+pod = pod.replace("COREOS_ASSEMBLER_CPU_REQUEST", "1")
+
 echo "Final podspec: ${pod}"
 
 // use a unique label to force Kubernetes to provision a separate pod per run

--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -64,6 +64,7 @@ spec:
        privileged: false
      resources:
        requests:
+         cpu: COREOS_ASSEMBLER_CPU_REQUEST
          memory: COREOS_ASSEMBLER_MEMORY_REQUEST
          devices.kubevirt.io/kvm: '1'
        limits:


### PR DESCRIPTION
It's good practice to be explicit with the requests used by pods, so
let's configure the CPU requests.