### PR TITLE
jobs/build-arch: Fix copy over of fedmsg.toml

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -225,14 +225,10 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}", extra: [[resource: "rele
             if [ -f /etc/fedora-messaging-cfg/fedmsg.toml ]; then
                 cosa shell -- sudo install -d -D -o builder -g builder --mode 777 \
                     /etc/fedora-messaging-cfg
-                cosa remote-session sync                   \
-                    /etc/fedora-messaging-cfg/fedmsg.toml  \
-                    :/etc/fedora-messaging-cfg/fedmsg.toml
+                cosa remote-session sync {,:}/etc/fedora-messaging-cfg/
                 cosa shell -- sudo install -d -D -o builder -g builder --mode 777 \
                     /run/kubernetes/secrets/fedora-messaging-coreos-key
-                cosa remote-session sync                                 \
-                    /run/kubernetes/secrets/fedora-messaging-coreos-key/ \
-                    :/run/kubernetes/secrets/fedora-messaging-coreos-key/
+                cosa remote-session sync {,:}/run/kubernetes/secrets/fedora-messaging-coreos-key/
             fi
 
             cosa init --force --branch ${ref} --commit=${fcos_config_commit} ${src_config_url}


### PR DESCRIPTION
The way kube secrets work is the files are usually symlinks to another
file in the same directory. Let's sync the whole directory so we get
the target file as well.

Also changed the sync definition for the key to be more succinct.