### PR TITLE
jobs/build-arch: run the releng tasks on the remote too

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -603,6 +603,7 @@ lock(resource: "build-${params.STREAM}") {
             }
             parallelruns['OSTree Import: Compose Repo'] = {
                 shwrap("""
+                cosa shell -- \
                 /var/tmp/fcos-releng/coreos-ostree-importer/send-ostree-import-request.py \
                     --build=${newBuildID} --arch=${basearch} \
                     --s3=${s3_stream_dir} --repo=compose \


### PR DESCRIPTION
Otherwise we need to sync some stuff back first and so far we haven't
had to do that.