### PR TITLE
Revert "jenkins/config: bump kubernetes-plugin maxRequestsPerHost"

### DIFF
--- a/jenkins/config/k8s-plugin-tweaks.yaml
+++ b/jenkins/config/k8s-plugin-tweaks.yaml
@@ -1,7 +1,0 @@
-# mitigation for
-# https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/client-and-managed-masters/considerations-for-kubernetes-clients-connection-when-using-kubernetes-plugin
-jenkins:
-  clouds:
-  - kubernetes:
-      maxRequestsPerHost: 64
-      name: "openshift"


### PR DESCRIPTION
This reverts commit fc3532704a0c3082810d34ca461d52747a53150a.

The intention is good, but we can't do this via JCASC because it
clobbers the existing `openshift` cloud configuration instead of merging
it in.