### PR TITLE
manifests/jenkins.yaml: set OVERRIDE_PV_CONFIG_WITH_IMAGE_CONFIG

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -80,6 +80,9 @@ objects:
             value: ${ENABLE_FATAL_ERROR_LOG_FILE}
           - name: JENKINS_UC_INSECURE
             value: ${JENKINS_UC_INSECURE}
+          # DELTA: we want baked configs to always be applied on updates
+          - name: OVERRIDE_PV_CONFIG_WITH_IMAGE_CONFIG
+            value: "true"
           # DELTA: point c-as-c plugin to config map files; see below
           - name: CASC_JENKINS_CONFIG
             value: /var/lib/jenkins/configuration-as-code


### PR DESCRIPTION
By default, when using a PVC, the OpenShift S2I Jenkins image only
instantiates templates on the first run. This however means that
configuration state can accumulate in the PVC.

Set the `OVERRIDE_PV_CONFIG_WITH_IMAGE_CONFIG` env var which tells the
S2I run script to always instantiate and copy in templates. This
*should* preserve build logs.

An example of this is the Kubernetes cloud config, which was lost in a
recent change (see #583).