### PR TITLE
manifests/pipeline: use image from quay.io for our imagestream

### DIFF
--- a/jobs/build-cosa.Jenkinsfile
+++ b/jobs/build-cosa.Jenkinsfile
@@ -78,7 +78,7 @@ node {
     shortcommit = commit.substring(0,7)
 }
 
-currentBuild.description = "[${gitref}] Running"
+currentBuild.description = "[${gitref}@${shortcommit}] Waiting"
 
 // Get the list of requested architectures to build for
 def basearches = params.ARCHES.split() as Set
@@ -150,7 +150,7 @@ try {
         currentBuild.description = "[${gitref}@${shortcommit}] ❌"
     }
     if (official && currentBuild.result != 'SUCCESS') {
-        message = ":fcos: :trashfire: build-cosa <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${gitref}-${shortcommit}]"
+        message = ":fcos: :trashfire: build-cosa <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${gitref}@${shortcommit}]"
         slackSend(color: 'danger', message: message)
     }
 }

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -29,9 +29,7 @@ parameters:
     value: # empty -> based on stream
   - description: Image of coreos-assembler to use
     name: COREOS_ASSEMBLER_IMAGE
-    # for now we just follow :latest, but we may start freezing if things become
-    # too unstable
-    value: registry.ci.openshift.org/coreos/coreos-assembler:latest
+    value: quay.io/coreos-assembler/coreos-assembler:main
   - description: AWS S3 bucket in which to store builds (or blank for none)
     name: S3_BUCKET
     value: fcos-builds


### PR DESCRIPTION
```
commit 0503f33d7f60ec1982280c653c551351ecc6bcee
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Aug 3 21:25:10 2022 -0400

    manifests/pipeline: use image from quay.io for our imagestream
    
    Forgot to update this previously.

commit 183bf751d03e90b7e5301a992ecba3226d6b8ec3
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Aug 3 21:24:06 2022 -0400

    jobs/build-cosa: fixup description and slack messages
    
    Update the first to mention the shortcommit and that we are waiting
    on the lock. Update the latter to have the @shortcommit syntax.
```
