### PR TITLE
Revert "manifests/jenkins.yaml: set OVERRIDE_PV_CONFIG_WITH_IMAGE_CONFIG"

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -80,9 +80,6 @@ objects:
             value: ${ENABLE_FATAL_ERROR_LOG_FILE}
           - name: JENKINS_UC_INSECURE
             value: ${JENKINS_UC_INSECURE}
-          # DELTA: we want baked configs to always be applied on updates
-          - name: OVERRIDE_PV_CONFIG_WITH_IMAGE_CONFIG
-            value: "true"
           # DELTA: point c-as-c plugin to config map files; see below
           - name: CASC_JENKINS_CONFIG
             value: /var/lib/jenkins/configuration-as-code


### PR DESCRIPTION
This reverts commit 086c56ea2320d0f711ba5f32ed55caa9294ed1e9.

This helped us recover access to the Kubernetes API server, but it's not
a great default because it means we lose everything anytime Jenkins is
restarted for any reason (e.g. pipeline or cluster updates). We do want
to reprovision from scratch more often, but we need to first move off of
the Jenkins SCM webhook handling, which is not friendly to frequent
reprovisioning.