### PR TITLE
jobs/build: request as many CPUs as parallel VMs and run reprovision tests serially

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -380,11 +380,21 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
         // Kola QEMU tests
         parallelruns['Kola:QEMU'] = {
             shwrap("""
-            cosa kola run --rerun --parallel 5 --no-test-exit-error
+            cosa kola run --rerun --parallel 5 --no-test-exit-error --tag '!reprovision'
             cosa shell -- tar -c --xz tmp/kola/ > kola-run.tar.xz
             cosa shell -- cat tmp/kola/reports/report.json > report.json
             """)
             archiveArtifacts "kola-run.tar.xz"
+            if (!pipeutils.checkKolaSuccess("report.json")) {
+                error('Kola:QEMU')
+            }
+            shwrap("""
+            cosa shell -- rm -rf tmp/kola
+            cosa kola run --rerun --no-test-exit-error --tag reprovision
+            cosa shell -- tar -c --xz tmp/kola/ > kola-run-reprovision.tar.xz
+            cosa shell -- cat tmp/kola/reports/report.json > report.json
+            """)
+            archiveArtifacts "kola-run-reprovision.tar.xz"
             if (!pipeutils.checkKolaSuccess("report.json")) {
                 error('Kola:QEMU')
             }

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -363,11 +363,21 @@ lock(resource: "build-${params.STREAM}") {
             // remove 1 for upgrade test
             def n = ncpus - 1
             shwrap("""
-            cosa kola run --rerun --parallel ${n} --no-test-exit-error
+            cosa kola run --rerun --parallel ${n} --no-test-exit-error --tag '!reprovision'
             cosa shell -- tar -c --xz tmp/kola/ > kola-run.tar.xz
             cosa shell -- cat tmp/kola/reports/report.json > report.json
             """)
             archiveArtifacts "kola-run.tar.xz"
+            if (!pipeutils.checkKolaSuccess("report.json")) {
+                error('Kola:QEMU')
+            }
+            shwrap("""
+            cosa shell -- rm -rf tmp/kola
+            cosa kola run --rerun --no-test-exit-error --tag reprovision
+            cosa shell -- tar -c --xz tmp/kola/ > kola-run-reprovision.tar.xz
+            cosa shell -- cat tmp/kola/reports/report.json > report.json
+            """)
+            archiveArtifacts "kola-run-reprovision.tar.xz"
             if (!pipeutils.checkKolaSuccess("report.json")) {
                 error('Kola:QEMU')
             }


### PR DESCRIPTION
```
commit c9fc772f7c17d77b94b6254cbab0888d63c7e736
Date:   Thu Aug 4 19:23:35 2022 -0400

    jobs/build: request as many CPUs as parallel VMs

    Right now we're running with `--parallel 5` and run the upgrade tests in
    parallel, but only have 4 CPUs. This causes some heavier tests to fail.
    Let's request as many CPUs as we run VM tests in parallel. Since the
    latter is calculated from the memory request, that's what we do.

    In effect, this bumps up our CPU requests to 6.
```
```
commit 04cb8c388688cfb4a11f1db1381aca2a37998df6
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Fri Aug 5 11:21:12 2022 -0400

    jobs/build: run reprovision tests not in parallel

    Those tests take 4G of RAM each and are heavy in I/O. Run them serially
    to stay within our declared memory request and minimize the chances of
    timeouts.
```