### PR TITLE
build-cosa: just build against main for now

### DIFF
--- a/jobs/build-cosa.Jenkinsfile
+++ b/jobs/build-cosa.Jenkinsfile
@@ -50,7 +50,7 @@ node {
         poll: false,
         scm: [
             $class: 'GitSCM',
-            branches: [[name: 'origin/rhcos*'], [name: 'origin/main']],
+            branches: [[name: 'origin/main']],
             userRemoteConfigs: [[url: 'https://github.com/coreos/coreos-assembler.git']],
             extensions: [[$class: 'CloneOption',
                           noTags: true,


### PR DESCRIPTION
Everytime we lose jenkins history it tries to build COSA
4.1 through 4.11 all over again. Let's limit it to `main`
for now and investigate using the Generic Webhook Trigger
plugin [1] next week.

[1] https://plugins.jenkins.io/generic-webhook-trigger/