### PR TITLE
jobs/build-cosa: push in v2s2 format

### DIFF
--- a/jobs/build-cosa.Jenkinsfile
+++ b/jobs/build-cosa.Jenkinsfile
@@ -118,7 +118,7 @@ try {
                     images += " --image=docker://${params.CONTAINER_REGISTRY_STAGING_REPO}:${arch}-${shortcommit}"
                 }
                 shwrap("""
-                cosa push-container-manifest \
+                cosa push-container-manifest --v2s2 \
                     --auth=\$REGISTRY_SECRET --tag ${gitref} \
                     --repo ${params.CONTAINER_REGISTRY_REPO} ${images}
                 """)


### PR DESCRIPTION
The cosa image we build is used to trigger internal RHCOS multi-arch
rebuilds (and in the near future will be used directly once we have all
the arches built). But the stack on the target cluster is too old to
understand OCI, so we get:

    Internal error occurred: missing signature key

Add `--v2s2` to push in v2s2 format.

Once we've rebased RHCOS to the FCOS pipeline, we should be able to
revert this.

Related: https://github.com/coreos/coreos-assembler/pull/2726