### PR TITLE
jobs/build-cosa: build COSA container for ppc64le

### DIFF
--- a/jobs/build-cosa.Jenkinsfile
+++ b/jobs/build-cosa.Jenkinsfile
@@ -14,7 +14,7 @@ properties([
     parameters([
       string(name: 'ARCHES',
              description: 'Space-separated list of target architectures',
-             defaultValue: "x86_64" + " " + streams.additional_arches.join(" "),
+             defaultValue: "x86_64 ppc64le" + " " + streams.additional_arches.join(" "),
              trim: true),
       string(name: 'COREOS_ASSEMBLER_GIT_URL',
              description: 'Override the coreos-assembler git repo to use',


### PR DESCRIPTION
We'll add this into streams.additional_arches soon, but for now let's
default to having the build-cosa job build for ppc64le.