### PR TITLE
print warning message to slack if `UNSTABLE`

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -658,6 +658,9 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
                 }
                 message = ":fcos: :sparkles: ${message} - SUCCESS"
                 color = 'good';
+            } else if (currentBuild.result == 'UNSTABLE') {
+                message = ":fcos: :warning: ${message} - WARNING"
+                color = 'warning';
             } else {
                 message = ":fcos: :trashfire: ${message} - FAILURE"
                 color = 'danger';

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -742,6 +742,9 @@ lock(resource: "build-${params.STREAM}") {
                 }
                 message = ":fcos: :sparkles: ${message} - SUCCESS"
                 color = 'good';
+            } else if (currentBuild.result == 'UNSTABLE') {
+                message = ":fcos: :warning: ${message} - WARNING"
+                color = 'warning';
             } else {
                 message = ":fcos: :trashfire: ${message} - FAILURE"
                 color = 'danger';

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -346,7 +346,11 @@ try { lock(resource: "bump-${params.STREAM}") { timeout(time: 120, unit: 'MINUTE
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
+    def color = 'danger'
+    if (currentBuild.result == 'UNSTABLE') {
+        color = 'warning'
+    }
     if (official && currentBuild.result != 'SUCCESS') {
-        slackSend(color: 'danger', message: ":fcos: :trashfire: <${env.BUILD_URL}|bump-lockfile #${env.BUILD_NUMBER} (${params.STREAM})>")
+        slackSend(color: color, message: ":fcos: :trashfire: <${env.BUILD_URL}|bump-lockfile #${env.BUILD_NUMBER} (${params.STREAM})>")
     }
 }


### PR DESCRIPTION
If an upgrade fails we have a parameter for allowing the build to
continue. Let's detect this case and give an appropriate slack
message and color.