### PR TITLE
plugins: add kubernetes-credentials-provider

### DIFF
--- a/jenkins/controller/plugins.txt
+++ b/jenkins/controller/plugins.txt
@@ -13,3 +13,4 @@ workflow-api:1153.vb_912c0e47fb_a_
 ssh-credentials:277.v95c2fec1c047
 pipeline-github:2.8-138.d766e30bb08b
 pipeline-utility-steps:2.12.1
+kubernetes-credentials-provider:0.20


### PR DESCRIPTION
This plugin can automatically import Kubernetes secrets with a certain
label into Jenkins. This will allow us to drop secret definitions
defined in a bunch of places (Jenkins template, JCASC dropins, and cosa
pod template).