### PR TITLE
don't run kola basic tests twice

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -380,7 +380,7 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
         // Kola QEMU tests
         parallelruns['Kola:QEMU'] = {
             shwrap("""
-            cosa kola run --rerun --parallel 5 --no-test-exit-error --tag '!reprovision'
+            cosa kola run --rerun --parallel 5 --no-test-exit-error --denylist-test basic  --tag '!reprovision'
             cosa shell -- tar -c --xz tmp/kola/ > kola-run.tar.xz
             cosa shell -- cat tmp/kola/reports/report.json > report.json
             """)

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -363,7 +363,7 @@ lock(resource: "build-${params.STREAM}") {
             // remove 1 for upgrade test
             def n = ncpus - 1
             shwrap("""
-            cosa kola run --rerun --parallel ${n} --no-test-exit-error --tag '!reprovision'
+            cosa kola run --rerun --parallel ${n} --no-test-exit-error --denylist-test basic --tag '!reprovision'
             cosa shell -- tar -c --xz tmp/kola/ > kola-run.tar.xz
             cosa shell -- cat tmp/kola/reports/report.json > report.json
             """)

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -208,7 +208,7 @@ try { lock(resource: "bump-${params.STREAM}") { timeout(time: 120, unit: 'MINUTE
                     parallelruns["${arch}:Kola"] = {
                         def n = ncpus - 1 // remove 1 for upgrade test
                         shwrap("""
-                        cosa kola run --rerun --parallel ${n} --no-test-exit-error --tag '!reprovision'
+                        cosa kola run --rerun --parallel ${n} --no-test-exit-error --denylist-test basic  --tag '!reprovision'
                         cosa shell -- tar -c --xz tmp/kola/ > kola-run.${arch}.tar.xz
                         cosa shell -- cat tmp/kola/reports/report.json > report-kola.${arch}.json
                         """)


### PR DESCRIPTION
Since we have a kola basic tests stage where we separately run the
basic tests, let's denylist them when we run the rest of the kola
tests.