### PR TITLE
Rely on new kubernetes-credentials-provider plugin for root CA cert and inject it into cosa container

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -295,6 +295,31 @@ echo $coreosbot_token > token
 oc create secret generic github-coreosbot-token --from-file=token
 ```
 
+### [PROD, OPTIONAL] Create additional root CA certificate secret
+
+If an additional root CA certificate is needed, create it as
+a secret:
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: additional-root-ca-cert
+  labels:
+    jenkins.io/credentials-type: "secretFile"
+  annotations:
+    jenkins.io/credentials-description: "Root certificate for XXX"
+type: Opaque
+stringData:
+  filename: ca.crt
+data:
+  data: |
+    # output of $(base64 < ca.crt)
+```
+
+The description can be customized. All other fields must be
+exactly as is.
+
 ### Create a Jenkins instance with a persistent volume backing store
 
 ```
@@ -340,8 +365,8 @@ circumstances. Below are some of the options. To see more run
     - Image of coreos-assembler to use.
 - `--bucket BUCKET`
     - AWS S3 bucket in which to store builds (or blank for none).
-- `--additional-root-ca-certs-secret SECRET`
-    - Secret name to any additional root CA certs
+- `--additional-root-ca-cert-secret SECRET`
+    - Secret name to any additional root CA cert
 
 For example, to target a specific combination of pipeline, FCOS config,
 cosa image, and bucket:
@@ -367,6 +392,12 @@ We can now start a build of the Jenkins controller:
 
 ```
 oc start-build --follow jenkins
+```
+
+If a root CA cert was provided, also start a build of the Jenkins agent:
+
+```
+oc start-build --follow jenkins-agent
 ```
 
 Once the Jenkins controller image is built, Jenkins should start up (verify

--- a/HACKING.md
+++ b/HACKING.md
@@ -365,8 +365,6 @@ circumstances. Below are some of the options. To see more run
     - Image of coreos-assembler to use.
 - `--bucket BUCKET`
     - AWS S3 bucket in which to store builds (or blank for none).
-- `--additional-root-ca-cert-secret SECRET`
-    - Secret name to any additional root CA cert
 
 For example, to target a specific combination of pipeline, FCOS config,
 cosa image, and bucket:
@@ -385,8 +383,9 @@ This will create:
 
 1. the Jenkins controller imagestream,
 2. the Jenkins agent imagestream,
-3. the coreos-assembler imagestream, and
-4. the pipeline-config configmap.
+3. the Jenkins agent BuildConfig (if a root CA cert was provided),
+4. the coreos-assembler imagestream, and
+5. the pipeline-config configmap.
 
 We can now start a build of the Jenkins controller:
 

--- a/deploy
+++ b/deploy
@@ -38,11 +38,12 @@ def main():
     resources = process_template(args)
     update_resources(args, resources)
 
+
 def targeting_official_namespace(args):
-    ctx_name = subprocess.check_output([args.oc_cmd, 'config', 'current-context'],
-                                       encoding='utf-8').strip()
-    cfg = yaml.safe_load(subprocess.check_output([args.oc_cmd, 'config', 'view'],
-                                                 encoding='utf-8'))
+    ctx_name = subprocess.check_output(
+        [args.oc_cmd, 'config', 'current-context'], encoding='utf-8').strip()
+    cfg = yaml.safe_load(subprocess.check_output(
+        [args.oc_cmd, 'config', 'view'], encoding='utf-8'))
     ctx = [c['context'] for c in cfg['contexts'] if c['name'] == ctx_name]
     assert len(ctx) == 1, f"Found {len(ctx)} contexts named '{ctx_name}'"
     ctx = ctx[0]
@@ -70,15 +71,22 @@ def parse_args():
     parser.add_argument("--config", metavar='<URL>[@REF]',
                         help="Repo and ref to use for FCOS config")
     parser.add_argument("--bucket", metavar='BUCKET',
-                        help="AWS S3 bucket to use")
+                        help="AWS S3 bucket to use for build uploads")
     parser.add_argument("--gcp-gs-bucket", metavar='GCP_GS_BUCKET',
-                        help="GCP GS bucket to use for image uploads during import")
-    parser.add_argument("--azure-testing-resource-group", metavar='AZURE_TESTING_RESOURCE_GROUP',
-                        help="Azure resource group to use for testing")
-    parser.add_argument("--azure-testing-storage-account", metavar='AZURE_TESTING_STORAGE_ACCOUNT',
-                        help="Azure storage account to use for testing image uploads")
-    parser.add_argument("--azure-testing-storage-container", metavar='AZURE_TESTING_STORAGE_CONTAINER',
-                        help="Azure storage container to use for testing image uploads")
+                        help="GCP GS bucket to use for image uploads "
+                             "during import")
+    parser.add_argument("--azure-testing-resource-group",
+                        metavar='AZURE_TESTING_RESOURCE_GROUP',
+                        help="Azure resource group for image uploads "
+                             "for kola tests")
+    parser.add_argument("--azure-testing-storage-account",
+                        metavar='AZURE_TESTING_STORAGE_ACCOUNT',
+                        help="Azure storage account for image uploads "
+                             "for kola tests")
+    parser.add_argument("--azure-testing-storage-container",
+                        metavar='AZURE_TESTING_STORAGE_CONTAINER',
+                        help="Azure storage container for image uploads "
+                             "for kola tests")
     parser.add_argument("--cosa-img", metavar='FQIN',
                         help="Pullspec to use for COSA image")
     parser.add_argument("--oc-cmd", default='oc',
@@ -87,7 +95,6 @@ def parse_args():
                         help="Secret name to additional root CA certs")
 
     args = parser.parse_args()
-
 
     return args
 
@@ -142,7 +149,8 @@ def process_template(args):
         # and generate the --param FOO=bar ... args for this template
         param_args = gen_param_args(tparams)
         j = json.loads(subprocess.check_output(
-            [args.oc_cmd, 'process', '--filename', f'manifests/{template}'] + param_args))
+            [args.oc_cmd, 'process', '--filename', f'manifests/{template}'] +
+            param_args))
         resources += j['items']
     return resources
 
@@ -154,7 +162,8 @@ def update_resources(args, resources):
         if action == 'skip':
             continue
         if args.dry_run:
-            print(f"Would {action} {resource['kind'].lower()} {resource['metadata']['name']}")
+            kind = resource['kind'].lower()
+            print(f"Would {action} {kind} {resource['metadata']['name']}")
             continue
         out = subprocess.run([args.oc_cmd, action, '--filename', '-'],
                              input=json.dumps(resource), encoding='utf-8',
@@ -180,7 +189,6 @@ def resource_exists(args, resource):
                             resource['metadata']['name']],
                            stdout=subprocess.DEVNULL,
                            stderr=subprocess.DEVNULL) == 0
-
 
 
 def params_from_git_refspec(refspec, param_prefix):

--- a/deploy
+++ b/deploy
@@ -85,10 +85,6 @@ def parse_args():
                         help="The path to the oc binary")
     parser.add_argument("--additional-root-ca-certs-secret", metavar='SECRET',
                         help="Secret name to additional root CA certs")
-    # XXX: to add as a mutually exclusive option with above
-    # parser.add_argument("--cosa", metavar='<URL>[@REF]',
-    #                     help="Repo and ref to use for COSA image",
-    #                     default=DEFAULT_COSA_IMG)
 
     args = parser.parse_args()
 

--- a/deploy
+++ b/deploy
@@ -91,8 +91,8 @@ def parse_args():
                         help="Pullspec to use for COSA image")
     parser.add_argument("--oc-cmd", default='oc',
                         help="The path to the oc binary")
-    parser.add_argument("--additional-root-ca-certs-secret", metavar='SECRET',
-                        help="Secret name to additional root CA certs")
+    parser.add_argument("--additional-root-ca-cert-secret", metavar='SECRET',
+                        help="Secret name to additional root CA cert")
 
     args = parser.parse_args()
 
@@ -125,8 +125,8 @@ def process_template(args):
         params['AZURE_TESTING_STORAGE_ACCOUNT'] = args.azure_testing_storage_account
     if args.azure_testing_storage_container:
         params['AZURE_TESTING_STORAGE_CONTAINER'] = args.azure_testing_storage_container
-    if args.additional_root_ca_certs_secret:
-        params['ADDITIONAL_ROOT_CA_CERTS_SECRET'] = args.additional_root_ca_certs_secret
+    if args.additional_root_ca_cert_secret:
+        params['ADDITIONAL_ROOT_CA_CERT_SECRET'] = args.additional_root_ca_cert_secret
         params['JENKINS_AGENT_IMAGE_TAG'] = "derived"
         templates += ['jenkins-agent.yaml']
 

--- a/deploy
+++ b/deploy
@@ -91,8 +91,6 @@ def parse_args():
                         help="Pullspec to use for COSA image")
     parser.add_argument("--oc-cmd", default='oc',
                         help="The path to the oc binary")
-    parser.add_argument("--additional-root-ca-cert-secret", metavar='SECRET',
-                        help="Secret name to additional root CA cert")
 
     args = parser.parse_args()
 
@@ -125,8 +123,7 @@ def process_template(args):
         params['AZURE_TESTING_STORAGE_ACCOUNT'] = args.azure_testing_storage_account
     if args.azure_testing_storage_container:
         params['AZURE_TESTING_STORAGE_CONTAINER'] = args.azure_testing_storage_container
-    if args.additional_root_ca_cert_secret:
-        params['ADDITIONAL_ROOT_CA_CERT_SECRET'] = args.additional_root_ca_cert_secret
+    if has_additional_root_ca(args):
         params['JENKINS_AGENT_IMAGE_TAG'] = "derived"
         templates += ['jenkins-agent.yaml']
 
@@ -153,6 +150,12 @@ def process_template(args):
             param_args))
         resources += j['items']
     return resources
+
+
+def has_additional_root_ca(args):
+    secrets = subprocess.check_output([args.oc_cmd, 'get', 'secrets', '-o=name'],
+                                      encoding='utf-8').splitlines()
+    'secret/additional-root-ca-cert' in secrets
 
 
 def update_resources(args, resources):

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -137,6 +137,9 @@ lock(resource: "build-${params.STREAM}") {
         cat /cosa/coreos-assembler-git.json
         """)
 
+        // add any additional root CA cert before we do anything that fetches
+        pipeutils.addOptionalRootCA()
+
         // declare these early so we can use them in `finally` block
         def newBuildID
         def basearch = shwrapCapture("cosa basearch")

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -61,6 +61,9 @@ try { lock(resource: "bump-${params.STREAM}") { timeout(time: 120, unit: 'MINUTE
             cpu: "${ncpus}", memory: "${cosa_memory_request_mb}Mi") {
     currentBuild.description = "[${params.STREAM}] Running"
 
+    // add any additional root CA cert before we do anything that fetches
+    pipeutils.addOptionalRootCA()
+
     // set up git user upfront
     shwrap("""
       git config --global user.name "CoreOS Bot"

--- a/manifests/jenkins-agent.yaml
+++ b/manifests/jenkins-agent.yaml
@@ -3,9 +3,9 @@ kind: Template
 metadata:
   name: jenkins-agent
 parameters:
-  - description: Secret name containing any additional root CA certificates
-    name: ADDITIONAL_ROOT_CA_CERTS_SECRET
-    value: additional-root-ca-certs
+  - description: Secret name containing any additional root CA certificate
+    name: ADDITIONAL_ROOT_CA_CERT_SECRET
+    value: additional-root-ca-cert
 objects:
   - kind: BuildConfig
     apiVersion: v1
@@ -15,12 +15,12 @@ objects:
       source:
         dockerfile: |
           FROM overridden
-          COPY certs/* /etc/pki/ca-trust/source/anchors/
+          COPY certs/data /etc/pki/ca-trust/source/anchors/root-ca.crt
           RUN update-ca-trust
         secrets:
           - destinationDir: certs
             secret:
-              name: ${ADDITIONAL_ROOT_CA_CERTS_SECRET}
+              name: ${ADDITIONAL_ROOT_CA_CERT_SECRET}
       strategy:
         dockerStrategy:
           from:

--- a/manifests/jenkins-agent.yaml
+++ b/manifests/jenkins-agent.yaml
@@ -1,11 +1,11 @@
+# This template is instantiated only if an additional root CA is needed. Note it
+# doesn't actually need to be a template (there are no parameters), but the way
+# `deploy` currently works expects it as a template.
+
 apiVersion: v1
 kind: Template
 metadata:
   name: jenkins-agent
-parameters:
-  - description: Secret name containing any additional root CA certificate
-    name: ADDITIONAL_ROOT_CA_CERT_SECRET
-    value: additional-root-ca-cert
 objects:
   - kind: BuildConfig
     apiVersion: v1
@@ -20,7 +20,7 @@ objects:
         secrets:
           - destinationDir: certs
             secret:
-              name: ${ADDITIONAL_ROOT_CA_CERT_SECRET}
+              name: additional-root-ca-cert
       strategy:
         dockerStrategy:
           from:

--- a/utils.groovy
+++ b/utils.groovy
@@ -134,4 +134,14 @@ def tryWithCredentials(creds, Closure body) {
     }
 }
 
+// Injects the root CA cert into the cosa pod if available.
+def addOptionalRootCA() {
+    tryWithCredentials([file(credentialsId: 'additional-root-ca-cert', variable: 'ROOT_CA')]) {
+        shwrap('''
+            cp $ROOT_CA /etc/pki/ca-trust/source/anchors/
+            /usr/lib/coreos-assembler/update-ca-trust-unpriv
+        ''')
+    }
+}
+
 return this


### PR DESCRIPTION
Roughly, this series documents how to create a secret for the root CA usable with kubernetes-credentials-provider, and then uses the auto-created secret in the pipeline to optionally have it added to the cosa container (relying on https://github.com/coreos/coreos-assembler/pull/3032).

See individual commit for more details.