### PR TITLE
deploy: fix `has_additional_root_ca()` return value

### DIFF
--- a/deploy
+++ b/deploy
@@ -155,7 +155,7 @@ def process_template(args):
 def has_additional_root_ca(args):
     secrets = subprocess.check_output([args.oc_cmd, 'get', 'secrets', '-o=name'],
                                       encoding='utf-8').splitlines()
-    'secret/additional-root-ca-cert' in secrets
+    return 'secret/additional-root-ca-cert' in secrets
 
 
 def update_resources(args, resources):

--- a/manifests/jenkins-agent.yaml
+++ b/manifests/jenkins-agent.yaml
@@ -15,10 +15,10 @@ objects:
       source:
         dockerfile: |
           FROM overridden
-          COPY certs/data /etc/pki/ca-trust/source/anchors/root-ca.crt
+          COPY cert/data /etc/pki/ca-trust/source/anchors/root-ca.crt
           RUN update-ca-trust
         secrets:
-          - destinationDir: certs
+          - destinationDir: cert
             secret:
               name: additional-root-ca-cert
       strategy:


### PR DESCRIPTION
Too much Rust.

Fixes 88a769a ("Simplify root CA cert provisioning").