### PR TITLE
jobs/build: warn when workaround for iso-live-login is detected

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -516,6 +516,19 @@ lock(resource: "build-${params.STREAM}") {
                     cosa shell -- tar -c --xz tmp/kola-testiso-uefi/ > kola-testiso-uefi.tar.xz
                     """)
                     archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-testiso*.tar.xz'
+
+                    // For now we want to notify ourselves when this workaround is observed. It won't
+                    // fail the build, just give us information.
+                    // https://github.com/coreos/fedora-coreos-tracker/issues/1233
+                    def grepRc = shwrapRc("""
+                         cosa shell -- grep 'tracker issue workaround engaged for .*issues/1233' \
+                            tmp/kola-testiso-uefi/insecure/{iso-live-login,iso-as-disk}/console.txt
+                    """)
+                    if (grepRc == 0) {
+                        warnError(message: 'Detected used workaround for #1233') {
+                            error('Detected used workaround for #1233')
+                        }
+                    }
                 }
             }
 

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -502,12 +502,6 @@ lock(resource: "build-${params.STREAM}") {
                     }
                     parallelruns['uefi'] = {
                         shwrap("cosa shell -- mkdir -p tmp/kola-testiso-uefi")
-                        shwrap("""
-                        cosa shell -- mkdir tmp/iso-live-login-with-rd-debug
-                        iso=tmp/iso-live-login-with-rd-debug/test.iso
-                        cosa shell -- coreos-installer iso kargs modify --append rd.debug builds/${newBuildID}/${basearch}/*.iso -o \$iso
-                        cosa kola testiso -S --qemu-firmware=uefi --scenarios iso-live-login,iso-as-disk --qemu-iso \$iso --output-dir tmp/kola-testiso-uefi/rd-debug
-                        """)
                         shwrap("cosa kola testiso -S --qemu-firmware=uefi --scenarios iso-live-login,iso-as-disk --output-dir tmp/kola-testiso-uefi/insecure")
                         shwrap("cosa kola testiso -S --qemu-firmware=uefi-secure --scenarios iso-live-login,iso-as-disk --output-dir tmp/kola-testiso-uefi/secure")
                     }


### PR DESCRIPTION
```
commit fe2634dafe8202fdd01161c3ac8c8b5f564bb044
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Sep 6 23:38:48 2022 -0400

    jobs/build: warn when workaround for iso-live-login is detected
    
    For now we want to notify ourselves when this workaround is observed. It won't
    fail the build, just give us information. See
    https://github.com/coreos/fedora-coreos-tracker/issues/1233

commit 8f4ada8c3c9774c1ad105e55179e3bb362e3032f
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Sep 6 22:42:43 2022 -0400

    jobs/build: drop the extra testiso with rd.debug test
    
    It turns out that passing in `--qemu-iso` to `kola testiso` doesn't
    work. See https://github.com/coreos/coreos-assembler/issues/3071
    
    This effectively reverts 34c0d2c.

```