### PR TITLE
streams: re-enable next-devel

### DIFF
--- a/next-devel/badge.json
+++ b/next-devel/badge.json
@@ -2,6 +2,6 @@
     "schemaVersion": 1,
     "style": "for-the-badge",
     "label": "next-devel",
-    "message": "closed",
-    "color": "lightgrey"
+    "message": "open",
+    "color": "green"
 }

--- a/next-devel/status.json
+++ b/next-devel/status.json
@@ -1,3 +1,3 @@
 {
-    "enabled": false
+    "enabled": true
 }

--- a/streams.groovy
+++ b/streams.groovy
@@ -2,7 +2,7 @@
 
 // Contains 'next-devel' when that stream is enabled.
 // Automatically edited by next-devel/manage.py.
-next_devel = []
+next_devel = ['next-devel']
 
 production = ['testing', 'stable', 'next']
 development = ['testing-devel'] + next_devel


### PR DESCRIPTION
The Fedora Linux 37 beta is next week so `next-devel` and `next` are moving over to Fedora 37 content. Re-enable `next-devel` to allow it to differ from `testing-devel`.