### PR TITLE
Add and use generic-webhook-trigger plugin

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -252,6 +252,25 @@ uuidgen -r > secret
 oc create secret generic github-webhook-shared-secret --from-file=secret
 ```
 
+NOTE: the secret will be used again when setting up the generic webhooks in the next section.
+
+### [PROD] Setup webhooks for the Generic webhook plugin
+
+Add a new webhook to the following repos:
+
+- [`coreos/fedora-coreos-config`](https://github.com/coreos/fedora-coreos-config.git) for the `build-fcos-buildroot` job.
+- [`coreos/coreos-assembler`](https://github.com/coreos/coreos-assembler.git) for the `build-cosa` job.
+
+In this case we'll re-use the GitHub webhook shared secret text that
+was created in the previous section. Add a webhook for each repo that
+follows:
+
+- Payload URL: `https://<JENKINS_URL>/generic-webhook-trigger/invoke?token=<JOB>`
+    - replace `<JENKINS_URL>` with the URL of the jenkins instance
+    - replace `<JOB>` with `build-fcos-buildroot` or `build-cosa` based on the repo you are adding the webhook to.
+- Content Type: `application/json`
+- Secret: Use the secret text from the GitHub webhook shared secret above
+
 ### [PROD] Create quay.io FCOS image push secret
 
 This secret is used to push the resulting OCI image to Quay.io

--- a/jenkins/config/generic-webhook-trigger.yaml
+++ b/jenkins/config/generic-webhook-trigger.yaml
@@ -1,0 +1,9 @@
+# Re-uses the secret from the Github Webhook plugin
+unclassified:
+  whitelist:
+    enabled: true
+    whitelistItems:
+    - hmacAlgorithm: HmacSHA256
+      hmacCredentialId: github-webhook-shared-secret
+      hmacEnabled: true
+      hmacHeader: x-hub-signature-256

--- a/jenkins/controller/plugins.txt
+++ b/jenkins/controller/plugins.txt
@@ -1,3 +1,13 @@
+# This file controls the plugins that get installed in Jenkins
+# To get a list of these from a running jenkins instance go to
+# <jenkins_url>/pluginManager/api/json?depth=1 in your web browser
+# (with authentication) then save that json output and filter it
+# with:
+#
+# cat json.json \
+#   | jq -r '.plugins[] | "\(.shortName):\(.version)"' | sort > plugins.txt
+#
+# Inspired by https://stackoverflow.com/a/52836951
 github-oauth:0.38
 configuration-as-code:1429.v09b_044a_c93de
 slack:608.v19e3b_44b_b_9ff

--- a/jenkins/controller/plugins.txt
+++ b/jenkins/controller/plugins.txt
@@ -14,3 +14,4 @@ ssh-credentials:277.v95c2fec1c047
 pipeline-github:2.8-138.d766e30bb08b
 pipeline-utility-steps:2.12.1
 kubernetes-credentials-provider:0.20
+generic-webhook-trigger:1.84


### PR DESCRIPTION
```
commit 8cbed1420b2192549bb298754015105c97c578cf
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sun Sep 11 09:06:10 2022 -0400

    HACKING: document generic webhook setup in GitHub
    
    This explains what values to use when setting up a webhook in GitHub
    for the jobs that are using the Generic Webhook Trigger plugin.

commit 9101e2b66d8ab797a5ede43796550112da6f25cd
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sat Sep 10 11:05:43 2022 -0400

    jobs/build-cosa: use the Generic Webhook Trigger plugin
    
    This plugin allows us to get the exact branch name from the webhook
    payload itself and use that when doing a build. The githubPush()
    method we were using previously would only trigger the job to happen
    but then the job could select any possible branch that hadn't been
    built recently to build. This gives us tighter control.

commit ccff24bd27099a969e4954faf4b94a7f7b1c1df4
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Sep 5 22:08:29 2022 -0400

    jobs/build-fcos-buildroot: use Generic Webhook Trigger plugin
    
    This plugin allows us to only trigger the job when something in
    the ci/buildroot/ subdirectory has changed, which will cut down
    on wasted resources.

commit 6ca0ee5b59ca2e07793919f704a432b7f7098877
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sat Sep 10 14:17:56 2022 -0400

    plugins: add header with some comments
    
    It explains what the file is and how to generate
    a similar verion of it from a running cluster.

commit c575e8e69f4298ea5a9fff546b7c79c52b3b538d
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sat Sep 10 14:09:33 2022 -0400

    plugins: add generic-webhook-trigger plugin
    
    This plugin will allow us tighter grain control over what branches
    get built against. It also allows us more filtering. For example,
    if we only want to trigger a job when a subdirectory in a repo is
    changed.
```
