### PR TITLE
jobs/release: move oscontainer to quay.io/fedora/fedora-coreos

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -271,12 +271,12 @@ follows:
 - Content Type: `application/json`
 - Secret: Use the secret text from the GitHub webhook shared secret above
 
-### [PROD] Create quay.io FCOS image push secret
+### [PROD] Create quay.io Fedora image push secret
 
-This secret is used to push the resulting OCI image to Quay.io
+This secret is used to push the oscontainer and others to Quay.io
 
-1. Obtain the file `oscontainer-secret` from BitWarden.
-2. Run: `$ oc create secret generic oscontainer-secret --from-file=dockercfg=oscontainer-secret`.
+1. Obtain the file `fedora-push-registry-secret` from BitWarden.
+2. Run: `$ oc create secret generic fedora-push-registry-secret --from-file=dockercfg=fedora-push-registry-secret`.
 
 ### [PROD] Create quay.io COSA image push secret
 

--- a/jenkins/config/fedora-push-registry-secret.yaml
+++ b/jenkins/config/fedora-push-registry-secret.yaml
@@ -1,0 +1,13 @@
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+        - file:
+            scope: GLOBAL
+            fileName: fedora-push-registry-secret
+            id: fedora-push-registry-secret
+            # Secret must be base64-encoded. `${fedora-push-registry-secret/dockercfg}`
+            # expands to the *contents* of that file, not its path.
+            # See: https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables
+            secretBytes: "${base64:${fedora-push-registry-secret/dockercfg}}"
+            description: Push secret for quay.io/fedora repos

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -68,8 +68,8 @@ echo "Final podspec: ${pod}"
 def pod_label = "cosa-${UUID.randomUUID().toString()}"
 
 // Destination for OCI image push
-// TODO: Change this to quay.io/fedora/coreos per https://fedoraproject.org/wiki/Changes/OstreeNativeContainer
-def quay_registry = "quay.io/coreos-assembler/fcos"
+def quay_registry = "quay.io/fedora/fedora-coreos"
+def old_quay_registry = "quay.io/coreos-assembler/fcos"
 
 // Get the list of requested architectures to release
 def basearches = params.ARCHES.split() as Set
@@ -177,13 +177,22 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
 
         stage("Push OSContainer Manifest") {
             // Ship a manifest list containing all requested architectures.
-            withCredentials([file(credentialsId: 'oscontainer-secret', variable: 'OSCONTAINER_SECRET')]) {
+            withCredentials([file(credentialsId: 'fedora-push-registry-secret', variable: 'REGISTRY_SECRET')]) {
                 def arch_args = basearches.collect{"--arch ${it}"}.join(" ")
                 shwrap("""
-                cosa push-container-manifest --auth=\${OSCONTAINER_SECRET} \
+                cosa push-container-manifest --auth=\${REGISTRY_SECRET} \
                     --repo=${quay_registry} --tag=${params.STREAM} \
                     --artifact=ostree --metajsonname=base-oscontainer \
                     --build=${params.VERSION} ${arch_args}
+                """)
+            }
+            // For a period of time let's also mirror into the old location too
+            // Drop this after October 2022
+            withCredentials([file(credentialsId: 'oscontainer-secret', variable: 'REGISTRY_SECRET')]) {
+                shwrap("""
+                skopeo copy --all --authfile \$REGISTRY_SECRET \
+                    docker://${quay_registry}:${params.STREAM} \
+                    docker://${old_quay_registry}:${params.STREAM}
                 """)
             }
         }

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -165,6 +165,9 @@ objects:
           - name: cosa-push-registry-secret
             mountPath: /var/run/secrets/cosa-push-registry-secret
             readOnly: true
+          - name: fedora-push-registry-secret
+            mountPath: /var/run/secrets/fedora-push-registry-secret
+            readOnly: true
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         serviceAccountName: ${JENKINS_SERVICE_NAME}
@@ -219,6 +222,10 @@ objects:
         - name: cosa-push-registry-secret
           secret:
             secretName: cosa-push-registry-secret
+            optional: true
+        - name: fedora-push-registry-secret
+          secret:
+            secretName: fedora-push-registry-secret
             optional: true
     triggers:
     - imageChangeParams:


### PR DESCRIPTION
Also keep old location active for now.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1171