### PR TITLE
jobs/{build,build-arch}: drop src_config_ref

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,7 +23,6 @@ additional_arches: [aarch64, ppc64le, s390x]
 
 source_config:
   url: https://github.com/coreos/fedora-coreos-config
-  ref: testing-devel
 
 # remove to disable S3 uploads
 s3_bucket: fcos-builds

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -1,7 +1,7 @@
 import org.yaml.snakeyaml.Yaml;
 
 def pipeutils, pipecfg, official, uploading, jenkins_agent_image_tag
-def src_config_url, src_config_ref, s3_bucket
+def src_config_url, s3_bucket
 node {
     checkout scm
     pipeutils = load("utils.groovy")
@@ -11,7 +11,6 @@ node {
 
     def jenkinscfg = pipeutils.load_jenkins_config()
     src_config_url = pipecfg.source_config.url
-    src_config_ref = pipecfg.source_config.ref
     s3_bucket = pipecfg.s3_bucket
     jenkins_agent_image_tag = jenkinscfg['jenkins-agent-image-tag']
 
@@ -178,9 +177,6 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
 
         def local_builddir = "/srv/devel/streams/${params.STREAM}"
         def ref = params.STREAM
-        if (src_config_ref != "") {
-            ref = src_config_ref
-        }
         def fcos_config_commit
         if (params.FCOS_CONFIG_COMMIT) {
             fcos_config_commit = params.FCOS_CONFIG_COMMIT

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -1,7 +1,7 @@
 import org.yaml.snakeyaml.Yaml;
 
 def pipeutils, pipecfg, official, uploading, jenkins_agent_image_tag
-def src_config_url, src_config_ref, s3_bucket
+def src_config_url, s3_bucket
 def gcp_gs_bucket
 node {
     checkout scm
@@ -11,7 +11,6 @@ node {
 
     def jenkinscfg = pipeutils.load_jenkins_config()
     src_config_url = pipecfg.source_config.url
-    src_config_ref = pipecfg.source_config.ref
     s3_bucket = pipecfg.s3_bucket
     gcp_gs_bucket = pipecfg.clouds?.gcp?.bucket
     jenkins_agent_image_tag = jenkinscfg['jenkins-agent-image-tag']
@@ -171,9 +170,6 @@ lock(resource: "build-${params.STREAM}") {
 
         def local_builddir = "/srv/devel/streams/${params.STREAM}"
         def ref = params.STREAM
-        if (src_config_ref != "") {
-            ref = src_config_ref
-        }
         def fcos_config_commit = shwrapCapture("git ls-remote ${src_config_url} ${ref} | cut -d \$'\t' -f 1")
 
         stage('Init') {


### PR DESCRIPTION
Since it was set it was overriding the stream every time the `build` job would run. This is kind of confusing behavior. Let's get rid of it and just force people who are hacking to use the real branch names, but in their fork.