### PR TITLE
jobs/{build,build-arch}: drain AWS test account ID into config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,6 +28,10 @@ source_config:
 s3_bucket: fcos-builds
 
 clouds:
+  aws:
+    # Accounts to share newly created AMIs with
+    test_accounts:
+      - "013116697141"
   gcp:
     bucket: fedora-coreos-cloud-image-uploads
   azure:

--- a/config.yaml
+++ b/config.yaml
@@ -32,9 +32,9 @@ clouds:
     # Accounts to share newly created AMIs with
     test_accounts:
       - "013116697141"
-  gcp:
-    bucket: fedora-coreos-cloud-image-uploads
   azure:
     test_resource_group: fedora-coreos-testing
     test_storage_account: fedoracoreostesting
     test_storage_container: fedora-coreos-testing-image-blobs
+  gcp:
+    bucket: fedora-coreos-cloud-image-uploads

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -1,7 +1,7 @@
 import org.yaml.snakeyaml.Yaml;
 
 def pipeutils, pipecfg, official, uploading, jenkins_agent_image_tag
-def src_config_url, s3_bucket
+def src_config_url, s3_bucket, aws_test_accounts
 node {
     checkout scm
     pipeutils = load("utils.groovy")
@@ -14,6 +14,9 @@ node {
     s3_bucket = pipecfg.s3_bucket
     jenkins_agent_image_tag = jenkinscfg['jenkins-agent-image-tag']
 
+    // Extra AWS testing accounts to share images with
+    aws_test_accounts = pipecfg.clouds?.aws?.test_accounts
+
     official = pipeutils.isOfficial()
     if (official) {
         echo "Running in official (prod) mode."
@@ -21,9 +24,6 @@ node {
         echo "Running in unofficial pipeline on ${env.JENKINS_URL}."
     }
 }
-
-// Share with the Fedora testing account so we can test it afterwards
-FEDORA_AWS_TESTING_USER_ID = "013116697141"
 
 // Base URL through which to download artifacts
 BUILDS_BASE_HTTP_URL = "https://builds.coreos.fedoraproject.org/prod/streams"
@@ -516,14 +516,14 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
                 // XXX: use the temporary 'ami-import' subpath for now; once we
                 // also publish vmdks, we could make this more efficient by
                 // uploading first, and then pointing ore at our uploaded vmdk
+                def grant_user_args = aws_test_accounts.collect{"--grant-user ${it}"}.join(" ")
                 shwrap("""
                 cosa buildextend-aws \
                     --upload \
                     --arch=${basearch} \
                     --build=${newBuildID} \
-                    --region=us-east-1 \
+                    --region=us-east-1 ${grant_user_args} \
                     --bucket s3://${s3_bucket}/ami-import \
-                    --grant-user ${FEDORA_AWS_TESTING_USER_ID} \
                     --credentials-file=\${AWS_FCOS_BUILDS_BOT_CONFIG}
                 """)
             }


### PR DESCRIPTION
No need to hard code this into the jobs any longer. Let's drain this value into the config itself.