### PR TITLE
jobs/build-{development,mechanical}: fix variable usage

### DIFF
--- a/jobs/build-development.Jenkinsfile
+++ b/jobs/build-development.Jenkinsfile
@@ -23,7 +23,7 @@ node {
     )
 
     stream = pipeutils.stream_from_branch(change.GIT_BRANCH)
-    if (stream in streams.development) {
+    if (stream in development_streams) {
         build job: 'build', wait: false, parameters: [
           string(name: 'STREAM', value: stream)
         ]

--- a/jobs/build-mechanical.Jenkinsfile
+++ b/jobs/build-mechanical.Jenkinsfile
@@ -27,7 +27,7 @@ node {
 
     if (pipeutils.triggered_by_push()) {
         stream = pipeutils.stream_from_branch(change.GIT_BRANCH)
-        if (stream in streams.mechanical) {
+        if (stream in mechanical_streams) {
             build job: 'build', wait: false, parameters: [
               string(name: 'STREAM', value: stream)
             ]


### PR DESCRIPTION
streams.development and streams.mechanical went away. Let's use the variable that was intended for us to use for this.

Fixes 314f02f.