### PR TITLE
support older COSA versions for multi-arch building

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,6 @@
+# this is an FCOS pipeline
+type: fcos
+
 streams:
     stable:
       type: production

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -144,10 +144,12 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
         def basearch = params.ARCH
 
         // If we are using the image stream (the default) then just translate
-        // that into 'quay.io/coreos-assembler/coreos-assembler:main'.
+        // that into a quay registry equivalent (the multi-arch builders can't
+        // run containers from image streams).
         def image = params.COREOS_ASSEMBLER_IMAGE
-        if (image == "coreos-assembler:main") {
-            image = "quay.io/coreos-assembler/coreos-assembler:main"
+        if (image.startsWith("coreos-assembler:")) {
+            image = image.replaceAll("coreos-assembler:",
+                                     "quay.io/coreos-assembler/coreos-assembler:")
         }
 
         try { timeout(time: 240, unit: 'MINUTES') {

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -2,10 +2,12 @@ import org.yaml.snakeyaml.Yaml;
 
 def pipeutils, pipecfg, official, uploading, jenkins_agent_image_tag
 def src_config_url, s3_bucket, aws_test_accounts
+def pipetype
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
+    pipetype = pipecfg.type
     pod = readFile(file: "manifests/pod.yaml")
 
 
@@ -485,7 +487,9 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
             if (basearch == "aarch64") {
                 stage('AWS') {
                     shwrap("""
-                    echo 'ZGlmZiAtLWdpdCBhL3NyYy9nZi1zZXQtcGxhdGZvcm0gYi9zcmMvZ2Ytc2V0LXBsYXRmb3JtCmluZGV4IDNiMWM1YWUzMS4uZGY1ZTBmOWQ3IDEwMDc1NQotLS0gYS9zcmMvZ2Ytc2V0LXBsYXRmb3JtCisrKyBiL3NyYy9nZi1zZXQtcGxhdGZvcm0KQEAgLTU5LDcgKzU5LDEzIEBAIGJsc2NmZ19wYXRoPSQoY29yZW9zX2dmIGdsb2ItZXhwYW5kIC9ib290L2xvYWRlci9lbnRyaWVzL29zdHJlZS0qLmNvbmYpCiBjb3Jlb3NfZ2YgZG93bmxvYWQgIiR7YmxzY2ZnX3BhdGh9IiAiJHt0bXBkfSIvYmxzLmNvbmYKICMgUmVtb3ZlIGFueSBwbGF0Zm9ybWlkIGN1cnJlbnRseSB0aGVyZQogc2VkIC1pIC1lICdzLCBpZ25pdGlvbi5wbGF0Zm9ybS5pZD1bYS16QS1aMC05XSosLGcnICIke3RtcGR9Ii9ibHMuY29uZgotc2VkIC1pIC1lICcvXm9wdGlvbnMgLyBzLCQsIGlnbml0aW9uLnBsYXRmb3JtLmlkPSciJHtwbGF0Zm9ybWlkfSInLCcgIiR7dG1wZH0iL2Jscy5jb25mCitpZiBbICIkKGNvcmVvc19nZiBleGlzdHMgL2Jvb3QvY29yZW9zL3BsYXRmb3Jtcy5qc29uKSIgIT0gInRydWUiIC1hICIke3BsYXRmb3JtaWR9IiA9PSAnYXdzJyBdOyB0aGVuCisgICAgIyBPdXIgcGxhdGZvcm0gaXMgQVdTIGFuZCB3ZSBzdGlsbCBuZWVkIHRoZSBjb25zb2xlPXR0eVMwIGhhY2sgZm9yIHRoZSBsZWdhY3kKKyAgICAjIChubyBwbGF0Zm9ybXMueWFtbCkgcGF0aC4KKyAgICBzZWQgLWkgLWUgJ3N8Xlwob3B0aW9ucyAuKlwpfFwxIGlnbml0aW9uLnBsYXRmb3JtLmlkPSciJHtwbGF0Zm9ybWlkfSInIGNvbnNvbGU9dHR5UzAsMTE1MjAwbjh8JyAiJHt0bXBkfSIvYmxzLmNvbmYKK2Vsc2UKKyAgICBzZWQgLWkgLWUgJy9eb3B0aW9ucyAvIHMsJCwgaWduaXRpb24ucGxhdGZvcm0uaWQ9JyIke3BsYXRmb3JtaWR9IicsJyAiJHt0bXBkfSIvYmxzLmNvbmYKK2ZpCiBpZiBbIC1uICIkcmVtb3ZlX2thcmdzIiBdOyB0aGVuCiAgICAgIyBSZW1vdmUgZXhpc3RpbmcgcWVtdS1zcGVjaWZpYyBrYXJncwogICAgIHNlZCAtaSAtZSAnL15vcHRpb25zIC8gc0AgJyIke3JlbW92ZV9rYXJnc30iJ0BAJyAiJHt0bXBkfSIvYmxzLmNvbmYKCg==' | base64 --decode | cosa shell -- sudo patch /usr/lib/coreos-assembler/gf-set-platform
+                    if [ "${pipetype}" == "fcos" ]; then
+                        echo 'ZGlmZiAtLWdpdCBhL3NyYy9nZi1zZXQtcGxhdGZvcm0gYi9zcmMvZ2Ytc2V0LXBsYXRmb3JtCmluZGV4IDNiMWM1YWUzMS4uZGY1ZTBmOWQ3IDEwMDc1NQotLS0gYS9zcmMvZ2Ytc2V0LXBsYXRmb3JtCisrKyBiL3NyYy9nZi1zZXQtcGxhdGZvcm0KQEAgLTU5LDcgKzU5LDEzIEBAIGJsc2NmZ19wYXRoPSQoY29yZW9zX2dmIGdsb2ItZXhwYW5kIC9ib290L2xvYWRlci9lbnRyaWVzL29zdHJlZS0qLmNvbmYpCiBjb3Jlb3NfZ2YgZG93bmxvYWQgIiR7YmxzY2ZnX3BhdGh9IiAiJHt0bXBkfSIvYmxzLmNvbmYKICMgUmVtb3ZlIGFueSBwbGF0Zm9ybWlkIGN1cnJlbnRseSB0aGVyZQogc2VkIC1pIC1lICdzLCBpZ25pdGlvbi5wbGF0Zm9ybS5pZD1bYS16QS1aMC05XSosLGcnICIke3RtcGR9Ii9ibHMuY29uZgotc2VkIC1pIC1lICcvXm9wdGlvbnMgLyBzLCQsIGlnbml0aW9uLnBsYXRmb3JtLmlkPSciJHtwbGF0Zm9ybWlkfSInLCcgIiR7dG1wZH0iL2Jscy5jb25mCitpZiBbICIkKGNvcmVvc19nZiBleGlzdHMgL2Jvb3QvY29yZW9zL3BsYXRmb3Jtcy5qc29uKSIgIT0gInRydWUiIC1hICIke3BsYXRmb3JtaWR9IiA9PSAnYXdzJyBdOyB0aGVuCisgICAgIyBPdXIgcGxhdGZvcm0gaXMgQVdTIGFuZCB3ZSBzdGlsbCBuZWVkIHRoZSBjb25zb2xlPXR0eVMwIGhhY2sgZm9yIHRoZSBsZWdhY3kKKyAgICAjIChubyBwbGF0Zm9ybXMueWFtbCkgcGF0aC4KKyAgICBzZWQgLWkgLWUgJ3N8Xlwob3B0aW9ucyAuKlwpfFwxIGlnbml0aW9uLnBsYXRmb3JtLmlkPSciJHtwbGF0Zm9ybWlkfSInIGNvbnNvbGU9dHR5UzAsMTE1MjAwbjh8JyAiJHt0bXBkfSIvYmxzLmNvbmYKK2Vsc2UKKyAgICBzZWQgLWkgLWUgJy9eb3B0aW9ucyAvIHMsJCwgaWduaXRpb24ucGxhdGZvcm0uaWQ9JyIke3BsYXRmb3JtaWR9IicsJyAiJHt0bXBkfSIvYmxzLmNvbmYKK2ZpCiBpZiBbIC1uICIkcmVtb3ZlX2thcmdzIiBdOyB0aGVuCiAgICAgIyBSZW1vdmUgZXhpc3RpbmcgcWVtdS1zcGVjaWZpYyBrYXJncwogICAgIHNlZCAtaSAtZSAnL15vcHRpb25zIC8gc0AgJyIke3JlbW92ZV9rYXJnc30iJ0BAJyAiJHt0bXBkfSIvYmxzLmNvbmYKCg==' | base64 --decode | cosa shell -- sudo patch /usr/lib/coreos-assembler/gf-set-platform
+                    fi
                     cosa buildextend-aws
                     """)
                 }


### PR DESCRIPTION
```
commit a75cdfdac686da8e1058c4e0d3d75edbcf336064
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Sep 16 09:51:18 2022 -0400

    jobs/build-arch: only patch gf-set-platform in the FCOS pipeline
    
    This patch is a temporary hack, but it's still around for now and
    we need to start supporting the RHCOS pipeline. Let's conditionalize
    the patch on if we are operating on the FCOS pipeline.

commit d5563b7cf57bfb1b29b49717fca3f672ca303708
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Sep 16 09:46:08 2022 -0400

    config: add toplevel type: config setting
    
    This will allow us to use this information in the pipeline to perform
    certain actions or not.

commit adc6f865e1a7348773c0b541888da4c18fbd081d
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Sep 15 15:39:35 2022 -0400

    jobs/build-arch: bridge `cosa remote-session` to older RHCOS releases
    
    We recently did some golang migration [1] and happened to add the
    `cosa remote-session` pieces [2] after that migration. This makes
    it not easy to backport to ther branches. For a period of time
    let's use the latest COSA for our COSA pod for multi-arch builds
    instead of the versioned COSA. We will still use the versioned COSA
    on the remote so the actual building will happened with the correctly
    versioned COSA (substituted below and passed as an argument to
    `cosa remote-session create --image=`).
    
    [1] https://github.com/coreos/coreos-assembler/pull/2919
    [2] https://github.com/coreos/coreos-assembler/pull/2979

commit 6fad0526e315296556e7e542ff271ee1134d2780
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Sep 15 15:35:56 2022 -0400

    jobs/build-arch: support tagged COSA image streams
    
    We need to support more than just the "coreos-assembler:main" image stream.
    Add in a translation layer for image streams that are from the tagged
    rhcos-4.X branches.

```