### PR TITLE
More removal of FCOS specific naming

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -98,7 +98,7 @@ accepts an AWS config file.
 Then create the secret in OpenShift:
 
 ```
-oc create secret generic aws-fcos-builds-bot-config --from-file=dir
+oc create secret generic aws-build-upload-config --from-file=dir
 ```
 
 We also have a second AWS config that can be used for running kola
@@ -114,7 +114,7 @@ aws_access_key_id=keyid
 aws_secret_access_key=key
 EOF
 
-oc create secret generic aws-fcos-kola-bot-config --from-file=config=/path/to/kola-secret
+oc create secret generic aws-kola-tests-config --from-file=config=/path/to/kola-secret
 ```
 
 NOTE: For the prod pipeline these secrets can be found in BitWarden

--- a/jenkins/config/aws.yaml
+++ b/jenkins/config/aws.yaml
@@ -4,7 +4,7 @@ credentials:
       - credentials:
         - aws:
             scope: GLOBAL
-            id: aws-fcos-builds-bot
-            accessKey: ${aws-fcos-builds-bot-config/accessKey}
-            secretKey: ${aws-fcos-builds-bot-config/secretKey}
-            description: AWS fcos-builds-bot credentials
+            id: aws-build-upload-config
+            accessKey: ${aws-build-upload-config/accessKey}
+            secretKey: ${aws-build-upload-config/secretKey}
+            description: AWS build upload credentials

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -528,27 +528,27 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
             // reset for the next batch of independent tasks
             parallelruns = [:]
 
-        // Key off of uploading: i.e. if we're configured to upload artifacts
-        // to S3, we also take that to mean we should upload an AMI. We could
-        // split this into two separate developer knobs in the future.
-        if (basearch =="aarch64" && uploading) {
-            parallelruns['Upload AWS'] = {
-                // XXX: hardcode us-east-1 for now
-                // XXX: use the temporary 'ami-import' subpath for now; once we
-                // also publish vmdks, we could make this more efficient by
-                // uploading first, and then pointing ore at our uploaded vmdk
-                def grant_user_args = aws_test_accounts.collect{"--grant-user ${it}"}.join(" ")
-                shwrap("""
-                cosa buildextend-aws \
-                    --upload \
-                    --arch=${basearch} \
-                    --build=${newBuildID} \
-                    --region=us-east-1 ${grant_user_args} \
-                    --bucket s3://${s3_bucket}/ami-import \
-                    --credentials-file=\${AWS_FCOS_BUILDS_BOT_CONFIG}
-                """)
+            // Key off of uploading: i.e. if we're configured to upload artifacts
+            // to S3, we also take that to mean we should upload an AMI. We could
+            // split this into two separate developer knobs in the future.
+            if (basearch =="aarch64" && uploading) {
+                parallelruns['Upload AWS'] = {
+                    // XXX: hardcode us-east-1 for now
+                    // XXX: use the temporary 'ami-import' subpath for now; once we
+                    // also publish vmdks, we could make this more efficient by
+                    // uploading first, and then pointing ore at our uploaded vmdk
+                    def grant_user_args = aws_test_accounts.collect{"--grant-user ${it}"}.join(" ")
+                    shwrap("""
+                    cosa buildextend-aws \
+                        --upload \
+                        --arch=${basearch} \
+                        --build=${newBuildID} \
+                        --region=us-east-1 ${grant_user_args} \
+                        --bucket s3://${s3_bucket}/ami-import \
+                        --credentials-file=\${AWS_FCOS_BUILDS_BOT_CONFIG}
+                    """)
+                }
             }
-        }
 
             // process this batch
             parallel parallelruns

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -67,7 +67,7 @@ properties([
       booleanParam(name: 'NO_UPLOAD',
                    defaultValue: false,
                    description: 'Do not upload results to S3; for debugging purposes.'),
-      string(name: 'FCOS_CONFIG_COMMIT',
+      string(name: 'SRC_CONFIG_COMMIT',
              description: 'The exact config repo git commit to build against',
              defaultValue: '',
              trim: true),
@@ -196,11 +196,11 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
 
         def local_builddir = "/srv/devel/streams/${params.STREAM}"
         def ref = params.STREAM
-        def fcos_config_commit
-        if (params.FCOS_CONFIG_COMMIT) {
-            fcos_config_commit = params.FCOS_CONFIG_COMMIT
+        def src_config_commit
+        if (params.SRC_CONFIG_COMMIT) {
+            src_config_commit = params.SRC_CONFIG_COMMIT
         } else {
-            fcos_config_commit = shwrapCapture("git ls-remote ${src_config_url} ${ref} | cut -d \$'\t' -f 1")
+            src_config_commit = shwrapCapture("git ls-remote ${src_config_url} ${ref} | cut -d \$'\t' -f 1")
         }
 
 
@@ -237,7 +237,7 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
             # sync over the send-ostree-import-request.py from the automation repo
             cosa remote-session sync {,:}/var/tmp/fcos-releng/coreos-ostree-importer/send-ostree-import-request.py
 
-            cosa init --force --branch ${ref} --commit=${fcos_config_commit} ${src_config_url}
+            cosa init --force --branch ${ref} --commit=${src_config_commit} ${src_config_url}
             """)
 
         }
@@ -637,7 +637,7 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
                         string(name: 'VERSION', value: newBuildID),
                         string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
                         string(name: 'ARCH', value: basearch),
-                        string(name: 'FCOS_CONFIG_COMMIT', value: fcos_config_commit)
+                        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
                     ]
                 }
             }
@@ -650,7 +650,7 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
                         string(name: 'VERSION', value: newBuildID),
                         string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
                         string(name: 'ARCH', value: basearch),
-                        string(name: 'FCOS_CONFIG_COMMIT', value: fcos_config_commit)
+                        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
                     ]
                 }
             }

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -170,14 +170,14 @@ lock(resource: "build-${params.STREAM}") {
 
         def local_builddir = "/srv/devel/streams/${params.STREAM}"
         def ref = params.STREAM
-        def fcos_config_commit = shwrapCapture("git ls-remote ${src_config_url} ${ref} | cut -d \$'\t' -f 1")
+        def src_config_commit = shwrapCapture("git ls-remote ${src_config_url} ${ref} | cut -d \$'\t' -f 1")
 
         stage('Init') {
             // for now, just use the PVC to keep cache.qcow2 in a stream-specific dir
             def cache_img = "/srv/prod/${params.STREAM}/cache.qcow2"
 
             shwrap("""
-            cosa init --force --branch ${ref} --commit=${fcos_config_commit} ${src_config_url}
+            cosa init --force --branch ${ref} --commit=${src_config_commit} ${src_config_url}
             mkdir -p \$(dirname ${cache_img})
             ln -s ${cache_img} cache/cache.qcow2
             """)
@@ -441,7 +441,7 @@ lock(resource: "build-${params.STREAM}") {
                         booleanParam(name: 'FORCE', value: true),
                         booleanParam(name: 'MINIMAL', value: params.MINIMAL),
                         booleanParam(name: 'ALLOW_KOLA_UPGRADE_FAILURE', value: params.ALLOW_KOLA_UPGRADE_FAILURE),
-                        string(name: 'FCOS_CONFIG_COMMIT', value: fcos_config_commit),
+                        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit),
                         string(name: 'COREOS_ASSEMBLER_IMAGE', value: params.COREOS_ASSEMBLER_IMAGE),
                         string(name: 'STREAM', value: params.STREAM),
                         string(name: 'VERSION', value: newBuildID),
@@ -657,7 +657,7 @@ lock(resource: "build-${params.STREAM}") {
                     string(name: 'VERSION', value: newBuildID),
                     string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
                     string(name: 'ARCH', value: basearch),
-                    string(name: 'FCOS_CONFIG_COMMIT', value: fcos_config_commit)
+                    string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
                 ]
             }
           // XXX: This is failing right now. Disable until the New
@@ -668,7 +668,7 @@ lock(resource: "build-${params.STREAM}") {
           //        string(name: 'STREAM', value: params.STREAM),
           //        string(name: 'VERSION', value: newBuildID),
           //        string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-          //        string(name: 'FCOS_CONFIG_COMMIT', value: fcos_config_commit)
+          //        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
           //    ]
           //}
         }
@@ -680,7 +680,7 @@ lock(resource: "build-${params.STREAM}") {
                     string(name: 'STREAM', value: params.STREAM),
                     string(name: 'VERSION', value: newBuildID),
                     string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-                    string(name: 'FCOS_CONFIG_COMMIT', value: fcos_config_commit)
+                    string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
                 ]
             }
         }
@@ -692,7 +692,7 @@ lock(resource: "build-${params.STREAM}") {
                     string(name: 'STREAM', value: params.STREAM),
                     string(name: 'VERSION', value: newBuildID),
                     string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-                    string(name: 'FCOS_CONFIG_COMMIT', value: fcos_config_commit)
+                    string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
                 ]
             }
         }
@@ -705,7 +705,7 @@ lock(resource: "build-${params.STREAM}") {
                     string(name: 'VERSION', value: newBuildID),
                     string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
                     string(name: 'ARCH', value: basearch),
-                    string(name: 'FCOS_CONFIG_COMMIT', value: fcos_config_commit)
+                    string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
                 ]
             }
         }

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -76,8 +76,8 @@ try { lock(resource: "bump-${params.STREAM}") { timeout(time: 120, unit: 'MINUTE
     def branch = params.STREAM
     def forceTimestamp = false
     def haveChanges = false
-    def fcos_config_commit = shwrapCapture("git ls-remote https://github.com/${repo} ${branch} | cut -d \$'\t' -f 1")
-    shwrap("cosa init --branch ${branch} --commit=${fcos_config_commit} https://github.com/${repo}")
+    def src_config_commit = shwrapCapture("git ls-remote https://github.com/${repo} ${branch} | cut -d \$'\t' -f 1")
+    shwrap("cosa init --branch ${branch} --commit=${src_config_commit} https://github.com/${repo}")
 
     def lockfile, pkgChecksum, pkgTimestamp
     def skip_tests_arches = params.SKIP_TESTS_ARCHES.split()
@@ -108,7 +108,7 @@ try { lock(resource: "bump-${params.STREAM}") { timeout(time: 120, unit: 'MINUTE
                         shwrapCapture("cosa remote-session create --image ${image} --expiration 4h")
                     withEnv(["COREOS_ASSEMBLER_REMOTE_SESSION=${archinfo[arch]['session']}"]) {
                         shwrap("""
-                        cosa init --branch ${branch} --commit=${fcos_config_commit} https://github.com/${repo}
+                        cosa init --branch ${branch} --commit=${src_config_commit} https://github.com/${repo}
                         """)
                     }
                 }

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -55,7 +55,7 @@ if (s3_stream_dir == "") {
 try { timeout(time: 90, unit: 'MINUTES') {
     cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
             memory: "256Mi", kvm: false,
-            secrets: ["aws-fcos-builds-bot-config", "aws-fcos-kola-bot-config"]) {
+            secrets: ["aws-build-upload-config", "aws-kola-tests-config"]) {
 
         stage('Fetch Metadata') {
             def commitopt = ''
@@ -63,7 +63,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
                 commitopt = "--commit=${params.SRC_CONFIG_COMMIT}"
             }
             shwrap("""
-            export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}/config
+            export AWS_CONFIG_FILE=\${AWS_BUILD_UPLOAD_CONFIG}/config
             cosa init --branch ${params.STREAM} ${commitopt} https://github.com/coreos/fedora-coreos-config
             cosa buildfetch --artifact=ostree --build=${params.VERSION} \
                 --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds
@@ -75,7 +75,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
                  extraArgs: params.KOLA_TESTS,
                  skipBasicScenarios: true,
                  platformArgs: """-p=aws \
-                    --aws-credentials-file=\${AWS_FCOS_KOLA_BOT_CONFIG}/config \
+                    --aws-credentials-file=\${AWS_KOLA_TESTS_CONFIG}/config \
                     --aws-region=us-east-1""")
 
         if (params.ARCH == "x86_64") {
@@ -92,7 +92,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
                          skipBasicScenarios: true,
                          marker: "kola-m4",
                          platformArgs: """-p=aws \
-                            --aws-credentials-file=\${AWS_FCOS_KOLA_BOT_CONFIG}/config \
+                            --aws-credentials-file=\${AWS_KOLA_TESTS_CONFIG}/config \
                             --aws-region=us-east-1 --aws-type=m4.large""")
             }, m6i: {
                 // https://github.com/coreos/fedora-coreos-tracker/issues/1004
@@ -103,7 +103,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
                          skipBasicScenarios: true,
                          marker: "kola-m6i",
                          platformArgs: """-p=aws \
-                            --aws-credentials-file=\${AWS_FCOS_KOLA_BOT_CONFIG}/config \
+                            --aws-credentials-file=\${AWS_KOLA_TESTS_CONFIG}/config \
                             --aws-region=us-east-1 --aws-type=m6i.large""")
             }
         } else if (params.ARCH == "aarch64") {
@@ -118,7 +118,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
                         skipBasicScenarios: true,
                         marker: "kola-c7g",
                         platformArgs: """-p=aws \
-                        --aws-credentials-file=\${AWS_FCOS_KOLA_BOT_CONFIG}/config \
+                        --aws-credentials-file=\${AWS_KOLA_TESTS_CONFIG}/config \
                         --aws-region=us-east-1 --aws-type=c7g.xlarge""")
         }
 

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -1,8 +1,9 @@
-def pipeutils, pipecfg, official
+def pipeutils, pipecfg, s3_bucket, official
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
+    s3_bucket = pipecfg.s3_bucket
     official = pipeutils.isOfficial()
 }
 
@@ -48,7 +49,7 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSIO
 
 def s3_stream_dir = params.S3_STREAM_DIR
 if (s3_stream_dir == "") {
-    s3_stream_dir = "fcos-builds/prod/streams/${params.STREAM}"
+    s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
 }
 
 try { timeout(time: 90, unit: 'MINUTES') {

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -32,7 +32,7 @@ properties([
              description: 'Override the coreos-assembler image to use',
              defaultValue: "coreos-assembler:main",
              trim: true),
-      string(name: 'FCOS_CONFIG_COMMIT',
+      string(name: 'SRC_CONFIG_COMMIT',
              description: 'The exact config repo git commit to run tests against',
              defaultValue: '',
              trim: true),
@@ -58,8 +58,8 @@ try { timeout(time: 90, unit: 'MINUTES') {
 
         stage('Fetch Metadata') {
             def commitopt = ''
-            if (params.FCOS_CONFIG_COMMIT != '') {
-                commitopt = "--commit=${params.FCOS_CONFIG_COMMIT}"
+            if (params.SRC_CONFIG_COMMIT != '') {
+                commitopt = "--commit=${params.SRC_CONFIG_COMMIT}"
             }
             shwrap("""
             export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}/config

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -39,7 +39,7 @@ properties([
              description: 'Override the coreos-assembler image to use',
              defaultValue: "coreos-assembler:main",
              trim: true),
-      string(name: 'FCOS_CONFIG_COMMIT',
+      string(name: 'SRC_CONFIG_COMMIT',
              description: 'The exact config repo git commit to run tests against',
              defaultValue: '',
              trim: true),
@@ -74,8 +74,8 @@ lock(resource: "kola-azure-${params.ARCH}") {
             def azure_image_name, azure_image_filepath
             stage('Fetch Metadata/Image') {
                 def commitopt = ''
-                if (params.FCOS_CONFIG_COMMIT != '') {
-                    commitopt = "--commit=${params.FCOS_CONFIG_COMMIT}"
+                if (params.SRC_CONFIG_COMMIT != '') {
+                    commitopt = "--commit=${params.SRC_CONFIG_COMMIT}"
                 }
                 // Grab the metadata. Also grab the image so we can upload it.
                 shwrap("""

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -1,4 +1,4 @@
-def pipeutils, pipecfg, official
+def pipeutils, pipecfg, s3_bucket, official
 def azure_testing_resource_group
 def azure_testing_storage_account
 def azure_testing_storage_container
@@ -6,6 +6,7 @@ node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
+    s3_bucket = pipecfg.s3_bucket
     def jenkinscfg = pipeutils.load_jenkins_config()
     azure_testing_resource_group = pipecfg.clouds?.azure?.test_resource_group
     azure_testing_storage_account = pipecfg.clouds?.azure?.test_storage_account
@@ -63,7 +64,7 @@ lock(resource: "kola-azure-${params.ARCH}") {
 
     def s3_stream_dir = params.S3_STREAM_DIR
     if (s3_stream_dir == "") {
-        s3_stream_dir = "fcos-builds/prod/streams/${params.STREAM}"
+        s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
     }
 
     try { timeout(time: 75, unit: 'MINUTES') {

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -70,7 +70,7 @@ lock(resource: "kola-azure-${params.ARCH}") {
     try { timeout(time: 75, unit: 'MINUTES') {
         cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
                 memory: "256Mi", kvm: false,
-                secrets: ["aws-fcos-builds-bot-config", "azure-kola-tests-config"]) {
+                secrets: ["aws-build-upload-config", "azure-kola-tests-config"]) {
 
             def azure_image_name, azure_image_filepath
             stage('Fetch Metadata/Image') {
@@ -80,7 +80,7 @@ lock(resource: "kola-azure-${params.ARCH}") {
                 }
                 // Grab the metadata. Also grab the image so we can upload it.
                 shwrap("""
-                export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}/config
+                export AWS_CONFIG_FILE=\${AWS_BUILD_UPLOAD_CONFIG}/config
                 cosa init --branch ${params.STREAM} ${commitopt} https://github.com/coreos/fedora-coreos-config
                 cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
                     --url=s3://${s3_stream_dir}/builds --artifact=azure

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -1,8 +1,9 @@
-def pipeutils, pipecfg, official
+def pipeutils, pipecfg, s3_bucket, official
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
+    s3_bucket = pipecfg.s3_bucket
     official = pipeutils.isOfficial()
 }
 
@@ -48,7 +49,7 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSIO
 
 def s3_stream_dir = params.S3_STREAM_DIR
 if (s3_stream_dir == "") {
-    s3_stream_dir = "fcos-builds/prod/streams/${params.STREAM}"
+    s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
 }
 
 try { timeout(time: 30, unit: 'MINUTES') {

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -32,7 +32,7 @@ properties([
              description: 'Override the coreos-assembler image to use',
              defaultValue: "coreos-assembler:main",
              trim: true),
-      string(name: 'FCOS_CONFIG_COMMIT',
+      string(name: 'SRC_CONFIG_COMMIT',
              description: 'The exact config repo git commit to run tests against',
              defaultValue: '',
              trim: true),
@@ -59,8 +59,8 @@ try { timeout(time: 30, unit: 'MINUTES') {
         def gcp_project
         stage('Fetch Metadata') {
             def commitopt = ''
-            if (params.FCOS_CONFIG_COMMIT != '') {
-                commitopt = "--commit=${params.FCOS_CONFIG_COMMIT}"
+            if (params.SRC_CONFIG_COMMIT != '') {
+                commitopt = "--commit=${params.SRC_CONFIG_COMMIT}"
             }
             shwrap("""
             export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}/config

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -55,7 +55,7 @@ if (s3_stream_dir == "") {
 try { timeout(time: 30, unit: 'MINUTES') {
     cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
             memory: "256Mi", kvm: false,
-            secrets: ["aws-fcos-builds-bot-config", "gcp-kola-tests-config"]) {
+            secrets: ["aws-build-upload-config", "gcp-kola-tests-config"]) {
 
         def gcp_project
         stage('Fetch Metadata') {
@@ -64,7 +64,7 @@ try { timeout(time: 30, unit: 'MINUTES') {
                 commitopt = "--commit=${params.SRC_CONFIG_COMMIT}"
             }
             shwrap("""
-            export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}/config
+            export AWS_CONFIG_FILE=\${AWS_BUILD_UPLOAD_CONFIG}/config
             cosa init --branch ${params.STREAM} ${commitopt} https://github.com/coreos/fedora-coreos-config
             cosa buildfetch --artifact=ostree --build=${params.VERSION} \
                 --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -28,7 +28,7 @@ properties([
              description: 'Override the coreos-assembler image to use',
              defaultValue: "coreos-assembler:main",
              trim: true),
-      string(name: 'FCOS_CONFIG_COMMIT',
+      string(name: 'SRC_CONFIG_COMMIT',
              description: 'The exact config repo git commit to run tests against',
              defaultValue: '',
              trim: true),
@@ -54,8 +54,8 @@ try { timeout(time: 60, unit: 'MINUTES') {
 
         stage('Fetch Metadata') {
             def commitopt = ''
-            if (params.FCOS_CONFIG_COMMIT != '') {
-                commitopt = "--commit=${params.FCOS_CONFIG_COMMIT}"
+            if (params.SRC_CONFIG_COMMIT != '') {
+                commitopt = "--commit=${params.SRC_CONFIG_COMMIT}"
             }
             shwrap("""
             export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}/config

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -1,8 +1,9 @@
-def pipeutils, pipecfg, official
+def pipeutils, pipecfg, s3_bucket, official
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
+    s3_bucket = pipecfg.s3_bucket
     official = pipeutils.isOfficial()
 }
 
@@ -44,7 +45,7 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSIO
 
 def s3_stream_dir = params.S3_STREAM_DIR
 if (s3_stream_dir == "") {
-    s3_stream_dir = "fcos-builds/prod/streams/${params.STREAM}"
+    s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
 }
 
 try { timeout(time: 60, unit: 'MINUTES') {

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -51,7 +51,7 @@ if (s3_stream_dir == "") {
 try { timeout(time: 60, unit: 'MINUTES') {
     cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
             memory: "256Mi", kvm: false,
-            secrets: ["aws-fcos-builds-bot-config", "aws-fcos-kola-bot-config"]) {
+            secrets: ["aws-build-upload-config", "aws-kola-tests-config"]) {
 
         stage('Fetch Metadata') {
             def commitopt = ''
@@ -59,7 +59,7 @@ try { timeout(time: 60, unit: 'MINUTES') {
                 commitopt = "--commit=${params.SRC_CONFIG_COMMIT}"
             }
             shwrap("""
-            export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}/config
+            export AWS_CONFIG_FILE=\${AWS_BUILD_UPLOAD_CONFIG}/config
             cosa init --branch ${params.STREAM} ${commitopt} https://github.com/coreos/fedora-coreos-config
             cosa buildfetch --build=${params.VERSION} \
                 --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds
@@ -74,7 +74,7 @@ try { timeout(time: 60, unit: 'MINUTES') {
                  skipUpgrade: true,
                  skipBasicScenarios: true,
                  platformArgs: """-p=aws \
-                    --aws-credentials-file=\${AWS_FCOS_KOLA_BOT_CONFIG}/config \
+                    --aws-credentials-file=\${AWS_KOLA_TESTS_CONFIG}/config \
                     --aws-region=us-east-1""")
 
         currentBuild.result = 'SUCCESS'

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -64,7 +64,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
     try { timeout(time: 90, unit: 'MINUTES') {
         cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
                 memory: "256Mi", kvm: false,
-                secrets: ["aws-fcos-builds-bot-config", "openstack-kola-tests-config"]) {
+                secrets: ["aws-build-upload-config", "openstack-kola-tests-config"]) {
 
             def openstack_image_name, openstack_image_filepath
             stage('Fetch Metadata/Image') {
@@ -74,7 +74,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
                 }
                 // Grab the metadata. Also grab the image so we can upload it.
                 shwrap("""
-                export AWS_CONFIG_FILE=\${AWS_FCOS_BUILDS_BOT_CONFIG}/config
+                export AWS_CONFIG_FILE=\${AWS_BUILD_UPLOAD_CONFIG}/config
                 cosa init --branch ${params.STREAM} ${commitopt} https://github.com/coreos/fedora-coreos-config
                 cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
                     --url=s3://${s3_stream_dir}/builds --artifact=openstack

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -1,8 +1,9 @@
-def pipeutils, pipecfg, official
+def pipeutils, pipecfg, s3_bucket, official
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
+    s3_bucket = pipecfg.s3_bucket
     official = pipeutils.isOfficial()
 }
 
@@ -57,7 +58,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
 
     def s3_stream_dir = params.S3_STREAM_DIR
     if (s3_stream_dir == "") {
-        s3_stream_dir = "fcos-builds/prod/streams/${params.STREAM}"
+        s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
     }
 
     try { timeout(time: 90, unit: 'MINUTES') {

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -32,7 +32,7 @@ properties([
              description: 'Override the coreos-assembler image to use',
              defaultValue: "coreos-assembler:main",
              trim: true),
-      string(name: 'FCOS_CONFIG_COMMIT',
+      string(name: 'SRC_CONFIG_COMMIT',
              description: 'The exact config repo git commit to run tests against',
              defaultValue: '',
              trim: true),
@@ -68,8 +68,8 @@ lock(resource: "kola-openstack-${params.ARCH}") {
             def openstack_image_name, openstack_image_filepath
             stage('Fetch Metadata/Image') {
                 def commitopt = ''
-                if (params.FCOS_CONFIG_COMMIT != '') {
-                    commitopt = "--commit=${params.FCOS_CONFIG_COMMIT}"
+                if (params.SRC_CONFIG_COMMIT != '') {
+                    commitopt = "--commit=${params.SRC_CONFIG_COMMIT}"
                 }
                 // Grab the metadata. Also grab the image so we can upload it.
                 shwrap("""

--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -1,8 +1,9 @@
-def pipecfg, pipeutils
+def pipecfg, pipeutils, s3_bucket
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
+    s3_bucket = pipecfg.s3_bucket
 }
 
 properties([
@@ -33,14 +34,14 @@ cosaPod(configMaps: ["fedora-messaging-cfg"], secrets: ["fedora-messaging-coreos
         // if so
         production_streams.each{stream ->
             for (subdir in ["streams", "updates"]) {
-                shwrap("aws s3 cp s3://fcos-builds/${subdir}/${stream}.json ${subdir}/${stream}.json")
+                shwrap("aws s3 cp s3://${s3_bucket}/${subdir}/${stream}.json ${subdir}/${stream}.json")
             }
             if (shwrapRc("git diff --exit-code") != 0) {
                 shwrap("git reset --hard HEAD")
                 for (subdir in ["streams", "updates"]) {
                     shwrap("""
                         aws s3 cp --acl public-read --cache-control 'max-age=60' \
-                            ${subdir}/${stream}.json s3://fcos-builds/${subdir}/${stream}.json
+                            ${subdir}/${stream}.json s3://${s3_bucket}/${subdir}/${stream}.json
                     """)
                 }
                 shwrap("""
@@ -56,7 +57,7 @@ cosaPod(configMaps: ["fedora-messaging-cfg"], secrets: ["fedora-messaging-coreos
                 python3 -c 'import sys, yaml, json; json.dump(yaml.safe_load(sys.stdin.read()), sys.stdout)' \
                     < release-notes/${stream}.yml > release-notes/${stream}.json
                 aws s3 cp --acl public-read --cache-control 'max-age=60' \
-                    release-notes/${stream}.json s3://fcos-builds/release-notes/${stream}.json
+                    release-notes/${stream}.json s3://${s3_bucket}/release-notes/${stream}.json
             """)
         }
     }

--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -21,7 +21,7 @@ properties([
 
 cosaPod(configMaps: ["fedora-messaging-cfg"], secrets: ["fedora-messaging-coreos-key"]) {
     git(url: 'https://github.com/coreos/fedora-coreos-streams', branch: 'main', credentialsId: 'github-coreosbot-token')
-    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-fcos-builds-bot']]) {
+    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-build-upload-config']]) {
         // XXX: eventually we want this as part of the pod or built into the image we use
         shwrap("git clone --depth=1 https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng")
 

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -136,8 +136,8 @@ objects:
             mountPath: /var/run/secrets/slack-api-token
             readOnly: true
           # DELTA: mount AWS creds; see below
-          - name: aws-fcos-builds-bot-creds
-            mountPath: /var/run/secrets/aws-fcos-builds-bot-config
+          - name: aws-build-upload-config
+            mountPath: /var/run/secrets/aws-build-upload-config
             readOnly: true
           # DELTA: mount GitHub webhook shared secret
           - name: github-webhook-shared-secret
@@ -185,9 +185,9 @@ objects:
             secretName: slack-api-token
             optional: true
         # DELTA: add AWS creds (used by the sync-stream-metadata job)
-        - name: aws-fcos-builds-bot-creds
+        - name: aws-build-upload-config
           secret:
-            secretName: aws-fcos-builds-bot-config
+            secretName: aws-build-upload-config
             optional: true
         # DELTA: add the GitHub webhook shared secret
         - name: github-webhook-shared-secret

--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -20,10 +20,10 @@ spec:
      command: ['/usr/bin/dumb-init']
      args: ['sleep', 'infinity']
      env:
-       - name: AWS_FCOS_BUILDS_BOT_CONFIG
-         value: /.aws-fcos-builds-bot-config/config
-       - name: AWS_FCOS_KOLA_BOT_CONFIG
-         value: /.aws-fcos-kola-bot-config/config
+       - name: AWS_BUILD_UPLOAD_CONFIG
+         value: /.aws-build-upload-config/config
+       - name: AWS_KOLA_TESTS_CONFIG
+         value: /.aws-kola-tests-config/config
        # This one doesn't have a config subdirectory
        - name: AZURE_KOLA_TESTS_CONFIG
          value: /.azure-kola-tests-config
@@ -36,11 +36,11 @@ spec:
      volumeMounts:
      - name: srv
        mountPath: /srv/
-     - name: aws-fcos-builds-bot-config
-       mountPath: /.aws-fcos-builds-bot-config/
+     - name: aws-build-upload-config
+       mountPath: /.aws-build-upload-config/
        readOnly: true
-     - name: aws-fcos-kola-bot-config
-       mountPath: /.aws-fcos-kola-bot-config/
+     - name: aws-kola-tests-config
+       mountPath: /.aws-kola-tests-config/
        readOnly: true
      - name: azure-kola-tests-config
        mountPath: /.azure-kola-tests-config/
@@ -74,14 +74,14 @@ spec:
   - name: srv
     emptyDir: {}
   # This secret is used for uploading to AWS
-  - name: aws-fcos-builds-bot-config
+  - name: aws-build-upload-config
     secret:
-      secretName: aws-fcos-builds-bot-config
+      secretName: aws-build-upload-config
       optional: true
   # This secret is used for running aws kola tests
-  - name: aws-fcos-kola-bot-config
+  - name: aws-kola-tests-config
     secret:
-      secretName: aws-fcos-kola-bot-config
+      secretName: aws-kola-tests-config
       optional: true
   # This secret is used for running Azure kola tests
   - name: azure-kola-tests-config


### PR DESCRIPTION
```
commit 98acd23193246cf17a89c085f3003ebfa07081ce
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Sep 16 16:09:37 2022 -0400

    jobs/build-arch: fix indentation

commit 32333c021068c0f926b3657eb0f2961535a7925f
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Sep 16 15:45:34 2022 -0400

    treewide: rename AWS credentials
    
    This does the following rename:
    
    - aws-fcos-builds-bot-config -> aws-build-upload-config
    - aws-fcos-kola-bot-config -> aws-kola-tests-config
    
    It is a further attempt to remove "FCOS" from any names in the pipeline.

commit a6b2649319d61fa53b337db74fc5665f5aef4a31
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Sep 16 14:30:11 2022 -0400

    treewide: remove hardcoded `fcos-builds` bucket
    
    We should be getting this from the configured s3_bucket in
    config.yaml.

commit ba7130b40f50c848c360e861f4a7f55e7d369dec
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Sep 16 12:58:35 2022 -0400

    treewide: FCOS_CONFIG_COMMIT -> SRC_CONFIG_COMMIT
    
    This helps the de-"FCOS" efforts move along by making the variable
    not FCOS specific.


```