### PR TITLE
tree: stop cloning releng-automation repo, use cosa

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -594,7 +594,6 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
             }
             parallelruns['OSTree Import: Compose Repo'] = {
                 shwrap("""
-                cosa shell -- \
                 /usr/lib/coreos-assembler/fedmsg-send-ostree-import-request \
                     --build=${newBuildID} --arch=${basearch} \
                     --s3=${s3_stream_dir} --repo=compose \

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -624,7 +624,6 @@ lock(resource: "build-${params.STREAM}") {
             }
             parallelruns['OSTree Import: Compose Repo'] = {
                 shwrap("""
-                cosa shell -- \
                 /usr/lib/coreos-assembler/fedmsg-send-ostree-import-request \
                     --build=${newBuildID} --arch=${basearch} \
                     --s3=${s3_stream_dir} --repo=compose \

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -93,13 +93,6 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
         def gcp_image = ""
         def ostree_prod_refs = [:]
 
-        // Clone the automation repo, which contains helper scripts. In the
-        // future, we'll probably want this either part of the cosa image, or
-        // in a derivative of cosa for pipeline needs.
-        shwrap("""
-        git clone --depth=1 https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng
-        """)
-
         // Fetch metadata files for the build we are interested in
         stage('Fetch Metadata') {
             shwrap("""
@@ -135,7 +128,7 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
             if ((stream_info.type == 'production') && utils.pathExists("/etc/fedora-messaging-cfg/fedmsg.toml")) {
                 stage("OSTree Import ${basearch}: Prod Repo") {
                     shwrap("""
-                    /var/tmp/fcos-releng/coreos-ostree-importer/send-ostree-import-request.py \
+                    /usr/lib/coreos-assembler/fedmsg-send-ostree-import-request \
                         --build=${params.VERSION} --arch=${basearch} \
                         --s3=${s3_stream_dir} --repo=prod \
                         --fedmsg-conf=/etc/fedora-messaging-cfg/fedmsg.toml
@@ -224,7 +217,7 @@ podTemplate(cloud: 'openshift', label: pod_label, yaml: pod) {
             if (utils.pathExists("/etc/fedora-messaging-cfg/fedmsg.toml")) {
                 for (basearch in basearches) {
                     shwrap("""
-                    /var/tmp/fcos-releng/scripts/broadcast-fedmsg.py --fedmsg-conf=/etc/fedora-messaging-cfg/fedmsg.toml \
+                    /usr/lib/coreos-assembler/fedmsg-broadcast --fedmsg-conf=/etc/fedora-messaging-cfg/fedmsg.toml \
                         stream.release --build ${params.VERSION} --basearch ${basearch} --stream ${params.STREAM}
                     """)
                 }

--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -22,9 +22,6 @@ properties([
 cosaPod(configMaps: ["fedora-messaging-cfg"], secrets: ["fedora-messaging-coreos-key"]) {
     git(url: 'https://github.com/coreos/fedora-coreos-streams', branch: 'main', credentialsId: 'github-coreosbot-token')
     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-build-upload-config']]) {
-        // XXX: eventually we want this as part of the pod or built into the image we use
-        shwrap("git clone --depth=1 https://github.com/coreos/fedora-coreos-releng-automation /var/tmp/fcos-releng")
-
         def production_streams = pipeutils.streams_of_type(pipecfg, 'production')
 
         // NB: we don't use `aws s3 sync` here because it's timestamp-based and
@@ -45,7 +42,7 @@ cosaPod(configMaps: ["fedora-messaging-cfg"], secrets: ["fedora-messaging-coreos
                     """)
                 }
                 shwrap("""
-                /var/tmp/fcos-releng/scripts/broadcast-fedmsg.py --fedmsg-conf=\${FEDORA_MESSAGING_CFG}/fedmsg.toml \
+                /usr/lib/coreos-assembler/fedmsg-broadcast --fedmsg-conf=\${FEDORA_MESSAGING_CFG}/fedmsg.toml \
                     stream.metadata.update --stream ${stream}
                 """)
             }


### PR DESCRIPTION
We've moved the scripts we need from that repo to cosa, so stop cloning the repo and use the ones from the cosa directory instead.

Requires: https://github.com/coreos/coreos-assembler/pull/3113