### PR TITLE
utils: fix null entry in list of artifacts

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -217,13 +217,18 @@ def change_metal_artifacts_list_order(artifacts) {
 
 // Gets desired artifacts to build from pipeline config
 def get_artifacts_to_build(pipecfg, stream, basearch) {
-    def artifacts
+    def artifacts = []
     if  (pipecfg.streams[stream].artifacts?."${basearch}" != null) {
         artifacts = pipecfg.streams[stream]['artifacts'][basearch]
     } else { // Merge default with additional artifacts
         def default_artifacts =  pipecfg['default_artifacts'][basearch]
         def additional_atifacts = pipecfg.streams[stream].additional_artifacts?."${basearch}"
-        artifacts = default_artifacts + additional_atifacts
+        if (default_artifacts != null) {
+            artifacts += default_artifacts
+        }
+        if (additional_atifacts != null) {
+            artifacts += additional_atifacts
+        }
     }
     return artifacts.unique()
 }


### PR DESCRIPTION
If default_artifacts or additional_atifacts are empty then we'll get `null` in the list of artifacts. Let's fix that.