### PR TITLE
updates for GCP/OpenStack/Azure AWS registry secrets/config

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -135,7 +135,13 @@ Once you have the json file that represents the credentials for your service acc
 from GCP, create the secret in OpenShift:
 
 ```
-oc create secret generic gcp-image-upload-config --from-file=config=/path/to/upload-secret
+oc create secret generic gcp-image-upload-config \
+    --from-literal=filename=gcp_config_file \
+    --from-file=data=/path/to/upload-secret
+oc label secret/gcp-image-upload-config \
+    jenkins.io/credentials-type=secretFile
+oc annotate secret/gcp-image-upload-config \
+    jenkins.io/credentials-description="GCP Image upload credentials config"
 ```
 
 We also have a second GCP config that can be used for running kola tests. If you have a
@@ -143,7 +149,13 @@ single account that you'd like to use for both image uploading and tests you can
 assuming they have enough permissions.
 
 ```
-oc create secret generic gcp-kola-tests-config --from-file=config=/path/to/kola-secret
+oc create secret generic gcp-kola-tests-config \
+    --from-literal=filename=gcp_config_file \
+    --from-file=data=/path/to/kola-secret
+oc label secret/gcp-kola-tests-config \
+    jenkins.io/credentials-type=secretFile
+oc annotate secret/gcp-kola-tests-config \
+    jenkins.io/credentials-description="GCP kola tests credentials config"
 ```
 
 NOTE: For the prod pipeline these secrets can be found in BitWarden

--- a/HACKING.md
+++ b/HACKING.md
@@ -169,13 +169,24 @@ azure auth file. See the
 for more information on those files.
 
 Once you have the azureAuth.json and azureProfile.json for connecting to Azure,
-create the secret in OpenShift:
+create the secrets in OpenShift:
 
 ```
-mkdir dir
-cp azureAuth.json dir/
-cp azureProfile.json dir/
-oc create secret generic azure-kola-tests-config --from-file=dir
+oc create secret generic azure-kola-tests-config-profile \
+    --from-literal=filename=azureProfile.json \
+    --from-file=data=/path/to/azureProfile.json
+oc label secret/azure-kola-tests-config-profile \
+    jenkins.io/credentials-type=secretFile
+oc annotate secret/azure-kola-tests-config-profile \
+    jenkins.io/credentials-description="Azure kola tests azureProfile.json"
+
+oc create secret generic azure-kola-tests-config-auth \
+    --from-literal=filename=azureAuth.json \
+    --from-file=data=/path/to/azureAuth.json
+oc label secret/azure-kola-tests-config-auth \
+    jenkins.io/credentials-type=secretFile
+oc annotate secret/azure-kola-tests-config-auth \
+    jenkins.io/credentials-description="Azure kola tests azureAuth.json"
 ```
 
 NOTE: For the prod pipeline these secrets can be found in BitWarden

--- a/HACKING.md
+++ b/HACKING.md
@@ -191,7 +191,13 @@ Once you have the yaml file that represents the credentials for connecting
 to your OpenStack instance, create the secret in OpenShift:
 
 ```
-oc create secret generic openstack-kola-tests-config --from-file=config=/path/to/clouds.yaml
+oc create secret generic openstack-kola-tests-config \
+    --from-literal=filename=openstack_config_file \
+    --from-file=data=/path/to/clouds.yaml
+oc label secret/openstack-kola-tests-config \
+    jenkins.io/credentials-type=secretFile
+oc annotate secret/openstack-kola-tests-config \
+    jenkins.io/credentials-description="OpenStack kola tests credentials config"
 ```
 
 NOTE: For the prod pipeline these secrets can be found in BitWarden

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -632,7 +632,8 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
                     }
                 }
                 // Kick off the Kola OpenStack job if we have credentials for running those tests.
-                if (utils.pathExists("\${OPENSTACK_KOLA_TESTS_CONFIG}")) {
+                pipeutils.tryWithCredentials([file(variable: 'OPENSTACK_KOLA_TESTS_CONFIG',
+                                              credentialsId: 'openstack-kola-tests-config')]) {
                     parallelruns['Kola:OpenStack'] = {
                         // We consider the OpenStack kola tests to be a followup job, so we use `wait: false` here.
                         build job: 'kola-openstack', wait: false, parameters: [

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -695,7 +695,8 @@ lock(resource: "build-${params.STREAM}") {
                 }
             }
             // Kick off the Kola OpenStack job if we have credentials for running those tests.
-            if (utils.pathExists("\${OPENSTACK_KOLA_TESTS_CONFIG}")) {
+            pipeutils.tryWithCredentials([file(variable: 'OPENSTACK_KOLA_TESTS_CONFIG',
+                                          credentialsId: 'openstack-kola-tests-config')]) {
                 parallelruns['Kola:OpenStack'] = {
                     // We consider the OpenStack kola tests to be a followup job, so we use `wait: false` here.
                     build job: 'kola-openstack', wait: false, parameters: [

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -670,7 +670,10 @@ lock(resource: "build-${params.STREAM}") {
               //}
             }
             // Kick off the Kola Azure job if we have credentials for running those tests.
-            if (utils.pathExists("\${AZURE_KOLA_TESTS_CONFIG}")) {
+            pipeutils.tryWithCredentials([file(variable: 'AZURE_KOLA_TESTS_CONFIG_PROFILE',
+                                                credentialsId: 'azure-kola-tests-config-profile'),
+                                           file(variable: 'AZURE_KOLA_TESTS_CONFIG_AUTH',
+                                                credentialsId: 'azure-kola-tests-config-auth')]) {
                 parallelruns['Kola:Azure'] = {
                     // We consider the Azure kola tests to be a followup job, so we use `wait: false` here.
                     build job: 'kola-azure', wait: false, parameters: [

--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -23,10 +23,6 @@ spec:
        # This one doesn't have a config subdirectory
        - name: AZURE_KOLA_TESTS_CONFIG
          value: /.azure-kola-tests-config
-       - name: GCP_IMAGE_UPLOAD_CONFIG
-         value: /.gcp-image-upload-config/config
-       - name: GCP_KOLA_TESTS_CONFIG
-         value: /.gcp-kola-tests-config/config
        - name: OPENSTACK_KOLA_TESTS_CONFIG
          value: /.openstack-kola-tests-config/config
      volumeMounts:
@@ -34,12 +30,6 @@ spec:
        mountPath: /srv/
      - name: azure-kola-tests-config
        mountPath: /.azure-kola-tests-config/
-       readOnly: true
-     - name: gcp-image-upload-config
-       mountPath: /.gcp-image-upload-config/
-       readOnly: true
-     - name: gcp-kola-tests-config
-       mountPath: /.gcp-kola-tests-config/
        readOnly: true
      - name: openstack-kola-tests-config
        mountPath: /.openstack-kola-tests-config/
@@ -67,16 +57,6 @@ spec:
   - name: azure-kola-tests-config
     secret:
       secretName: azure-kola-tests-config
-      optional: true
-  # This secret is used for uploading to GCP
-  - name: gcp-image-upload-config
-    secret:
-      secretName: gcp-image-upload-config
-      optional: true
-  # This secret is used for running GCP kola tests
-  - name: gcp-kola-tests-config
-    secret:
-      secretName: gcp-kola-tests-config
       optional: true
   # This secret is used for running OpenStack kola tests
   - name: openstack-kola-tests-config

--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -19,16 +19,9 @@ spec:
      imagePullPolicy: Always
      command: ['/usr/bin/dumb-init']
      args: ['sleep', 'infinity']
-     env:
-       # This one doesn't have a config subdirectory
-       - name: AZURE_KOLA_TESTS_CONFIG
-         value: /.azure-kola-tests-config
      volumeMounts:
      - name: srv
        mountPath: /srv/
-     - name: azure-kola-tests-config
-       mountPath: /.azure-kola-tests-config/
-       readOnly: true
      - name: fedora-messaging-cfg
        mountPath: /etc/fedora-messaging-cfg
        readOnly: true
@@ -48,11 +41,6 @@ spec:
   volumes:
   - name: srv
     emptyDir: {}
-  # This secret is used for running Azure kola tests
-  - name: azure-kola-tests-config
-    secret:
-      secretName: azure-kola-tests-config
-      optional: true
   # These two here are used for signing with RoboSignatory
   - name: fedora-messaging-cfg
     configMap:

--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -23,16 +23,11 @@ spec:
        # This one doesn't have a config subdirectory
        - name: AZURE_KOLA_TESTS_CONFIG
          value: /.azure-kola-tests-config
-       - name: OPENSTACK_KOLA_TESTS_CONFIG
-         value: /.openstack-kola-tests-config/config
      volumeMounts:
      - name: srv
        mountPath: /srv/
      - name: azure-kola-tests-config
        mountPath: /.azure-kola-tests-config/
-       readOnly: true
-     - name: openstack-kola-tests-config
-       mountPath: /.openstack-kola-tests-config/
        readOnly: true
      - name: fedora-messaging-cfg
        mountPath: /etc/fedora-messaging-cfg
@@ -57,11 +52,6 @@ spec:
   - name: azure-kola-tests-config
     secret:
       secretName: azure-kola-tests-config
-      optional: true
-  # This secret is used for running OpenStack kola tests
-  - name: openstack-kola-tests-config
-    secret:
-      secretName: openstack-kola-tests-config
       optional: true
   # These two here are used for signing with RoboSignatory
   - name: fedora-messaging-cfg


### PR DESCRIPTION
```
commit a17efa6f0baa76caac88bf6771d8eef5f21289a4
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Sep 27 21:28:39 2022 -0400

    treewide: migrate Azure credentials/secrets to kube creds plugin
    
    Similar to what was just done for AWS, GCP, and OpenStack. This one
    was a little more complicated because there are two files needed:
    azureProfile.json and azureAuth.json. Since the kube credentials
    jenkins plugin doesn't handle multiple files in a single secret very
    well I just broke them out into separate secrets.

commit c93f4acbee2d5966b24aa3cd40ad3822073656d0
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Sep 27 21:07:29 2022 -0400

    treewide: migrate OpenStack credentials/secrets to kube creds plugin
    
    Similar to what was just done for AWS/GCP.

commit cf8ebcd7aa9dcf40d2170c605bf235e49448c8ea
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Sep 27 20:53:19 2022 -0400

    treewide: migrate GCP credentials/secrets to kube creds plugin
    
    The same as we just did for AWS. Let's migrate the creds for GCP.

commit 095911519e4b7325cb1092b32f092cc3903b68a8 (upstreamorigin/main)
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Sep 27 16:17:11 2022 -0400

    treewide: migrate aws credentials/secrets to kube creds plugin
    
    This is a large commit that does a few things:
    
    - Simplifies the aws-build-upload-config secret by removing the
      accessKey and secretKey components of that secret
    - Converts the aws secrets into ones integrated by the kubernetes
      credentials plugin and deletes the aws jenkins credential
        - Also converts the sync-stream-metadata job to use a file based
          credential along with the AWS_CONFIG_FILE env variable.
        - Also removes the no longer used aws credential plugin
    - Removes mounts for AWS secrets from the pod and jenkins manifests

```
