### PR TITLE
treewide: convert fedora messaging credentials to support k8s creds plugin

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -341,17 +341,28 @@ oc annotate secret/cosa-push-registry-secret \
 
 ### [PROD] Create fedora-messaging configuration
 
-First create the configmap:
+First create the Fedora Messaging configuration secret:
 
 ```
-oc create configmap fedora-messaging-cfg --from-file=configs/fedmsg.toml
+oc create secret generic fedora-messaging-config \
+    --from-literal=filename=fedmsg.toml \
+    --from-file=data=configs/fedmsg.toml
+oc label secret/fedora-messaging-config \
+    jenkins.io/credentials-type=secretFile
+oc annotate secret/fedora-messaging-config \
+    jenkins.io/credentials-description="Fedora messaging fedmsg.toml"
 ```
 
 Then add the client secrets:
 
 ```
-oc create secret generic fedora-messaging-coreos-key \
-  --from-file=coreos.crt --from-file=coreos.key
+oc create secret generic fedora-messaging-coreos-x509-cert \
+    --from-file=clientCertificate=coreos.crt \
+    --from-file=clientKeySecret=coreos.key
+oc label secret/fedora-messaging-coreos-x509-cert \
+    jenkins.io/credentials-type=x509ClientCert
+oc annotate secret/fedora-messaging-coreos-x509-cert \
+    jenkins.io/credentials-description="Fedora messaging CoreOS x509 client cert"
 ```
 
 You can obtain `coreos.crt` and `coreos.key` from BitWarden.

--- a/configs/fedmsg.toml
+++ b/configs/fedmsg.toml
@@ -3,8 +3,8 @@ amqp_url = "amqps://coreos:@rabbitmq.fedoraproject.org/%2Fpubsub"
 
 [tls]
 ca_cert = "/etc/fedora-messaging/cacert.pem"
-keyfile = "/run/kubernetes/secrets/fedora-messaging-coreos-key/coreos.key"
-certfile = "/run/kubernetes/secrets/fedora-messaging-coreos-key/coreos.crt"
+keyfile = "FEDORA_MESSAGING_X509_CERT_PATH/key.pem"
+certfile = "FEDORA_MESSAGING_X509_CERT_PATH/cert.pem"
 
 [client_properties]
 app = "Fedora CoreOS Pipeline"

--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -22,12 +22,6 @@ spec:
      volumeMounts:
      - name: srv
        mountPath: /srv/
-     - name: fedora-messaging-cfg
-       mountPath: /etc/fedora-messaging-cfg
-       readOnly: true
-     - name: fedora-messaging-coreos-key
-       mountPath: /run/kubernetes/secrets/fedora-messaging-coreos-key
-       readOnly: true
      securityContext:
        privileged: false
      resources:
@@ -41,12 +35,3 @@ spec:
   volumes:
   - name: srv
     emptyDir: {}
-  # These two here are used for signing with RoboSignatory
-  - name: fedora-messaging-cfg
-    configMap:
-      name: fedora-messaging-cfg
-      optional: true
-  - name: fedora-messaging-coreos-key
-    secret:
-      secretName: fedora-messaging-coreos-key
-      optional: true


### PR DESCRIPTION
This commit does several things:

- Converts the fedora-messaging-cfg secret (now fedora-messaging-config) into a secret rather than a configmap so it can be dynamically loaded with withCredentials and not required to be hard mounted into the pods.
- Sets up a new fedora-messaging-coreos-x509-cert secret (was fedora-messaging-coreos-key) in the x509ClientCert type for the kube credentials plugin.
- Removes the old configmap/secret mounts from the COSA pod.yaml
- Switches configs/fedmsg.toml to have a templated string `FEDORA_MESSAGING_X509_CERT_PATH` that will be substituted out at runtime with the actual path of the files.
- Adds tryWithMessagingCredentials() to aid in setup/use of the config and secrets for fedora messaging.