### PR TITLE
treewide: migrate slack-api-token for use with k8s creds plugin

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -238,8 +238,12 @@ If you want to be able to have build status messages appear in Slack,
 create a `slack-api-token` secret:
 
 ```
-$ echo -n "$TOKEN" > slack-token
-$ oc create secret generic slack-api-token --from-file=token=slack-token
+TOKEN=<token>
+oc create secret generic slack-api-token --from-literal=text="${TOKEN}"
+oc label secret/slack-api-token \
+    jenkins.io/credentials-type=secretText
+oc annotate secret/slack-api-token \
+    jenkins.io/credentials-description="Slack API token"
 ```
 
 You can obtain a token when creating a new instance of the Jenkins CI

--- a/jenkins/config/slack.yaml
+++ b/jenkins/config/slack.yaml
@@ -1,14 +1,5 @@
-credentials:
-  system:
-    domainCredentials:
-      - credentials:
-        - string:
-            scope: GLOBAL
-            id: slack-token
-            secret: ${slack-api-token/token}
-            description: Slack API token
 unclassified:
   slackNotifier:
     teamDomain: coreos
-    tokenCredentialId: slack-token
+    tokenCredentialId: slack-api-token
     room: "#jenkins-fedora-coreos"

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -131,10 +131,6 @@ objects:
           - name: ${JENKINS_SERVICE_NAME}-casc-cfg
             mountPath: /var/lib/jenkins/configuration-as-code
             readOnly: true
-          # DELTA: mount Slack token; see below
-          - name: slack-token
-            mountPath: /var/run/secrets/slack-api-token
-            readOnly: true
           # DELTA: mount GitHub webhook shared secret
           - name: github-webhook-shared-secret
             mountPath: /var/run/secrets/github-webhook-shared-secret
@@ -154,11 +150,6 @@ objects:
         - name: ${JENKINS_SERVICE_NAME}-casc-cfg
           configMap:
             name: jenkins-casc-cfg
-        # DELTA: add the Slack token (needed to report pipeline failures)
-        - name: slack-token
-          secret:
-            secretName: slack-api-token
-            optional: true
         # DELTA: add the GitHub webhook shared secret
         - name: github-webhook-shared-secret
           secret:


### PR DESCRIPTION
~~Also add `trySlackSend()` function, use it across the tree~~