### PR TITLE
treewide: use secretFile for fedora messaging creds

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -387,12 +387,20 @@ Then add the client secrets:
 
 ```
 oc create secret generic fedora-messaging-coreos-x509-cert \
-    --from-file=clientCertificate=coreos.crt \
-    --from-file=clientKeySecret=coreos.key
+    --from-literal=filename=coreos.crt \
+    --from-file=coreos.crt
 oc label secret/fedora-messaging-coreos-x509-cert \
-    jenkins.io/credentials-type=x509ClientCert
+    jenkins.io/credentials-type=secretFile
 oc annotate secret/fedora-messaging-coreos-x509-cert \
     jenkins.io/credentials-description="Fedora messaging CoreOS x509 client cert"
+
+oc create secret generic fedora-messaging-coreos-x509-key \
+    --from-literal=filename=coreos.key \
+    --from-file=coreos.key
+oc label secret/fedora-messaging-coreos-x509-key \
+    jenkins.io/credentials-type=secretFile
+oc annotate secret/fedora-messaging-coreos-x509-key \
+    jenkins.io/credentials-description="Fedora messaging CoreOS x509 client key"
 ```
 
 You can obtain `coreos.crt` and `coreos.key` from BitWarden.

--- a/HACKING.md
+++ b/HACKING.md
@@ -418,9 +418,9 @@ oc annotate secret/github-coreosbot-token-text \
 oc create secret generic github-coreosbot-token-username-password \
     --from-literal=username=coreosbot \
     --from-literal=password=${TOKEN}
-oc label secret/github-coreosbot-token-text \
+oc label secret/github-coreosbot-token-username-password \
     jenkins.io/credentials-type=usernamePassword
-oc annotate secret/github-coreosbot-token-text \
+oc annotate secret/github-coreosbot-token-username-password  \
     jenkins.io/credentials-description="GitHub coreosbot token as username/password"
 ```
 

--- a/configs/fedmsg.toml
+++ b/configs/fedmsg.toml
@@ -3,8 +3,8 @@ amqp_url = "amqps://coreos:@rabbitmq.fedoraproject.org/%2Fpubsub"
 
 [tls]
 ca_cert = "/etc/fedora-messaging/cacert.pem"
-keyfile = "FEDORA_MESSAGING_X509_CERT_PATH/key.pem"
-certfile = "FEDORA_MESSAGING_X509_CERT_PATH/cert.pem"
+keyfile = "FEDORA_MESSAGING_X509_KEY"
+certfile = "FEDORA_MESSAGING_X509_CERT"
 
 [client_properties]
 app = "Fedora CoreOS Pipeline"

--- a/utils.groovy
+++ b/utils.groovy
@@ -168,16 +168,16 @@ def tryWithOrWithoutCredentials(creds, Closure body) {
 
 // Runs closure if the fedmsg credentials exist, otherwise gracefully return.
 def tryWithMessagingCredentials(Closure body) {
-    // Here we need to use `dockerCert`, which was renamed to
-    // `x509ClientCert` but the binding credentials plugin hasn't
-    // been updated to support the new name. https://stackoverflow.com/a/72293992
     tryWithCredentials([file(variable: 'FEDORA_MESSAGING_CONF',
                              credentialsId: 'fedora-messaging-config'),
-                        dockerCert(variable: 'FEDORA_MESSAGING_X509_CERT_PATH',
-                                   credentialsId: 'fedora-messaging-coreos-x509-cert')]) {
+                        file(variable: 'FEDORA_MESSAGING_X509_CERT',
+                             credentialsId: 'fedora-messaging-coreos-x509-cert'),
+                        file(variable: 'FEDORA_MESSAGING_X509_KEY',
+                             credentialsId: 'fedora-messaging-coreos-x509-key')]) {
         // Substitute in the full path to the cert/key into the config
         shwrap('''
-        sed -i s,FEDORA_MESSAGING_X509_CERT_PATH,${FEDORA_MESSAGING_X509_CERT_PATH}, ${FEDORA_MESSAGING_CONF}
+        sed -i s,FEDORA_MESSAGING_X509_CERT,${FEDORA_MESSAGING_X509_CERT}, ${FEDORA_MESSAGING_CONF}
+        sed -i s,FEDORA_MESSAGING_X509_KEY,${FEDORA_MESSAGING_X509_KEY}, ${FEDORA_MESSAGING_CONF}
         ''')
         // Also sync it over to the remote if we're operating in a remote session
         shwrap('''


### PR DESCRIPTION
The version of the Kubernetes Credentials Provider plugin that we
are on right now doesn't support x509ClientCert yet. Let's use two
separate secretFile secrets instead.
