### PR TITLE
A few minor pipeline fixes that should get us working again

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -388,7 +388,7 @@ Then add the client secrets:
 ```
 oc create secret generic fedora-messaging-coreos-x509-cert \
     --from-literal=filename=coreos.crt \
-    --from-file=coreos.crt
+    --from-file=data=coreos.crt
 oc label secret/fedora-messaging-coreos-x509-cert \
     jenkins.io/credentials-type=secretFile
 oc annotate secret/fedora-messaging-coreos-x509-cert \
@@ -396,7 +396,7 @@ oc annotate secret/fedora-messaging-coreos-x509-cert \
 
 oc create secret generic fedora-messaging-coreos-x509-key \
     --from-literal=filename=coreos.key \
-    --from-file=coreos.key
+    --from-file=data=coreos.key
 oc label secret/fedora-messaging-coreos-x509-key \
     jenkins.io/credentials-type=secretFile
 oc annotate secret/fedora-messaging-coreos-x509-key \

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -587,6 +587,7 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
                 }
                 parallelruns['OSTree Import: Compose Repo'] = {
                     shwrap("""
+                    cosa shell -- \
                     /usr/lib/coreos-assembler/fedmsg-send-ostree-import-request \
                         --build=${newBuildID} --arch=${basearch} \
                         --s3=${s3_stream_dir} --repo=compose \

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -525,14 +525,11 @@ lock(resource: "build-${params.STREAM}") {
                 }
             }
 
-            // reset for the next batch of independent tasks
-            parallelruns = [:]
-
             // Key off of uploading: i.e. if we're configured to upload artifacts
             // to S3, we also take that to mean we should upload an AMI. We could
             // split this into two separate developer knobs in the future.
             if (uploading) {
-                parallelruns['Upload AWS'] = {
+                stage('Upload AWS'] = {
                     // XXX: hardcode us-east-1 for now
                     // XXX: use the temporary 'ami-import' subpath for now; once we
                     // also publish vmdks, we could make this more efficient by
@@ -550,11 +547,10 @@ lock(resource: "build-${params.STREAM}") {
                 }
             }
 
-            // If there is a config for GCP then we'll upload our image to GCP
             if (uploading) {
                 pipeutils.tryWithCredentials([file(variable: 'GCP_IMAGE_UPLOAD_CONFIG',
                                                    credentialsId: 'gcp-image-upload-config')]) {
-                    parallelruns['Upload GCP'] = {
+                    stage('Upload GCP') {
                         shwrap("""
                         # pick up the project to use from the config
                         gcp_project=\$(jq -r .project_id \${GCP_IMAGE_UPLOAD_CONFIG})
@@ -579,9 +575,6 @@ lock(resource: "build-${params.STREAM}") {
                     }
                 }
             }
-
-            // process this batch
-            parallel parallelruns
         }
 
         stage('Archive') {

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -632,6 +632,7 @@ lock(resource: "build-${params.STREAM}") {
                 }
                 parallelruns['OSTree Import: Compose Repo'] = {
                     shwrap("""
+                    cosa shell -- \
                     /usr/lib/coreos-assembler/fedmsg-send-ostree-import-request \
                         --build=${newBuildID} --arch=${basearch} \
                         --s3=${s3_stream_dir} --repo=compose \

--- a/utils.groovy
+++ b/utils.groovy
@@ -186,8 +186,11 @@ def tryWithMessagingCredentials(Closure body) {
                 $(dirname ${FEDORA_MESSAGING_CONF})
             cosa remote-session sync {,:}/${FEDORA_MESSAGING_CONF}
             cosa shell -- sudo install -d -D -o builder -g builder --mode 777 \
-                $(dirname ${FEDORA_MESSAGING_X509_CERT_PATH})
-            cosa remote-session sync {,:}/${FEDORA_MESSAGING_X509_CERT_PATH}
+                $(dirname ${FEDORA_MESSAGING_X509_CERT})
+            cosa remote-session sync {,:}/${FEDORA_MESSAGING_X509_CERT}
+            cosa shell -- sudo install -d -D -o builder -g builder --mode 777 \
+                $(dirname ${FEDORA_MESSAGING_X509_KEY})
+            cosa remote-session sync {,:}/${FEDORA_MESSAGING_X509_KEY}
         fi
         ''')
         body()


### PR DESCRIPTION
- jobs/build: unparallel the cloud image upload/creation for now
- utils: fix more variables in tryWithMessagingCredentials
- Revert "jobs/build-arch: emit ostree import request from controller"
- HACKING: fix fedora-messaging secrets definition
