### PR TITLE
config.yaml: drop `type: fcos` knob

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,3 @@
-# this is an FCOS pipeline
-type: fcos
-
 streams:
     stable:
       type: production
@@ -69,6 +66,9 @@ default_artifacts:
     - virtualbox
     - vmware
     - vultr
+
+# Temporary hack for AWS aarch64; see comment in `build-arch.Jenkinsfile`.
+aws_aarch64_serial_console_hack: true
 
 clouds:
   aws:

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -2,12 +2,10 @@ import org.yaml.snakeyaml.Yaml;
 
 def pipeutils, pipecfg, official, uploading, jenkins_agent_image_tag
 def src_config_url, s3_bucket, aws_test_accounts
-def pipetype
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
-    pipetype = pipecfg.type
     pod = readFile(file: "manifests/pod.yaml")
 
 
@@ -463,18 +461,18 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
             // see https://github.com/coreos/fedora-coreos-tracker/issues/920#issuecomment-914334988
             // Right now we only patch if platforms.yaml hasn't made it to this stream yet.
             // Fold this back into the above parallel runs (i.e. add to config.yaml
-            // artifacts list for aarch64 and delete below code) once platforms.yaml
+            // artifacts list for aarch64 and delete below code and knob) once platforms.yaml
             // exists everywhere. https://github.com/coreos/fedora-coreos-config/pull/1181
             if (basearch == "aarch64") {
                 stage('AWS') {
-                    shwrap("""
-                    if [ "${pipetype}" == "fcos" ]; then
+                    if (pipecfg.aws_aarch64_serial_console_hack) {
+                        shwrap("""
                         if [ ! -e src/config/platforms.yaml ]; then
                             echo 'ZGlmZiAtLWdpdCBhL3NyYy9nZi1zZXQtcGxhdGZvcm0gYi9zcmMvZ2Ytc2V0LXBsYXRmb3JtCmluZGV4IDNiMWM1YWUzMS4uZGY1ZTBmOWQ3IDEwMDc1NQotLS0gYS9zcmMvZ2Ytc2V0LXBsYXRmb3JtCisrKyBiL3NyYy9nZi1zZXQtcGxhdGZvcm0KQEAgLTU5LDcgKzU5LDEzIEBAIGJsc2NmZ19wYXRoPSQoY29yZW9zX2dmIGdsb2ItZXhwYW5kIC9ib290L2xvYWRlci9lbnRyaWVzL29zdHJlZS0qLmNvbmYpCiBjb3Jlb3NfZ2YgZG93bmxvYWQgIiR7YmxzY2ZnX3BhdGh9IiAiJHt0bXBkfSIvYmxzLmNvbmYKICMgUmVtb3ZlIGFueSBwbGF0Zm9ybWlkIGN1cnJlbnRseSB0aGVyZQogc2VkIC1pIC1lICdzLCBpZ25pdGlvbi5wbGF0Zm9ybS5pZD1bYS16QS1aMC05XSosLGcnICIke3RtcGR9Ii9ibHMuY29uZgotc2VkIC1pIC1lICcvXm9wdGlvbnMgLyBzLCQsIGlnbml0aW9uLnBsYXRmb3JtLmlkPSciJHtwbGF0Zm9ybWlkfSInLCcgIiR7dG1wZH0iL2Jscy5jb25mCitpZiBbICIkKGNvcmVvc19nZiBleGlzdHMgL2Jvb3QvY29yZW9zL3BsYXRmb3Jtcy5qc29uKSIgIT0gInRydWUiIC1hICIke3BsYXRmb3JtaWR9IiA9PSAnYXdzJyBdOyB0aGVuCisgICAgIyBPdXIgcGxhdGZvcm0gaXMgQVdTIGFuZCB3ZSBzdGlsbCBuZWVkIHRoZSBjb25zb2xlPXR0eVMwIGhhY2sgZm9yIHRoZSBsZWdhY3kKKyAgICAjIChubyBwbGF0Zm9ybXMueWFtbCkgcGF0aC4KKyAgICBzZWQgLWkgLWUgJ3N8Xlwob3B0aW9ucyAuKlwpfFwxIGlnbml0aW9uLnBsYXRmb3JtLmlkPSciJHtwbGF0Zm9ybWlkfSInIGNvbnNvbGU9dHR5UzAsMTE1MjAwbjh8JyAiJHt0bXBkfSIvYmxzLmNvbmYKK2Vsc2UKKyAgICBzZWQgLWkgLWUgJy9eb3B0aW9ucyAvIHMsJCwgaWduaXRpb24ucGxhdGZvcm0uaWQ9JyIke3BsYXRmb3JtaWR9IicsJyAiJHt0bXBkfSIvYmxzLmNvbmYKK2ZpCiBpZiBbIC1uICIkcmVtb3ZlX2thcmdzIiBdOyB0aGVuCiAgICAgIyBSZW1vdmUgZXhpc3RpbmcgcWVtdS1zcGVjaWZpYyBrYXJncwogICAgIHNlZCAtaSAtZSAnL15vcHRpb25zIC8gc0AgJyIke3JlbW92ZV9rYXJnc30iJ0BAJyAiJHt0bXBkfSIvYmxzLmNvbmYKCg==' | base64 --decode | cosa shell -- sudo patch /usr/lib/coreos-assembler/gf-set-platform
                         fi
-                    fi
-                    cosa buildextend-aws
-                    """)
+                        """)
+                    }
+                    shwrap("cosa buildextend-aws")
                 }
             }
 


### PR DESCRIPTION
Let's not have code that explicitly switches on FCOS vs RHCOS in the pipeline. Instead, let's try to take each instance on a case-by-case basis and formalize the distinction they're trying to express at a higher level.

In the case of the aarch64 serial console issue, we'll get that via the recent `platforms.yaml` work. For now, to not regress let's introduce a temporary knob to activate the AWS aarch64 serial console hack.