### PR TITLE
jobs: drop unnecessary pipecfg aliases

### DIFF
--- a/jobs/build-fcos-buildroot.Jenkinsfile
+++ b/jobs/build-fcos-buildroot.Jenkinsfile
@@ -1,4 +1,4 @@
-def pipeutils, official, src_config_url
+def pipeutils, official
 def gitref, commit, shortcommit
 def containername = 'fcos-buildroot'
 node {
@@ -6,7 +6,6 @@ node {
     pipeutils = load("utils.groovy")
     official = pipeutils.isOfficial()
     pipecfg = pipeutils.load_pipecfg()
-    src_config_url = pipecfg.source_config.url
 }
 
 properties([
@@ -48,7 +47,7 @@ properties([
              trim: true),
       string(name: 'CONFIG_GIT_URL',
              description: 'Override the src/config git repo to use',
-             defaultValue: src_config_url,
+             defaultValue: pipecfg.source_config.url,
              trim: true),
       string(name: 'CONFIG_GIT_REF',
              description: 'Override the src/config git ref to use',

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -1,9 +1,8 @@
-def pipeutils, pipecfg, official, arches
+def pipeutils, pipecfg, official
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
-    arches = pipecfg.additional_arches.plus("x86_64")
     official = pipeutils.isOfficial()
 }
 
@@ -81,6 +80,7 @@ try { lock(resource: "bump-${params.STREAM}") { timeout(time: 120, unit: 'MINUTE
 
     def lockfile, pkgChecksum, pkgTimestamp
     def skip_tests_arches = params.SKIP_TESTS_ARCHES.split()
+    def arches = pipecfg.additional_arches.plus("x86_64")
     def archinfo = arches.collectEntries{[it, [:]]}
     for (architecture in archinfo.keySet()) {
         def arch = architecture

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -1,10 +1,8 @@
-def pipeutils, pipecfg, s3_bucket, official, src_config_url
+def pipeutils, pipecfg, official
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
-    s3_bucket = pipecfg.s3_bucket
-    src_config_url = pipecfg.source_config.url
     official = pipeutils.isOfficial()
 }
 
@@ -50,7 +48,7 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSIO
 
 def s3_stream_dir = params.S3_STREAM_DIR
 if (s3_stream_dir == "") {
-    s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
+    s3_stream_dir = "${pipecfg.s3_bucket}/prod/streams/${params.STREAM}"
 }
 
 try { timeout(time: 90, unit: 'MINUTES') {
@@ -65,7 +63,7 @@ try { timeout(time: 90, unit: 'MINUTES') {
             withCredentials([file(variable: 'AWS_CONFIG_FILE',
                                   credentialsId: 'aws-build-upload-config')]) {
                 shwrap("""
-                cosa init --branch ${params.STREAM} ${commitopt} ${src_config_url}
+                cosa init --branch ${params.STREAM} ${commitopt} ${pipecfg.source_config.url}
                 cosa buildfetch --artifact=ostree --build=${params.VERSION} \
                     --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds
                 """)

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -1,17 +1,9 @@
-def pipeutils, pipecfg, s3_bucket, official, src_config_url
-def azure_testing_resource_group
-def azure_testing_storage_account
-def azure_testing_storage_container
+def pipeutils, pipecfg, official
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
-    s3_bucket = pipecfg.s3_bucket
-    src_config_url = pipecfg.source_config.url
     def jenkinscfg = pipeutils.load_jenkins_config()
-    azure_testing_resource_group = pipecfg.clouds?.azure?.test_resource_group
-    azure_testing_storage_account = pipecfg.clouds?.azure?.test_storage_account
-    azure_testing_storage_container = pipecfg.clouds?.azure?.test_storage_container
     official = pipeutils.isOfficial()
 }
 
@@ -65,7 +57,7 @@ lock(resource: "kola-azure-${params.ARCH}") {
 
     def s3_stream_dir = params.S3_STREAM_DIR
     if (s3_stream_dir == "") {
-        s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
+        s3_stream_dir = "${pipecfg.s3_bucket}/prod/streams/${params.STREAM}"
     }
 
     try { timeout(time: 75, unit: 'MINUTES') {
@@ -82,7 +74,7 @@ lock(resource: "kola-azure-${params.ARCH}") {
                 withCredentials([file(variable: 'AWS_CONFIG_FILE',
                                       credentialsId: 'aws-build-upload-config')]) {
                     shwrap("""
-                    cosa init --branch ${params.STREAM} ${commitopt} ${src_config_url}
+                    cosa init --branch ${params.STREAM} ${commitopt} ${pipecfg.source_config.url}
                     cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
                         --url=s3://${s3_stream_dir}/builds --artifact=azure
                     cosa decompress --build=${params.VERSION} --artifact=azure
@@ -101,6 +93,9 @@ lock(resource: "kola-azure-${params.ARCH}") {
                              file(variable: 'AZURE_KOLA_TESTS_CONFIG_AUTH',
                                   credentialsId: 'azure-kola-tests-config-auth')]) {
 
+                def azure_testing_resource_group = pipecfg.clouds?.azure?.test_resource_group
+                def azure_testing_storage_account = pipecfg.clouds?.azure?.test_storage_account
+                def azure_testing_storage_container = pipecfg.clouds?.azure?.test_storage_container
 
                 stage('Upload/Create Image') {
                     // Create the image in Azure

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -3,7 +3,6 @@ node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
-    def jenkinscfg = pipeutils.load_jenkins_config()
     official = pipeutils.isOfficial()
 }
 

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -1,10 +1,8 @@
-def pipeutils, pipecfg, s3_bucket, official, src_config_url
+def pipeutils, pipecfg, official
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
-    s3_bucket = pipecfg.s3_bucket
-    src_config_url = pipecfg.source_config.url
     official = pipeutils.isOfficial()
 }
 
@@ -50,7 +48,7 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSIO
 
 def s3_stream_dir = params.S3_STREAM_DIR
 if (s3_stream_dir == "") {
-    s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
+    s3_stream_dir = "${pipecfg.s3_bucket}/prod/streams/${params.STREAM}"
 }
 
 try { timeout(time: 30, unit: 'MINUTES') {
@@ -65,7 +63,7 @@ try { timeout(time: 30, unit: 'MINUTES') {
             withCredentials([file(variable: 'AWS_CONFIG_FILE',
                                   credentialsId: 'aws-build-upload-config')]) {
                 shwrap("""
-                cosa init --branch ${params.STREAM} ${commitopt} ${src_config_url}
+                cosa init --branch ${params.STREAM} ${commitopt} ${pipecfg.source_config.url}
                 cosa buildfetch --artifact=ostree --build=${params.VERSION} \
                     --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds
                 """)

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -1,10 +1,8 @@
-def pipeutils, pipecfg, s3_bucket, official, src_config_url
+def pipeutils, pipecfg, official
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
-    s3_bucket = pipecfg.s3_bucket
-    src_config_url = pipecfg.source_config.url
     official = pipeutils.isOfficial()
 }
 
@@ -46,7 +44,7 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSIO
 
 def s3_stream_dir = params.S3_STREAM_DIR
 if (s3_stream_dir == "") {
-    s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
+    s3_stream_dir = "${pipecfg.s3_bucket}/prod/streams/${params.STREAM}"
 }
 
 try { timeout(time: 60, unit: 'MINUTES') {
@@ -61,7 +59,7 @@ try { timeout(time: 60, unit: 'MINUTES') {
             withCredentials([file(variable: 'AWS_CONFIG_FILE',
                                   credentialsId: 'aws-build-upload-config')]) {
                 shwrap("""
-                cosa init --branch ${params.STREAM} ${commitopt} ${src_config_url}
+                cosa init --branch ${params.STREAM} ${commitopt} ${pipecfg.source_config.url}
                 cosa buildfetch --build=${params.VERSION} \
                     --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds
                 """)

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -1,10 +1,8 @@
-def pipeutils, pipecfg, s3_bucket, official, src_config_url
+def pipeutils, pipecfg, official
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
-    s3_bucket = pipecfg.s3_bucket
-    src_config_url = pipecfg.source_config.url
     official = pipeutils.isOfficial()
 }
 
@@ -59,7 +57,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
 
     def s3_stream_dir = params.S3_STREAM_DIR
     if (s3_stream_dir == "") {
-        s3_stream_dir = "${s3_bucket}/prod/streams/${params.STREAM}"
+        s3_stream_dir = "${pipecfg.s3_bucket}/prod/streams/${params.STREAM}"
     }
 
     try { timeout(time: 90, unit: 'MINUTES') {
@@ -76,7 +74,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
                 withCredentials([file(variable: 'AWS_CONFIG_FILE',
                                       credentialsId: 'aws-build-upload-config')]) {
                     shwrap("""
-                    cosa init --branch ${params.STREAM} ${commitopt} ${src_config_url}
+                    cosa init --branch ${params.STREAM} ${commitopt} ${pipecfg.source_config.url}
                     cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
                         --url=s3://${s3_stream_dir}/builds --artifact=openstack
                     cosa decompress --build=${params.VERSION} --artifact=openstack

--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -1,9 +1,8 @@
-def pipecfg, pipeutils, s3_bucket
+def pipecfg, pipeutils
 node {
     checkout scm
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
-    s3_bucket = pipecfg.s3_bucket
 }
 
 properties([
@@ -32,14 +31,14 @@ cosaPod() {
         // if so
         production_streams.each{stream ->
             for (subdir in ["streams", "updates"]) {
-                shwrap("aws s3 cp s3://${s3_bucket}/${subdir}/${stream}.json ${subdir}/${stream}.json")
+                shwrap("aws s3 cp s3://${pipecfg.s3_bucket}/${subdir}/${stream}.json ${subdir}/${stream}.json")
             }
             if (shwrapRc("git diff --exit-code") != 0) {
                 shwrap("git reset --hard HEAD")
                 for (subdir in ["streams", "updates"]) {
                     shwrap("""
                         aws s3 cp --acl public-read --cache-control 'max-age=60' \
-                            ${subdir}/${stream}.json s3://${s3_bucket}/${subdir}/${stream}.json
+                            ${subdir}/${stream}.json s3://${pipecfg.s3_bucket}/${subdir}/${stream}.json
                     """)
                 }
                 pipeutils.tryWithMessagingCredentials() {
@@ -57,7 +56,7 @@ cosaPod() {
                 python3 -c 'import sys, yaml, json; json.dump(yaml.safe_load(sys.stdin.read()), sys.stdout)' \
                     < release-notes/${stream}.yml > release-notes/${stream}.json
                 aws s3 cp --acl public-read --cache-control 'max-age=60' \
-                    release-notes/${stream}.json s3://${s3_bucket}/release-notes/${stream}.json
+                    release-notes/${stream}.json s3://${pipecfg.s3_bucket}/release-notes/${stream}.json
             """)
         }
     }


### PR DESCRIPTION
Stop fishing values out of `pipecfg` into separate variable and get in
the habit of referencing `pipecfg` directly instead.