### PR TITLE
jobs/build: support yumrepos knob in pipecfg and add root CA on remote workers

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -205,6 +205,9 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
         def session = shwrapCapture("cosa remote-session create --image ${image} --expiration 4h")
         withEnv(["COREOS_ASSEMBLER_REMOTE_SESSION=${session}"]) {
 
+        // add any additional root CA cert before we do anything that fetches
+        pipeutils.addOptionalRootCA()
+
         def local_builddir = "/srv/devel/streams/${params.STREAM}"
         def ref = params.STREAM
         def src_config_commit

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -193,15 +193,6 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
             uploading = false
         }
 
-        def local_builddir = "/srv/devel/streams/${params.STREAM}"
-        def ref = params.STREAM
-        def src_config_commit
-        if (params.SRC_CONFIG_COMMIT) {
-            src_config_commit = params.SRC_CONFIG_COMMIT
-        } else {
-            src_config_commit = shwrapCapture("git ls-remote ${src_config_url} ${ref} | cut -d \$'\t' -f 1")
-        }
-
 
         // Wrap a bunch of commands now inside the context of a remote
         // session. All `cosa` commands, other than `cosa remote-session`
@@ -213,6 +204,15 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
         pipeutils.withPodmanRemoteArchBuilder(arch: basearch) {
         def session = shwrapCapture("cosa remote-session create --image ${image} --expiration 4h")
         withEnv(["COREOS_ASSEMBLER_REMOTE_SESSION=${session}"]) {
+
+        def local_builddir = "/srv/devel/streams/${params.STREAM}"
+        def ref = params.STREAM
+        def src_config_commit
+        if (params.SRC_CONFIG_COMMIT) {
+            src_config_commit = params.SRC_CONFIG_COMMIT
+        } else {
+            src_config_commit = shwrapCapture("git ls-remote ${src_config_url} ${ref} | cut -d \$'\t' -f 1")
+        }
 
         stage('Init') {
             def yumrepos = pipecfg.source_config.yumrepos ? "--yumrepos ${pipecfg.source_config.yumrepos}" : ""

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -215,6 +215,7 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
         withEnv(["COREOS_ASSEMBLER_REMOTE_SESSION=${session}"]) {
 
         stage('Init') {
+            def yumrepos = pipecfg.source_config.yumrepos ? "--yumrepos ${pipecfg.source_config.yumrepos}" : ""
 
             shwrap("""
             # sync over AWS secret if it exists
@@ -224,7 +225,7 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
                 cosa remote-session sync \${dir}/ :\${dir}/
             fi
 
-            cosa init --force --branch ${ref} --commit=${src_config_commit} ${src_config_url}
+            cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${src_config_url}
             """)
 
         }

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -174,9 +174,10 @@ lock(resource: "build-${params.STREAM}") {
         stage('Init') {
             // for now, just use the PVC to keep cache.qcow2 in a stream-specific dir
             def cache_img = "/srv/prod/${params.STREAM}/cache.qcow2"
+            def yumrepos = pipecfg.source_config.yumrepos ? "--yumrepos ${pipecfg.source_config.yumrepos}" : ""
 
             shwrap("""
-            cosa init --force --branch ${ref} --commit=${src_config_commit} ${src_config_url}
+            cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${src_config_url}
             mkdir -p \$(dirname ${cache_img})
             ln -s ${cache_img} cache/cache.qcow2
             """)

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -136,9 +136,6 @@ lock(resource: "build-${params.STREAM}") {
         cat /cosa/coreos-assembler-git.json
         """)
 
-        // add any additional root CA cert before we do anything that fetches
-        pipeutils.addOptionalRootCA()
-
         // declare these early so we can use them in `finally` block
         def newBuildID
         def basearch = shwrapCapture("cosa basearch")
@@ -166,6 +163,9 @@ lock(resource: "build-${params.STREAM}") {
         } else {
             uploading = false
         }
+
+        // add any additional root CA cert before we do anything that fetches
+        pipeutils.addOptionalRootCA()
 
         def local_builddir = "/srv/devel/streams/${params.STREAM}"
         def ref = params.STREAM

--- a/utils.groovy
+++ b/utils.groovy
@@ -204,6 +204,13 @@ def addOptionalRootCA() {
             cp $ROOT_CA /etc/pki/ca-trust/source/anchors/
             /usr/lib/coreos-assembler/update-ca-trust-unpriv
         ''')
+        // Also sync it over to the remote if we're operating in a remote session
+        shwrap('''
+        if [ -n "${COREOS_ASSEMBLER_REMOTE_SESSION:-}" ]; then
+            cosa remote-session sync {,:}/etc/pki/ca-trust/anchors/
+            cosa shell -- /usr/lib/coreos-assembler/update-ca-trust-unpriv
+        fi
+        ''')
     }
 }
 


### PR DESCRIPTION
```
commit 013056891e212d6e37ec5caae48f1349310f3c4a
Date:   Mon Oct 3 16:40:38 2022 -0400

    jobs/build: support yumrepos knob in pipecfg

    Now that `cosa init` has a concept of "yumrepos", wire that through from
    the pipecfg so that RHCOS can make use of it.
```
```
commit bf1051d8e796f67f3606ee794e9204f802a0381b
Date:   Mon Oct 3 17:06:05 2022 -0400

    jobs/build-arch: add root CA on remote workers

    Remote workers also need to be able to access e.g. the yum repos.
    Propagate any configured root CA in the controller cosa into the worker
    cosa.
```