### PR TITLE
jobs/kola-aws: parallelize tests; switch xen to i3.large

### DIFF
--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -92,13 +92,22 @@ try { timeout(time: 90, unit: 'MINUTES') {
                 }
                 parallelruns['Kola:Xen'] = {
                     // https://github.com/coreos/fedora-coreos-tracker/issues/997
+                    // Run this test on i3.large so we can also run ext.config.platforms.aws.nvme
+                    // to verify access to instance storage nvme disks works
+                    // https://github.com/coreos/fedora-coreos-tracker/issues/1306
+                    // Also add in the ext.config.platforms.aws.assert-xen test just
+                    // to sanity check we are on a Xen instance.
+                    def xen_tests = tests
+                    if (xen_tests == "basic") {
+                        xen_tests = "basic ext.config.platforms.aws.nvme ext.config.platforms.aws.assert-xen"
+                    }
                     fcosKola(cosaDir: env.WORKSPACE,
                              build: params.VERSION, arch: params.ARCH,
-                             extraArgs: tests,
+                             extraArgs: xen_tests,
                              skipUpgrade: true,
                              skipBasicScenarios: true,
                              marker: "kola-xen",
-                             platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=m4.large')
+                             platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=i3.large')
                 }
                 parallelruns['Kola:Intel-Ice-Lake'] = {
                     // https://github.com/coreos/fedora-coreos-tracker/issues/1004

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -74,34 +74,40 @@ try { timeout(time: 90, unit: 'MINUTES') {
 
         withCredentials([file(variable: 'AWS_CONFIG_FILE',
                               credentialsId: 'aws-kola-tests-config')]) {
-            fcosKola(cosaDir: env.WORKSPACE, parallel: 5,
-                     build: params.VERSION, arch: params.ARCH,
-                     extraArgs: params.KOLA_TESTS,
-                     skipBasicScenarios: true,
-                     platformArgs: '-p=aws --aws-region=us-east-1')
+            // A few independent tasks that can be run in parallel
+            def parallelruns = [:]
+
+            parallelruns['Kola:Full'] = {
+                fcosKola(cosaDir: env.WORKSPACE, parallel: 5,
+                         build: params.VERSION, arch: params.ARCH,
+                         extraArgs: params.KOLA_TESTS,
+                         skipBasicScenarios: true,
+                         platformArgs: '-p=aws --aws-region=us-east-1')
+            }
 
             if (params.ARCH == "x86_64") {
                 def tests = params.KOLA_TESTS
                 if (tests == "") {
                     tests = "basic"
                 }
-                parallel Xen: {
+                parallelruns['Kola:Xen'] = {
                     // https://github.com/coreos/fedora-coreos-tracker/issues/997
                     fcosKola(cosaDir: env.WORKSPACE,
                              build: params.VERSION, arch: params.ARCH,
                              extraArgs: tests,
                              skipUpgrade: true,
                              skipBasicScenarios: true,
-                             marker: "kola-m4",
+                             marker: "kola-xen",
                              platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=m4.large')
-                }, m6i: {
+                }
+                parallelruns['Kola:Intel-Ice-Lake'] = {
                     // https://github.com/coreos/fedora-coreos-tracker/issues/1004
                     fcosKola(cosaDir: env.WORKSPACE,
                              build: params.VERSION, arch: params.ARCH,
                              extraArgs: tests,
                              skipUpgrade: true,
                              skipBasicScenarios: true,
-                             marker: "kola-m6i",
+                             marker: "kola-intel-ice-lake",
                              platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=m6i.large')
                 }
             } else if (params.ARCH == "aarch64") {
@@ -109,14 +115,20 @@ try { timeout(time: 90, unit: 'MINUTES') {
                 if (tests == "") {
                     tests = "basic"
                 }
-                fcosKola(cosaDir: env.WORKSPACE,
-                            build: params.VERSION, arch: params.ARCH,
-                            extraArgs: tests,
-                            skipUpgrade: true,
-                            skipBasicScenarios: true,
-                            marker: "kola-c7g",
-                            platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=c7g.xlarge')
+                parallelruns['Kola:Graviton3'] = {
+                    // https://aws.amazon.com/ec2/instance-types/c7g/
+                    fcosKola(cosaDir: env.WORKSPACE,
+                                build: params.VERSION, arch: params.ARCH,
+                                extraArgs: tests,
+                                skipUpgrade: true,
+                                skipBasicScenarios: true,
+                                marker: "kola-graviton3",
+                                platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=c7g.xlarge')
+                }
             }
+
+            // process this batch
+            parallel parallelruns
         }
 
         currentBuild.result = 'SUCCESS'


### PR DESCRIPTION
```
commit fc19699a056b4f195972413abd9868b8b7ca96c2
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Oct 4 11:27:37 2022 -0400

    jobs/kola-aws: switch Xen test to i3.large to verify NVME
    
    Since we had a user report of broken NVME on i3.large let's switch
    our Xen test to that instance type and verify the NVME device works
    there. Also add in a test to make 100% sure we chose a Xen instance.

commit 45fe3510a5846f3388a40cc559558c9dd1c55fd7
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Oct 4 10:11:34 2022 -0400

    jobs/kola-aws: parallelize tests
    
    We don't typically have problems with quota on AWS so let's run all
    these in parallel. It has a few benefits:
    
    1. Faster
    2. If a test in Kola:Full fails because of a flake we still get the
       other tests (Xen, Ice Lake, Graviton3) to run. So we can safely
       ignore the flake in the future, but also get test results for
       those other tests.

```

Requires https://github.com/coreos/fedora-coreos-config/pull/2005