### PR TITLE
Rework jenkins-agent handling

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -441,9 +441,9 @@ a secret. This assumes `ca.crt` is a file in the working directory:
 ```
 oc create secret generic additional-root-ca-cert \
     --from-literal=filename=ca.crt --from-file=data=ca.crt
-oc label secret/oscontainer-push-registry-secret \
+oc label secret/additional-root-ca-cert \
     jenkins.io/credentials-type=secretFile
-oc annotate secret/oscontainer-push-registry-secret \
+oc annotate secret/additional-root-ca-cert \
     jenkins.io/credentials-description="Root certificate for XXX"
 ```
 

--- a/deploy
+++ b/deploy
@@ -101,8 +101,10 @@ def process_template(args):
     if args.cosa_img:
         params['COREOS_ASSEMBLER_IMAGE'] = args.cosa_img
     if has_additional_root_ca(args):
-        params['JENKINS_AGENT_IMAGE_TAG'] = "derived"
         templates += ['jenkins-agent.yaml']
+        # we want :latest to be owned by our BuildConfig, so call the base
+        # image :base instead of :latest
+        params['JENKINS_AGENT_BASE_TAG'] = "base"
 
     print("Parameters:")
     for k, v in params.items():

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -1,6 +1,6 @@
 import org.yaml.snakeyaml.Yaml;
 
-def pipeutils, pipecfg, official, uploading, jenkins_agent_image_tag
+def pipeutils, pipecfg, official, uploading
 def src_config_url, s3_bucket, aws_test_accounts
 node {
     checkout scm
@@ -12,7 +12,6 @@ node {
     def jenkinscfg = pipeutils.load_jenkins_config()
     src_config_url = pipecfg.source_config.url
     s3_bucket = pipecfg.s3_bucket
-    jenkins_agent_image_tag = jenkinscfg['jenkins-agent-image-tag']
 
     // Extra AWS testing accounts to share images with
     aws_test_accounts = pipecfg.clouds?.aws?.test_accounts
@@ -110,7 +109,6 @@ if (cosa_pod_image =~ '^coreos-assembler:rhcos-4.(6|7|8|9|10|11)$') {
 // substitute the right COSA image and mem request into the pod definition before spawning it
 pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "${cosa_memory_request_mb}Mi")
 pod = pod.replace("COREOS_ASSEMBLER_IMAGE", cosa_pod_image)
-pod = pod.replace("JENKINS_AGENT_IMAGE_TAG", jenkins_agent_image_tag)
 
 def podYaml = readYaml(text: pod);
 

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -1,6 +1,6 @@
 import org.yaml.snakeyaml.Yaml;
 
-def pipeutils, pipecfg, official, uploading, jenkins_agent_image_tag
+def pipeutils, pipecfg, official, uploading
 def src_config_url, s3_bucket, aws_test_accounts
 def gcp_gs_bucket
 node {
@@ -13,7 +13,6 @@ node {
     src_config_url = pipecfg.source_config.url
     s3_bucket = pipecfg.s3_bucket
     gcp_gs_bucket = pipecfg.clouds?.gcp?.bucket
-    jenkins_agent_image_tag = jenkinscfg['jenkins-agent-image-tag']
 
     // Extra AWS testing accounts to share images with
     aws_test_accounts = pipecfg.clouds?.aws?.test_accounts
@@ -101,7 +100,6 @@ pod = pod.replace("COREOS_ASSEMBLER_CPU_LIMIT", "${ncpus}")
 // substitute the right COSA image and mem request into the pod definition before spawning it
 pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "${cosa_memory_request_mb}Mi")
 pod = pod.replace("COREOS_ASSEMBLER_IMAGE", params.COREOS_ASSEMBLER_IMAGE)
-pod = pod.replace("JENKINS_AGENT_IMAGE_TAG", jenkins_agent_image_tag)
 
 def podYaml = readYaml(text: pod);
 

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -1,5 +1,4 @@
 def pipeutils, pipecfg, s3_bucket, official, src_config_url
-def jenkins_agent_image_tag
 node {
     checkout scm
     pipeutils = load("utils.groovy")
@@ -8,7 +7,6 @@ node {
     def jenkinscfg = pipeutils.load_jenkins_config()
     s3_bucket = pipecfg.s3_bucket
     src_config_url = pipecfg.source_config.url
-    jenkins_agent_image_tag = jenkinscfg['jenkins-agent-image-tag']
     official = pipeutils.isOfficial()
 }
 
@@ -54,7 +52,6 @@ currentBuild.description = "[${params.STREAM}][${params.ARCHES}] - ${params.VERS
 
 // substitute the right COSA image into the pod definition before spawning it
 pod = pod.replace("COREOS_ASSEMBLER_IMAGE", params.COREOS_ASSEMBLER_IMAGE)
-pod = pod.replace("JENKINS_AGENT_IMAGE_TAG", jenkins_agent_image_tag)
 
 // shouldn't need more than 256Mi for this job
 pod = pod.replace("COREOS_ASSEMBLER_MEMORY_REQUEST", "256Mi")

--- a/manifests/jenkins-agent.yaml
+++ b/manifests/jenkins-agent.yaml
@@ -31,7 +31,7 @@ objects:
       output:
         to:
           kind: ImageStreamTag
-          name: jenkins-agent:derived
+          name: jenkins-agent:latest
       successfulBuildsHistoryLimit: 2
       failedBuildsHistoryLimit: 2
       triggers:

--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -9,6 +9,9 @@ parameters:
   - description: Git branch/tag reference for Jenkins S2I
     name: JENKINS_S2I_REF
     value: main
+  - name: JENKINS_AGENT_BASE_TAG
+    description: Tag name of base OpenShift Jenkins agent image
+    value: latest
 
 objects:
 
@@ -58,7 +61,7 @@ objects:
         # this allows e.g. the pipeline to directly reference the imagestream
         local: true
       tags:
-        - name: base
+        - name: ${JENKINS_AGENT_BASE_TAG}
           from:
             kind: ImageStreamTag
             name: jenkins-agent-base:latest

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -86,10 +86,13 @@ objects:
           # DELTA: Increase heartbeat interval so durable-task-plugin waits a
           # bit longer for scripts to start before failing the build.
           # https://github.com/coreos/coreos-ci/issues/28
+          # DELTA: Set the default JNLP image to our Jenkins agent imagestream.
+          # https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/cloudbees-ci-on-modern-cloud-platforms/change-the-default-jnlp-image-for-kubernetes-agents-provisioning#_system_property_approach
           - name: JENKINS_JAVA_OVERRIDES
             value: >-
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=900
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true
+              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage=image-registry.openshift-image-registry.svc:5000/${NAMESPACE}/jenkins-agent:latest
           # DELTA: Increase session timeout to 24h (for docs on each field, see:
           # https://support.cloudbees.com/hc/en-us/articles/4406750806427)
           - name: JENKINS_OPTS

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -27,9 +27,6 @@ parameters:
   - description: Git branch/tag reference for pipeline configuration
     name: PIPECFG_REF
     value: main
-  - description: Jenkins agent image to use
-    name: JENKINS_AGENT_IMAGE_TAG
-    value: base
   - description: Image of coreos-assembler to use
     name: COREOS_ASSEMBLER_IMAGE
     value: quay.io/coreos-assembler/coreos-assembler:main
@@ -72,6 +69,5 @@ objects:
     data:
       jenkins-jobs-url: ${JENKINS_JOBS_URL}
       jenkins-jobs-ref: ${JENKINS_JOBS_REF}
-      jenkins-agent-image-tag: ${JENKINS_AGENT_IMAGE_TAG}
       pipecfg-url: ${PIPECFG_URL}
       pipecfg-ref: ${PIPECFG_REF}

--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -11,9 +11,6 @@ spec:
   # run as `jenkins` so we can do `oc start-build`
   serviceAccountName: jenkins
   containers:
-   - name: jnlp
-     image: jenkins-agent:JENKINS_AGENT_IMAGE_TAG
-     args: ['$(JENKINS_SECRET)', '$(JENKINS_NAME)']
    - name: coreos-assembler
      image: COREOS_ASSEMBLER_IMAGE
      imagePullPolicy: Always


### PR DESCRIPTION
Because of the additional root CA, we need the ability to optionally set
up a BuildConfig that will layer the root CA onto the base jenkins-agent
image.

However, the way we did this was exposing this choice to the Jenkins
jobs where they had to know which tag to use. This becomes cumbersome if
we also want to make use of coreos-ci-lib helpers.

Rather than trying to plumb that all the way through, we change tactics:
1. set a system property telling the Kubernetes plugin to default to our
   Jenkins agent imagestream tagged `:latest`
2. default `:latest` to be the base OpenShift Jenkins agent image
3. if an additional root CA is provided, make `:latest` be the output of
   the `jenkins-agent` BuildConfig

That way, jobs no longer have to set any explicit Jenkins agent image,
and the Kubernetes plugin will automatically choose the correct one.

This actually also fixes an issue with CoreOS CI where it's using the
upstream Jenkins agent image instead of the default image from the
OpenShift release payload because there, we haven't been explicitly
overriding the image for a long time (see
https://github.com/coreos/coreos-ci-lib/commit/f1eca31ed7d7).

This is also prep for dropping `pod.yaml` and using `cosaPod` instead.
