### PR TITLE
jobs/build: templatize source config ref to use

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -199,6 +199,12 @@ lock(resource: "build-${params.STREAM}-${params.ARCH}") {
 
         def local_builddir = "/srv/devel/streams/${params.STREAM}"
         def ref = params.STREAM
+        if (stream_info.source_config_ref) {
+          ref = stream_info.source_config_ref
+        } else if (pipecfg.source_config.ref) {
+          // XXX: move to generic templating function
+          ref = pipecfg.source_config.ref.replace('${STREAM}', params.STREAM)
+        }
         def src_config_commit
         if (params.SRC_CONFIG_COMMIT) {
             src_config_commit = params.SRC_CONFIG_COMMIT

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -159,6 +159,12 @@ lock(resource: "build-${params.STREAM}") {
 
         def local_builddir = "/srv/devel/streams/${params.STREAM}"
         def ref = params.STREAM
+        if (stream_info.source_config_ref) {
+          ref = stream_info.source_config_ref
+        } else if (pipecfg.source_config.ref) {
+          // XXX: move to generic templating function
+          ref = pipecfg.source_config.ref.replace('${STREAM}', params.STREAM)
+        }
         def src_config_commit = shwrapCapture("git ls-remote ${pipecfg.source_config.url} ${ref} | cut -d \$'\t' -f 1")
 
         stage('Init') {


### PR DESCRIPTION
RHCOS uses a different naming scheme from FCOS. Support a new `ref` member under `source_config` and also per-stream overrides (for the `master` branch).

```yaml
source_config:
  url: https://github.com/openshift/os
  ref: release-${STREAM}

streams:
  4.12:
    source_config_ref: master
```