### PR TITLE
treewide: fedora-coreos -> coreos-pipeline in some labels/descriptions

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -552,7 +552,7 @@ One can leverage Kubernetes labels to delete all objects
 related to the pipeline:
 
 ```
-oc delete all -l app=fedora-coreos
+oc delete all -l app=coreos-pipeline
 ```
 
 This won't delete a few resources. Notably the PVC and the
@@ -562,7 +562,7 @@ require cluster admin access to reallocate it in the future
 other objects:
 
 ```
-oc delete serviceaccounts -l app=fedora-coreos
-oc delete rolebindings -l app=fedora-coreos
-oc delete configmaps -l app=fedora-coreos
+oc delete serviceaccounts -l app=coreos-pipeline
+oc delete rolebindings -l app=coreos-pipeline
+oc delete configmaps -l app=coreos-pipeline
 ```

--- a/manifests/jenkins-agent.yaml
+++ b/manifests/jenkins-agent.yaml
@@ -6,6 +6,9 @@ apiVersion: v1
 kind: Template
 metadata:
   name: jenkins-agent
+labels:
+  app: coreos-pipeline
+  template: coreos-pipeline-jenkins-agent-template
 objects:
   - kind: BuildConfig
     apiVersion: v1

--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Template
 metadata:
   name: jenkins-s2i
+labels:
+  app: coreos-pipeline
+  template: coreos-pipeline-jenkins-s2i-template
 parameters:
   - description: Git source URI for Jenkins S2I
     name: JENKINS_S2I_URL

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -5,13 +5,13 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 labels:
-  app: fedora-coreos
-  template: fedora-coreos-jenkins-template
+  app: coreos-pipeline
+  template: coreos-pipeline-jenkins-template
 message: A Jenkins service has been created in your project.  Log into Jenkins with
   your OpenShift account.  The tutorial at https://github.com/openshift/origin/blob/master/examples/jenkins/README.md
   contains more information about using this template.
 metadata:
-  name: fedora-coreos-jenkins
+  name: coreos-pipeline-jenkins
 objects:
 - apiVersion: v1
   kind: Route

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Template
 labels:
-  app: fedora-coreos
-  template: fedora-coreos-template
+  app: coreos-pipeline
+  template: coreos-pipeline-template
 parameters:
   - description: Git source URI for Jenkins jobs
     name: JENKINS_JOBS_URL

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -3,17 +3,6 @@ kind: Template
 labels:
   app: fedora-coreos
   template: fedora-coreos-template
-metadata:
-  annotations:
-    description: |-
-      Jenkins pipeline for Fedora CoreOS.
-    iconClass: icon-jenkins
-    openshift.io/display-name: Fedora CoreOS Pipeline
-    openshift.io/documentation-url: https://github.com/coreos/fedora-coreos-pipeline
-    openshift.io/support-url: https://github.com/coreos/fedora-coreos-pipeline
-    openshift.io/provider-display-name: Fedora CoreOS
-    tags: fcos,jenkins,fedora
-  name: fedora-coreos
 parameters:
   - description: Git source URI for Jenkins jobs
     name: JENKINS_JOBS_URL


### PR DESCRIPTION
```
commit 0424601f087fb4143fa280830d3bf20c2db30132
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Oct 5 22:13:30 2022 -0400

    manifests: add app=coreos-pipeline label to some objects
    
    This should help clean more things up when trying to follow the
    documentation at https://github.com/coreos/fedora-coreos-pipeline/blob/main/HACKING.md#nuking-everything

commit d0ab10453d6d319eb411a7dee717dd8ecfb39929
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Oct 5 22:11:34 2022 -0400

    treewide: fedora-coreos -> coreos-pipeline in some labels/descriptions
    
    This advances the recent efforts to make the pipeline naming more
    generic so it doesn't feel so specific to Fedora CoreOS. In the case
    we replace "Fedora CoreOS" in various places with "CoreOS Pipeline".

```
