### PR TITLE
manifests: Update apiVersion to template.openshift.io/v1

### DIFF
--- a/manifests/jenkins-agent.yaml
+++ b/manifests/jenkins-agent.yaml
@@ -2,7 +2,7 @@
 # doesn't actually need to be a template (there are no parameters), but the way
 # `deploy` currently works expects it as a template.
 
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: jenkins-agent

--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: jenkins-s2i

--- a/manifests/pipeline.yaml
+++ b/manifests/pipeline.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 labels:
   app: fedora-coreos


### PR DESCRIPTION
Should make the manifests work with 4.11.

Fixes:
```
W0915 13:21:03.098571  369479 shim_kubectl.go:58] Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to "template.openshift.io/v1" for your resource
```