### PR TITLE
manifests/jenkins.yaml: use imagestream name for jenkins-agent

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -92,7 +92,7 @@ objects:
             value: >-
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=900
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true
-              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage=image-registry.openshift-image-registry.svc:5000/${NAMESPACE}/jenkins-agent:latest
+              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage=jenkins-agent:latest
           # DELTA: Increase session timeout to 24h (for docs on each field, see:
           # https://support.cloudbees.com/hc/en-us/articles/4406750806427)
           - name: JENKINS_OPTS


### PR DESCRIPTION
The imagestream already has the local lookupPolicy enabled, so this already works. That way we avoid hardcoding the registry name.