### PR TITLE
utils.groovy: fix path to CA certificates

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -204,7 +204,7 @@ def addOptionalRootCA() {
         // Also sync it over to the remote if we're operating in a remote session
         shwrap('''
         if [ -n "${COREOS_ASSEMBLER_REMOTE_SESSION:-}" ]; then
-            cosa remote-session sync {,:}/etc/pki/ca-trust/anchors/
+            cosa remote-session sync {,:}/etc/pki/ca-trust/source/anchors/
             cosa shell -- /usr/lib/coreos-assembler/update-ca-trust-unpriv
         fi
         ''')


### PR DESCRIPTION
Fixes 99c69fb ("utils: also sync root CA to remote cosa").