### PR TITLE
utils: fix rsyncing X.509 fedmsg cert directory

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -187,7 +187,7 @@ def tryWithMessagingCredentials(Closure body) {
             cosa remote-session sync {,:}/${FEDORA_MESSAGING_CONF}
             cosa shell -- sudo install -d -D -o builder -g builder --mode 777 \
                 $(dirname ${FEDORA_MESSAGING_X509_CERT_PATH})
-            cosa remote-session sync {,:}/${FEDORA_MESSAGING_X509_CERT_PATH}
+            cosa remote-session sync {,:}/${FEDORA_MESSAGING_X509_CERT_PATH}/
         fi
         ''')
         body()


### PR DESCRIPTION
We need the trailing slash here so that rsync copies the contents of the directory rather than the directory itself into the new directory.