### PR TITLE
utils.groovy: Change `additional_artifacts` to `skip_artifacts`

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -38,12 +38,12 @@ streams:
       type: production
       # OPTIONAL: override cosa image to use for this stream
       cosa_image: "quay.io/jlebon/coreos-assembler:stable"
-      # OPTIONAL: additional artifacts to build for this stream
-      additional_artifacts:
+      # OPTIONAL: skip some of the default artifacts for this stream
+      skip_artifacts:
         aarch64:
-          - azure
-        ppc64le:
-          - powervs
+          - openstack
+        x86_64:
+          - vmware
     rawhide:
       type: mechanical
 

--- a/utils.groovy
+++ b/utils.groovy
@@ -282,14 +282,14 @@ def get_artifacts_to_build(pipecfg, stream, basearch) {
     def artifacts = []
     if  (pipecfg.streams[stream].artifacts?."${basearch}" != null) {
         artifacts = pipecfg.streams[stream]['artifacts'][basearch]
-    } else { // Merge default with additional artifacts
+    } else { // Get the list difference from default with skip artifacts
         def default_artifacts =  pipecfg['default_artifacts'][basearch]
-        def additional_atifacts = pipecfg.streams[stream].additional_artifacts?."${basearch}"
+        def skip_artifacts = pipecfg.streams[stream].skip_artifacts?."${basearch}"
         if (default_artifacts != null) {
-            artifacts += default_artifacts
+            artifacts = default_artifacts
         }
-        if (additional_atifacts != null) {
-            artifacts += additional_atifacts
+        if (skip_artifacts != null) {
+            artifacts -= skip_artifacts
         }
     }
     return artifacts.unique()


### PR DESCRIPTION
 - Instead of using additional artifacts use skip artifacts, in this way the default artifact list will use the artifact list from the latest version and not the old.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>