### PR TITLE
config: disable branched stream

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,8 +12,8 @@ streams:
       type: development # do not touch; line managed by `next-devel/manage.py`
     rawhide:
       type: mechanical
-    branched:
-      type: mechanical
+    # branched:
+    #  type: mechanical
     # bodhi-updates:
     #   type: mechanical
     # bodhi-updates-testing:


### PR DESCRIPTION
I think we can drop this now that we have `next-devel` on F37. We'll re-enable it if we find a good reason to.