### PR TITLE
jobs/{build,kola*}: bump memory requests

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -75,7 +75,7 @@ def strict_build_param = stream_info.type == "mechanical" ? "" : "--strict"
 // here; we can look into making them configurable through the template if
 // developers really need to tweak them (note that in the default minimal devel
 // workflow, only the qemu image is built).
-def cosa_memory_request_mb = 6.5 * 1024 as Integer
+def cosa_memory_request_mb = 8.5 * 1024 as Integer
 
 // Now that we've established the memory constraint based on xz above, derive
 // kola parallelism from that. We leave 512M for overhead and VMs are 1G each

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -52,7 +52,7 @@ if (s3_stream_dir == "") {
 }
 
 try { timeout(time: 90, unit: 'MINUTES') {
-    cosaPod(memory: "256Mi", kvm: false,
+    cosaPod(memory: "512Mi", kvm: false,
             image: params.COREOS_ASSEMBLER_IMAGE) {
 
         stage('Fetch Metadata') {

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -60,7 +60,8 @@ lock(resource: "kola-azure-${params.ARCH}") {
     }
 
     try { timeout(time: 75, unit: 'MINUTES') {
-        cosaPod(memory: "256Mi", kvm: false,
+        // Go with 1Gi here because we download/decompress/upload the image
+        cosaPod(memory: "1Gi", kvm: false,
                 image: params.COREOS_ASSEMBLER_IMAGE) {
 
             def azure_image_name, azure_image_filepath

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -52,7 +52,7 @@ if (s3_stream_dir == "") {
 }
 
 try { timeout(time: 30, unit: 'MINUTES') {
-    cosaPod(memory: "256Mi", kvm: false,
+    cosaPod(memory: "512Mi", kvm: false,
             image: params.COREOS_ASSEMBLER_IMAGE) {
 
         stage('Fetch Metadata') {

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -48,7 +48,7 @@ if (s3_stream_dir == "") {
 }
 
 try { timeout(time: 60, unit: 'MINUTES') {
-    cosaPod(memory: "256Mi", kvm: false,
+    cosaPod(memory: "512Mi", kvm: false,
             image: params.COREOS_ASSEMBLER_IMAGE) {
 
         stage('Fetch Metadata') {

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -61,7 +61,8 @@ lock(resource: "kola-openstack-${params.ARCH}") {
     }
 
     try { timeout(time: 90, unit: 'MINUTES') {
-        cosaPod(memory: "256Mi", kvm: false,
+        // Go with 1Gi here because we download/decompress/upload the image
+        cosaPod(memory: "1Gi", kvm: false,
                 image: params.COREOS_ASSEMBLER_IMAGE) {
 
             def openstack_image_name, openstack_image_filepath


### PR DESCRIPTION
Now that we set the memory limit as well we find out we're using more than we are requesting. Let's request a more appropriate amount of memory for our jobs.

For the build job we set it to 8.5 Gi because we run two testiso runs
at the same time and those can take up to 4Gi each.


For the kola-* jobs the request is updated to 1Gi if the job is going
to download and decompress the disk image artifact and 512Mi otherwise.

