### PR TITLE
jobs/{build,build-arch,bump-lockfile}: start using kola() kolaTestIso()

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -161,7 +161,9 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         // We set the session to time out after 4h. This essentially
         // performs garbage collection on the remote if we fail to clean up.
         pipeutils.withPodmanRemoteArchBuilder(arch: basearch) {
-        def session = shwrapCapture("cosa remote-session create --image ${image} --expiration 4h")
+        def session = shwrapCapture("""
+        cosa remote-session create --image ${image} --expiration 4h --workdir ${env.WORKSPACE}
+        """)
         withEnv(["COREOS_ASSEMBLER_REMOTE_SESSION=${session}"]) {
 
         // add any additional root CA cert before we do anything that fetches

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -104,8 +104,9 @@ try { lock(resource: "bump-${params.STREAM}") { timeout(time: 120, unit: 'MINUTE
         parallel archinfo.keySet().collectEntries{arch -> [arch, {
             if (arch != "x86_64") {
                 pipeutils.withPodmanRemoteArchBuilder(arch: arch) {
-                    archinfo[arch]['session'] = \
-                        shwrapCapture("cosa remote-session create --image ${image} --expiration 4h")
+                    archinfo[arch]['session'] = shwrapCapture("""
+                    cosa remote-session create --image ${image} --expiration 4h --workdir ${env.WORKSPACE}
+                    """)
                     withEnv(["COREOS_ASSEMBLER_REMOTE_SESSION=${archinfo[arch]['session']}"]) {
                         shwrap("""
                         cosa init --branch ${branch} --commit=${src_config_commit} https://github.com/${repo}

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -77,11 +77,11 @@ try { timeout(time: 90, unit: 'MINUTES') {
             def parallelruns = [:]
 
             parallelruns['Kola:Full'] = {
-                fcosKola(cosaDir: env.WORKSPACE, parallel: 5,
-                         build: params.VERSION, arch: params.ARCH,
-                         extraArgs: params.KOLA_TESTS,
-                         skipBasicScenarios: true,
-                         platformArgs: '-p=aws --aws-region=us-east-1')
+                kola(cosaDir: env.WORKSPACE, parallel: 5,
+                     build: params.VERSION, arch: params.ARCH,
+                     extraArgs: params.KOLA_TESTS,
+                     skipBasicScenarios: true,
+                     platformArgs: '-p=aws --aws-region=us-east-1')
             }
 
             if (params.ARCH == "x86_64") {
@@ -100,23 +100,21 @@ try { timeout(time: 90, unit: 'MINUTES') {
                     if (xen_tests == "basic") {
                         xen_tests = "basic ext.config.platforms.aws.nvme ext.config.platforms.aws.assert-xen"
                     }
-                    fcosKola(cosaDir: env.WORKSPACE,
-                             build: params.VERSION, arch: params.ARCH,
-                             extraArgs: xen_tests,
-                             skipUpgrade: true,
-                             skipBasicScenarios: true,
-                             marker: "kola-xen",
-                             platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=i3.large')
+                    kola(cosaDir: env.WORKSPACE,
+                         build: params.VERSION, arch: params.ARCH,
+                         extraArgs: xen_tests,
+                         skipUpgrade: true,
+                         marker: "xen",
+                         platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=i3.large')
                 }
                 parallelruns['Kola:Intel-Ice-Lake'] = {
                     // https://github.com/coreos/fedora-coreos-tracker/issues/1004
-                    fcosKola(cosaDir: env.WORKSPACE,
-                             build: params.VERSION, arch: params.ARCH,
-                             extraArgs: tests,
-                             skipUpgrade: true,
-                             skipBasicScenarios: true,
-                             marker: "kola-intel-ice-lake",
-                             platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=m6i.large')
+                    kola(cosaDir: env.WORKSPACE,
+                         build: params.VERSION, arch: params.ARCH,
+                         extraArgs: tests,
+                         skipUpgrade: true,
+                         marker: "intel-ice-lake",
+                         platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=m6i.large')
                 }
             } else if (params.ARCH == "aarch64") {
                 def tests = params.KOLA_TESTS
@@ -125,13 +123,12 @@ try { timeout(time: 90, unit: 'MINUTES') {
                 }
                 parallelruns['Kola:Graviton3'] = {
                     // https://aws.amazon.com/ec2/instance-types/c7g/
-                    fcosKola(cosaDir: env.WORKSPACE,
-                                build: params.VERSION, arch: params.ARCH,
-                                extraArgs: tests,
-                                skipUpgrade: true,
-                                skipBasicScenarios: true,
-                                marker: "kola-graviton3",
-                                platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=c7g.xlarge')
+                    kola(cosaDir: env.WORKSPACE,
+                         build: params.VERSION, arch: params.ARCH,
+                         extraArgs: tests,
+                         skipUpgrade: true,
+                         marker: "graviton3",
+                         platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=c7g.xlarge')
                 }
             }
 

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -140,16 +140,15 @@ lock(resource: "kola-azure-${params.ARCH}") {
                 // skip the upgrade test.
                 try {
                     def azure_subscription = shwrapCapture("jq -r .subscriptionId \${AZURE_KOLA_TESTS_CONFIG_AUTH}")
-                    fcosKola(cosaDir: env.WORKSPACE, parallel: 10,
-                            build: params.VERSION, arch: params.ARCH,
-                            extraArgs: params.KOLA_TESTS,
-                            skipBasicScenarios: true,
-                            skipUpgrade: true,
-                            platformArgs: """-p=azure                               \
-                                --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
-                                --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
-                                --azure-location $region                            \
-                                --azure-disk-uri /subscriptions/${azure_subscription}/resourceGroups/${azure_testing_resource_group}/providers/Microsoft.Compute/images/${azure_image_name}""")
+                    kola(cosaDir: env.WORKSPACE, parallel: 10,
+                         build: params.VERSION, arch: params.ARCH,
+                         extraArgs: params.KOLA_TESTS,
+                         skipUpgrade: true,
+                         platformArgs: """-p=azure                               \
+                             --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
+                             --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
+                             --azure-location $region                            \
+                             --azure-disk-uri /subscriptions/${azure_subscription}/resourceGroups/${azure_testing_resource_group}/providers/Microsoft.Compute/images/${azure_image_name}""")
                 } finally {
                     parallel "Delete Image": {
                         // Delete the image in Azure

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -75,13 +75,12 @@ try { timeout(time: 30, unit: 'MINUTES') {
                               credentialsId: 'gcp-kola-tests-config')]) {
             // pick up the project to use from the config
             def gcp_project = shwrapCapture("jq -r .project_id \${GCP_KOLA_TESTS_CONFIG}")
-            fcosKola(cosaDir: env.WORKSPACE, parallel: 5,
-                     build: params.VERSION, arch: params.ARCH,
-                     extraArgs: params.KOLA_TESTS,
-                     skipBasicScenarios: true,
-                     platformArgs: """-p=gce \
-                        --gce-json-key=\${GCP_KOLA_TESTS_CONFIG} \
-                        --gce-project=${gcp_project}""")
+            kola(cosaDir: env.WORKSPACE, parallel: 5,
+                 build: params.VERSION, arch: params.ARCH,
+                 extraArgs: params.KOLA_TESTS,
+                 platformArgs: """-p=gce \
+                    --gce-json-key=\${GCP_KOLA_TESTS_CONFIG} \
+                    --gce-project=${gcp_project}""")
         }
 
         currentBuild.result = 'SUCCESS'

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -71,12 +71,11 @@ try { timeout(time: 60, unit: 'MINUTES') {
         // realistic than QEMU and it also supports aarch64.
         withCredentials([file(variable: 'AWS_CONFIG_FILE',
                               credentialsId: 'aws-kola-tests-config')]) {
-            fcosKola(cosaDir: env.WORKSPACE,
-                     build: params.VERSION, arch: params.ARCH,
-                     extraArgs: "--tag k8s",
-                     skipUpgrade: true,
-                     skipBasicScenarios: true,
-                     platformArgs: '-p=aws --aws-region=us-east-1')
+            kola(cosaDir: env.WORKSPACE,
+                 build: params.VERSION, arch: params.ARCH,
+                 extraArgs: "--tag k8s",
+                 skipUpgrade: true,
+                 platformArgs: '-p=aws --aws-region=us-east-1')
         }
 
         currentBuild.result = 'SUCCESS'

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -116,19 +116,18 @@ lock(resource: "kola-openstack-${params.ARCH}") {
                 // Since we don't have permanent images uploaded to VexxHost we'll
                 // skip the upgrade test.
                 try {
-                    fcosKola(cosaDir: env.WORKSPACE, parallel: 5,
-                            build: params.VERSION, arch: params.ARCH,
-                            extraArgs: params.KOLA_TESTS,
-                            skipBasicScenarios: true,
-                            skipUpgrade: true,
-                            platformArgs: """-p=openstack                               \
-                                --allow-rerun-success                                   \
-                                --openstack-config-file=\${OPENSTACK_KOLA_TESTS_CONFIG} \
-                                --openstack-flavor=v3-starter-4                         \
-                                --openstack-network=private                             \
-                                --openstack-region=${region}                            \
-                                --openstack-floating-ip-network=public                  \
-                                --openstack-image=${openstack_image_name}""")
+                    kola(cosaDir: env.WORKSPACE, parallel: 5,
+                         build: params.VERSION, arch: params.ARCH,
+                         extraArgs: params.KOLA_TESTS,
+                         skipUpgrade: true,
+                         platformArgs: """-p=openstack                               \
+                             --allow-rerun-success                                   \
+                             --openstack-config-file=\${OPENSTACK_KOLA_TESTS_CONFIG} \
+                             --openstack-flavor=v3-starter-4                         \
+                             --openstack-network=private                             \
+                             --openstack-region=${region}                            \
+                             --openstack-floating-ip-network=public                  \
+                             --openstack-image=${openstack_image_name}""")
                 } finally {
                     stage('Delete Image') {
                         // Delete the image in OpenStack


### PR DESCRIPTION
With recent updates to coreos-ci-lib [1] we can now using the kola() and kolaTestIso() functions even for multi-arch. This enables us to share code for kola tests across the three places that had heavily duplicated code in the past.

[1] https://github.com/coreos/coreos-ci-lib/pull/120