### PR TITLE
config: start producing azure artifacts for aarch64

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -33,6 +33,7 @@ registry_repos:
 
 default_artifacts:
   aarch64:
+    - azure
     - openstack
     - live
     - metal


### PR DESCRIPTION
The Typhoon project requested this and it worked for me the last time I tried so we might as well start creating the file.