### PR TITLE
jobs/{build,build-arch}: fix off by one issue with artifact builds

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -419,8 +419,13 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
                 }]
             }
             def artifacts_split_idx = artifacts.size().intdiv(2)
-            parallel parallelruns.subMap(artifacts[0..artifacts_split_idx-1])
-            parallel parallelruns.subMap(artifacts[artifacts_split_idx..-1])
+            // use [0..artifacts_split_idx] for the first run and
+            // [artifacts_split_idx+1..-1] for the second run so we
+            // can guarantee if we're only building metal/live artifacts
+            // that the two metal runs go in the first run.
+            // https://github.com/coreos/fedora-coreos-pipeline/pull/695
+            parallel parallelruns.subMap(artifacts[0..artifacts_split_idx])
+            parallel parallelruns.subMap(artifacts[artifacts_split_idx+1..-1])
 
             // Hack for serial console on aarch64 aws images
             // see https://github.com/coreos/fedora-coreos-tracker/issues/920#issuecomment-914334988

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -434,8 +434,13 @@ lock(resource: "build-${params.STREAM}") {
                 }]
             }
             def artifacts_split_idx = artifacts.size().intdiv(2)
-            parallel parallelruns.subMap(artifacts[0..artifacts_split_idx-1])
-            parallel parallelruns.subMap(artifacts[artifacts_split_idx..-1])
+            // use [0..artifacts_split_idx] for the first run and
+            // [artifacts_split_idx+1..-1] for the second run so we
+            // can guarantee if we're only building metal/live artifacts
+            // that the two metal runs go in the first run.
+            // https://github.com/coreos/fedora-coreos-pipeline/pull/695
+            parallel parallelruns.subMap(artifacts[0..artifacts_split_idx])
+            parallel parallelruns.subMap(artifacts[artifacts_split_idx+1..-1])
 
             stage('Test Live ISO') {
                 // compress the metal and metal4k images now so we're testing


### PR DESCRIPTION
We've structured our artifact builds into two runs and we've also gone to some effort to put the metal and metal4k builds into the first run and the live ISO build into the second run (since the ISO depends on the metal/metal4k). The way we had it before if you trimmed down your list such that you were only building metal/metal4k/live then you'd end up with metal in the first run and metal4k/live in the second run, which fails for obvious reasons. Let's flip that so that metal and metal4k will be in the first run.