### PR TITLE
jobs/release: bump memory for release job to 512Mi

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -58,7 +58,7 @@ def stream_info = pipecfg.streams[params.STREAM]
 // Also lock version-arch-specific locks to make sure these builds are finished.
 def locks = basearches.collect{[resource: "release-${params.VERSION}-${it}"]}
 lock(resource: "release-${params.STREAM}", extra: locks) {
-    cosaPod(cpu: "1", memory: "256Mi",
+    cosaPod(cpu: "1", memory: "512Mi",
             image: params.COREOS_ASSEMBLER_IMAGE) {
     try {
 


### PR DESCRIPTION
I've seen the release job get killed a few times when performing the buildfetch:

```
11:50:06  + cosa buildfetch --artifact=ostree --build=37.20221018.10.1 --arch=all --url=s3://fcos-builds/prod/streams/next-devel/builds
11:50:06  2022-10-19 15:50:06,343 INFO - Credentials found in config file: ****
11:50:06  Fetching: s3://fcos-builds/prod/streams/next-devel/builds/builds.json
11:50:06  Updated builds/builds.json
11:50:06  Fetching: s3://fcos-builds/prod/streams/next-devel/builds/37.20221018.10.1/x86_64/meta.json
11:50:06  Fetching: s3://fcos-builds/prod/streams/next-devel/builds/37.20221018.10.1/x86_64/commitmeta.json
11:50:06  Fetching: s3://fcos-builds/prod/streams/next-devel/builds/37.20221018.10.1/x86_64/ostree-commit-object
11:50:06  Fetching: s3://fcos-builds/prod/streams/next-devel/builds/37.20221018.10.1/x86_64/fedora-coreos-37.20221018.10.1-ostree.x86_64.ociarchive
11:50:16  Fetching: s3://fcos-builds/prod/streams/next-devel/builds/37.20221018.10.1/s390x/meta.json
11:50:16  Fetching: s3://fcos-builds/prod/streams/next-devel/builds/37.20221018.10.1/s390x/commitmeta.json
11:50:16  Fetching: s3://fcos-builds/prod/streams/next-devel/builds/37.20221018.10.1/s390x/ostree-commit-object
11:50:16  Fetching: s3://fcos-builds/prod/streams/next-devel/builds/37.20221018.10.1/s390x/fedora-coreos-37.20221018.10.1-ostree.s390x.ociarchive
11:50:31  error: failed to execute cmd-buildfetch: signal: killed
```

We're most likely hitting the existing 256Mi memory limit. Let's bump it.