### PR TITLE
jobs/build-cosa: bump memory request to 512Mi

### DIFF
--- a/jobs/build-cosa.Jenkinsfile
+++ b/jobs/build-cosa.Jenkinsfile
@@ -96,7 +96,7 @@ try {
     lock(resource: "build-${containername}") {
     timeout(time: 60, unit: 'MINUTES') {
     cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
-            memory: "256Mi", kvm: false) {
+            memory: "512Mi", kvm: false) {
 
         currentBuild.description = "[${gitref}@${shortcommit}] Running"
 


### PR DESCRIPTION
I've seen this job fail a few times today with:

```
[2022-10-19T20:00:25.440Z] + cosa remote-build-container --arch x86_64 --cache-ttl 24h --git-ref 32062fd522296e8b74199b2841697c85f26733c8 --git-url https://github.com/coreos/coreos-assembler.git --repo quay.io/coreos-assembler/staging --push-to-registry --auth=****
[2022-10-19T20:00:28.690Z] 2022-10-19 20:00:28,214 INFO - Translated https://github.com/coreos/coreos-assembler.git#32062fd522296e8b74199b2841697c85f26733c8 into 32062fd
[2022-10-19T20:00:28.690Z] 2022-10-19 20:00:28,215 INFO - Targetting a container image for quay.io/coreos-assembler/staging:x86_64-32062fd
[2022-10-19T20:00:28.690Z] 2022-10-19 20:00:28,215 INFO - Running command: ['podman', 'search', '--list-tags', 'quay.io/coreos-assembler/staging']
[2022-10-19T20:00:28.944Z] 2022-10-19 20:00:28,713 INFO - Running command: ['podman', 'image', 'exists', 'quay.io/coreos-assembler/staging:x86_64-32062fd']
[2022-10-19T20:00:29.197Z] 2022-10-19 20:00:28,987 INFO - Building container via podman
[2022-10-19T20:00:29.199Z] 2022-10-19 20:00:28,987 INFO - Running command: ['podman', 'build', '--cache-ttl=24h', '--tag=quay.io/coreos-assembler/staging:x86_64-32062fd', '/tmp/tmpatug_qu6/', '--label=org.opencontainers.image.revision=32062fd522296e8b74199b2841697c85f26733c8', '--label=org.opencontainers.image.source=https://github.com/coreos/coreos-assembler.git']
[2022-10-19T20:00:39.107Z] 2022-10-19 20:00:38,487 ERROR - Command returned bad exitcode
[2022-10-19T20:00:39.108Z] 2022-10-19 20:00:38,488 ERROR - COMMAND: ['podman', 'build', '--cache-ttl=24h', '--tag=quay.io/coreos-assembler/staging:x86_64-32062fd', '/tmp/tmpatug_qu6/', '--label=org.opencontainers.image.revision=32062fd522296e8b74199b2841697c85f26733c8', '--label=org.opencontainers.image.source=https://github.com/coreos/coreos-assembler.git']
[2022-10-19T20:00:39.108Z] Traceback (most recent call last):
[2022-10-19T20:00:39.108Z]   File "/usr/lib/coreos-assembler/cmd-remote-build-container", line 236, in <module>
[2022-10-19T20:00:39.108Z]     sys.exit(main())
[2022-10-19T20:00:39.108Z]   File "/usr/lib/coreos-assembler/cmd-remote-build-container", line 160, in main
[2022-10-19T20:00:39.108Z]     build_container_image(args.labels, builddir, args.fromimage,
[2022-10-19T20:00:39.108Z]   File "/usr/lib/coreos-assembler/cmd-remote-build-container", line 33, in build_container_image
[2022-10-19T20:00:39.108Z]     runcmd(cmd)
[2022-10-19T20:00:39.108Z]   File "/usr/lib/coreos-assembler/cosalib/cmdlib.py", line 78, in runcmd
[2022-10-19T20:00:39.108Z]     raise e
[2022-10-19T20:00:39.108Z]   File "/usr/lib/coreos-assembler/cosalib/cmdlib.py", line 70, in runcmd
[2022-10-19T20:00:39.108Z]     cp = subprocess.run(cmd, **pargs)
[2022-10-19T20:00:39.108Z]   File "/usr/lib64/python3.10/subprocess.py", line 524, in run
[2022-10-19T20:00:39.108Z]     raise CalledProcessError(retcode, process.args,
[2022-10-19T20:00:39.108Z] subprocess.CalledProcessError: Command '['podman', 'build', '--cache-ttl=24h', '--tag=quay.io/coreos-assembler/staging:x86_64-32062fd', '/tmp/tmpatug_qu6/', '--label=org.opencontainers.image.revision=32062fd522296e8b74199b2841697c85f26733c8', '--label=org.opencontainers.image.source=https://github.com/coreos/coreos-assembler.git']' died with <Signals.SIGKILL: 9>.
[2022-10-19T20:00:39.108Z] error: failed to execute cmd-remote-build-container: exit status 1
script returned exit code 1
```

I suspect we are bumping up into our memory limit. Let's bump it.