### PR TITLE
Add support for pushing extensions container and legacy oscontainer

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -349,7 +349,25 @@ oc create secret generic oscontainer-push-registry-secret \
 oc label secret/oscontainer-push-registry-secret \
     jenkins.io/credentials-type=secretFile
 oc annotate secret/oscontainer-push-registry-secret \
-    jenkins.io/credentials-description="Registry push secret for CoreOS OSContainer"
+    jenkins.io/credentials-description="Push secret for registry for CoreOS OSContainer"
+```
+
+### [PROD] Create OSContainer image push secret for old location
+
+This secret is used to push the oscontainer and others to the old registry. The
+secret can be obtained from the `oscontainer-push-old-registry-secret` in
+BitWarden.
+
+After obtaining the secret data you can create the Kubernetes secret via:
+
+```
+oc create secret generic oscontainer-push-old-registry-secret \
+    --from-literal=filename=dockercfg \
+    --from-file=data=oscontainer-push-old-registry-secret
+oc label secret/oscontainer-push-old-registry-secret \
+    jenkins.io/credentials-type=secretFile
+oc annotate secret/oscontainer-push-old-registry-secret \
+    jenkins.io/credentials-description="Push secret for old registry for CoreOS OSContainer"
 ```
 
 ### [PROD] Create COSA image push secret

--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,9 @@ s3_bucket: fcos-builds
 
 registry_repos:
   oscontainer: quay.io/fedora/fedora-coreos
+  # For a period of time let's also mirror into the old location too
+  # Drop this after October 2022. See
+  # https://discussion.fedoraproject.org/t/updated-registry-location-for-fedora-coreos-ostree-native-container/42740
   oscontainer_old: quay.io/coreos-assembler/fcos
 
 default_artifacts:

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -44,6 +44,10 @@ streams:
           - openstack
         x86_64:
           - vmware
+      # OPTIONAL: stream-specific container repos to push to
+      additional_registry_repos:
+        oscontainer_old: registry.ci.openshift.org/rhcos-devel/machine-os-oci-content
+        legacy_oscontainer_old: registry.ci.openshift.org/rhcos-devel/machine-os-content
     rawhide:
       type: mechanical
 
@@ -59,6 +63,14 @@ registry_repos:
   oscontainer: quay.io/fedora/fedora-coreos
   # OPTIONAL/TEMPORARY: additional repo to which to push oscontainer
   oscontainer_old: quay.io/coreos-assembler/fcos
+  # OPTIONAL: repo to which to push legacy oscontainer
+  legacy_oscontainer: quay.io/openshift-release-dev/rhel-coreos-dev
+  # OPTIONAL/TEMPORARY: additional repo to which to push oscontainer
+  legacy_oscontainer_old: registry.ci.openshift.org/rhcos/rhel-coreos
+  # OPTIONAL: repo to which to push the extensions container
+  extensions: quay.io/openshift-release-dev/rhel-coreos-extensions-dev
+  # OPTIONAL: whether to also tag images with build ID
+  add_build_tag: true
 
 # OPTIONAL/TEMPORARY: enable AWS aarch64 hack; see comment in `build-arch.Jenkinsfile`.
 aws_aarch64_serial_console_hack: true

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -168,9 +168,6 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
             }
             def oscontainer_old_registry_repo = pipecfg.registry_repos?.oscontainer_old
             if (oscontainer_old_registry_repo) {
-                // For a period of time let's also mirror into the old location too
-                // Drop this after October 2022. See
-                // https://discussion.fedoraproject.org/t/updated-registry-location-for-fedora-coreos-ostree-native-container/42740
                 withCredentials([file(credentialsId: 'oscontainer-secret', variable: 'REGISTRY_SECRET')]) {
                     shwrap("""
                     skopeo copy --all --authfile \$REGISTRY_SECRET \

--- a/utils.groovy
+++ b/utils.groovy
@@ -308,4 +308,11 @@ def build_artifacts(pipecfg, stream, basearch) {
     utils.runParallel(parallelruns, maxRuns)
 }
 
+def get_registry_repos(pipecfg, stream) {
+    def registry_repos = pipecfg.registry_repos ?: [:]
+    // merge top-level registry_repos with stream-specific bits
+    registry_repos += pipecfg.streams[stream].additional_registry_repos ?: [:]
+    return registry_repos
+}
+
 return this


### PR DESCRIPTION
Those are two containers we need to push in RHCOS that's not in FCOS.
Expand the list of supported keys in `registry_repos` for those and
accordingly rework the logic in the release job to be more functional.

Make it automatically skip containers that weren't actually built (e.g.
`extensions` are not built on FCOS and RHCOS <= 4.11).

Support stream-specific additional `registry_repos` so that RHCOS <=
4.11 can specify the `registry.ci.openshift.org` location, which is no
longer needed in 4.12.

Add a new `add_build_tag` which is required to ensure that the pushed
images are not garbage-collected.

Use the new `cosa copy-container` which knows to "unmanifest list" when
copying from Quay.io to `registry.ci.openshift.org`.