### PR TITLE
Use new credentials functions; limit cloud test run logic

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -384,7 +384,9 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             }
 
             // Run Kola TestISO tests for metal artifacts
-            kolaTestIso(cosaDir: env.WORKSPACE, arch: basearch)
+            if (shwrapCapture("cosa meta --get-value images.live-iso") != "None") {
+                kolaTestIso(cosaDir: env.WORKSPACE, arch: basearch)
+            }
 
             // Upload to relevant clouds
             if (uploading) {
@@ -456,6 +458,76 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             }
         }
 
+        // Now that the metadata is uploaded go ahead and kick off some tests
+        // These can all be kicked off in parallel. These take little time
+        // so there isn't much benefit in running them in parallel, but it
+        // makes the UI view have less columns, which is useful.
+        parallelruns = [:]
+        if (!params.MINIMAL && uploading) {
+            // Kick off the Kola AWS job if we have an uploaded image and credentials for running those tests.
+            if (shwrapCapture("cosa meta --get-value aws") != "None" &&
+                utils.credentialsExist([file(variable: 'AWS_KOLA_TESTS_CONFIG',
+                                             credentialsId: 'aws-kola-tests-config')])) {
+                parallelruns['Kola:AWS'] = {
+                    // We consider the AWS kola tests to be a followup job, so we use `wait: false` here.
+                    build job: 'kola-aws', wait: false, parameters: [
+                        string(name: 'STREAM', value: params.STREAM),
+                        string(name: 'VERSION', value: newBuildID),
+                        string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
+                        string(name: 'ARCH', value: basearch),
+                        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
+                    ]
+                }
+            }
+            // Kick off the Kola Azure job if we have an artifact and credentials for running those tests.
+            if (shwrapCapture("cosa meta --get-value images.azure") != "None" &&
+                utils.credentialsExist([file(variable: 'AZURE_KOLA_TESTS_CONFIG_AUTH',
+                                             credentialsId: 'azure-kola-tests-config-auth'),
+                                        file(variable: 'AZURE_KOLA_TESTS_CONFIG_PROFILE',
+                                             credentialsId: 'azure-kola-tests-config-profile')])) {
+                parallelruns['Kola:Azure'] = {
+                    // We consider the Azure kola tests to be a followup job, so we use `wait: false` here.
+                    build job: 'kola-azure', wait: false, parameters: [
+                        string(name: 'STREAM', value: params.STREAM),
+                        string(name: 'VERSION', value: newBuildID),
+                        string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
+                        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
+                    ]
+                }
+            }
+            // Kick off the Kola GCP job if we have an uploaded image and credentials for running those tests.
+            if (shwrapCapture("cosa meta --get-value gcp") != "None" &&
+                utils.credentialsExist([file(variable: 'GCP_KOLA_TESTS_CONFIG',
+                                             credentialsId: 'gcp-kola-tests-config')])) {
+                parallelruns['Kola:GCP'] = {
+                    // We consider the GCP kola tests to be a followup job, so we use `wait: false` here.
+                    build job: 'kola-gcp', wait: false, parameters: [
+                        string(name: 'STREAM', value: params.STREAM),
+                        string(name: 'VERSION', value: newBuildID),
+                        string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
+                        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
+                    ]
+                }
+            }
+            // Kick off the Kola OpenStack job if we have an artifact and credentials for running those tests.
+            if (shwrapCapture("cosa meta --get-value images.openstack") != "None" &&
+                utils.credentialsExist([file(variable: 'OPENSTACK_KOLA_TESTS_CONFIG',
+                                             credentialsId: 'openstack-kola-tests-config')])) {
+                parallelruns['Kola:OpenStack'] = {
+                    // We consider the OpenStack kola tests to be a followup job, so we use `wait: false` here.
+                    build job: 'kola-openstack', wait: false, parameters: [
+                        string(name: 'STREAM', value: params.STREAM),
+                        string(name: 'VERSION', value: newBuildID),
+                        string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
+                        string(name: 'ARCH', value: basearch),
+                        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
+                    ]
+                }
+            }
+        }
+        // process this batch
+        parallel parallelruns
+
         stage('Destroy Remote') {
             shwrap("cosa remote-session destroy")
         }
@@ -463,47 +535,6 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         } // end withEnv
         } // end withPodmanRemoteArchBuilder
 
-        // Now that the metadata is uploaded go ahead and kick off some tests
-        // These can all be kicked off in parallel. These take little time
-        // so there isn't much benefit in running them in parallel, but it
-        // makes the UI view have less columns, which is useful.
-        parallelruns = [:]
-
-        if (basearch == "aarch64") {
-            if (!params.MINIMAL && uploading) {
-                // Kick off the Kola AWS job if we have credentials for running those tests.
-                if (utils.credentialsExist([file(variable: 'AWS_KOLA_TESTS_CONFIG',
-                                            credentialsId: 'aws-kola-tests-config')])) {
-                    parallelruns['Kola:AWS'] = {
-                        // We consider the AWS kola tests to be a followup job, so we use `wait: false` here.
-                        build job: 'kola-aws', wait: false, parameters: [
-                            string(name: 'STREAM', value: params.STREAM),
-                            string(name: 'VERSION', value: newBuildID),
-                            string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-                            string(name: 'ARCH', value: basearch),
-                            string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
-                        ]
-                    }
-                }
-                // Kick off the Kola OpenStack job if we have credentials for running those tests.
-                if (utils.credentialsExist([file(variable: 'OPENSTACK_KOLA_TESTS_CONFIG',
-                                            credentialsId: 'openstack-kola-tests-config')])) {
-                    parallelruns['Kola:OpenStack'] = {
-                        // We consider the OpenStack kola tests to be a followup job, so we use `wait: false` here.
-                        build job: 'kola-openstack', wait: false, parameters: [
-                            string(name: 'STREAM', value: params.STREAM),
-                            string(name: 'VERSION', value: newBuildID),
-                            string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-                            string(name: 'ARCH', value: basearch),
-                            string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
-                        ]
-                    }
-                }
-            }
-        }
-
-        // process this batch
-        parallel parallelruns
 
         currentBuild.result = 'SUCCESS'
 

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -472,8 +472,8 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         if (basearch == "aarch64") {
             if (!params.MINIMAL && uploading) {
                 // Kick off the Kola AWS job if we have credentials for running those tests.
-                tryWithCredentials([file(variable: 'AWS_KOLA_TESTS_CONFIG',
-                                         credentialsId: 'aws-kola-tests-config')]) {
+                if (utils.credentialsExist([file(variable: 'AWS_KOLA_TESTS_CONFIG',
+                                            credentialsId: 'aws-kola-tests-config')])) {
                     parallelruns['Kola:AWS'] = {
                         // We consider the AWS kola tests to be a followup job, so we use `wait: false` here.
                         build job: 'kola-aws', wait: false, parameters: [
@@ -486,8 +486,8 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
                     }
                 }
                 // Kick off the Kola OpenStack job if we have credentials for running those tests.
-                tryWithCredentials([file(variable: 'OPENSTACK_KOLA_TESTS_CONFIG',
-                                         credentialsId: 'openstack-kola-tests-config')]) {
+                if (utils.credentialsExist([file(variable: 'OPENSTACK_KOLA_TESTS_CONFIG',
+                                            credentialsId: 'openstack-kola-tests-config')])) {
                     parallelruns['Kola:OpenStack'] = {
                         // We consider the OpenStack kola tests to be a followup job, so we use `wait: false` here.
                         build job: 'kola-openstack', wait: false, parameters: [

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -333,9 +333,11 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         }
 
         // Run Kola Tests
-        def n = 4 // VMs are 2G each and arch builders have approx 32G
-        kola(cosaDir: env.WORKSPACE, parallel: n, arch: basearch,
-             allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE)
+        stage("Kola") {
+            def n = 4 // VMs are 2G each and arch builders have approx 32G
+            kola(cosaDir: env.WORKSPACE, parallel: n, arch: basearch,
+                 allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE)
+        }
 
         if (!params.MINIMAL) {
 
@@ -385,7 +387,9 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
 
             // Run Kola TestISO tests for metal artifacts
             if (shwrapCapture("cosa meta --get-value images.live-iso") != "None") {
-                kolaTestIso(cosaDir: env.WORKSPACE, arch: basearch)
+                stage("Kola:TestISO") {
+                    kolaTestIso(cosaDir: env.WORKSPACE, arch: basearch)
+                }
             }
 
             // Upload to relevant clouds

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -474,8 +474,8 @@ lock(resource: "build-${params.STREAM}") {
 
         if (!params.MINIMAL && uploading) {
             // Kick off the Kola AWS job if we have credentials for running those tests.
-            tryWithCredentials([file(variable: 'AWS_KOLA_TESTS_CONFIG',
-                                     credentialsId: 'aws-kola-tests-config')]) {
+            if (utils.credentialsExist([file(variable: 'AWS_KOLA_TESTS_CONFIG',
+                                        credentialsId: 'aws-kola-tests-config')])) {
                 parallelruns['Kola:AWS'] = {
                     // We consider the AWS kola tests to be a followup job, so we use `wait: false` here.
                     build job: 'kola-aws', wait: false, parameters: [
@@ -499,10 +499,10 @@ lock(resource: "build-${params.STREAM}") {
               //}
             }
             // Kick off the Kola Azure job if we have credentials for running those tests.
-            tryWithCredentials([file(variable: 'AZURE_KOLA_TESTS_CONFIG_PROFILE',
-                                     credentialsId: 'azure-kola-tests-config-profile'),
-                                file(variable: 'AZURE_KOLA_TESTS_CONFIG_AUTH',
-                                     credentialsId: 'azure-kola-tests-config-auth')]) {
+            if (utils.credentialsExist([file(variable: 'AZURE_KOLA_TESTS_CONFIG_AUTH',
+                                        credentialsId: 'azure-kola-tests-config-auth'),
+                                        file(variable: 'AZURE_KOLA_TESTS_CONFIG_PROFILE',
+                                        credentialsId: 'azure-kola-tests-config-profile')])) {
                 parallelruns['Kola:Azure'] = {
                     // We consider the Azure kola tests to be a followup job, so we use `wait: false` here.
                     build job: 'kola-azure', wait: false, parameters: [
@@ -514,8 +514,8 @@ lock(resource: "build-${params.STREAM}") {
                 }
             }
             // Kick off the Kola GCP job if we have credentials for running those tests.
-            tryWithCredentials([file(variable: 'GCP_KOLA_TESTS_CONFIG',
-                                     credentialsId: 'gcp-kola-tests-config')]) {
+            if (utils.credentialsExist([file(variable: 'GCP_KOLA_TESTS_CONFIG',
+                                       credentialsId: 'gcp-kola-tests-config')])) {
                 parallelruns['Kola:GCP'] = {
                     // We consider the GCP kola tests to be a followup job, so we use `wait: false` here.
                     build job: 'kola-gcp', wait: false, parameters: [
@@ -527,8 +527,8 @@ lock(resource: "build-${params.STREAM}") {
                 }
             }
             // Kick off the Kola OpenStack job if we have credentials for running those tests.
-            tryWithCredentials([file(variable: 'OPENSTACK_KOLA_TESTS_CONFIG',
-                                     credentialsId: 'openstack-kola-tests-config')]) {
+            if (utils.credentialsExist([file(variable: 'OPENSTACK_KOLA_TESTS_CONFIG',
+                                        credentialsId: 'openstack-kola-tests-config')])) {
                 parallelruns['Kola:OpenStack'] = {
                     // We consider the OpenStack kola tests to be a followup job, so we use `wait: false` here.
                     build job: 'kola-openstack', wait: false, parameters: [

--- a/utils.groovy
+++ b/utils.groovy
@@ -179,16 +179,8 @@ def tryWithMessagingCredentials(Closure body) {
         sed -i s,FEDORA_MESSAGING_X509_CERT_PATH,${FEDORA_MESSAGING_X509_CERT_PATH}, ${FEDORA_MESSAGING_CONF}
         ''')
         // Also sync it over to the remote if we're operating in a remote session
-        shwrap('''
-        if [ -n "${COREOS_ASSEMBLER_REMOTE_SESSION:-}" ]; then
-            cosa shell -- sudo install -d -D -o builder -g builder --mode 777 \
-                $(dirname ${FEDORA_MESSAGING_CONF})
-            cosa remote-session sync {,:}/${FEDORA_MESSAGING_CONF}
-            cosa shell -- sudo install -d -D -o builder -g builder --mode 777 \
-                $(dirname ${FEDORA_MESSAGING_X509_CERT_PATH})
-            cosa remote-session sync {,:}/${FEDORA_MESSAGING_X509_CERT_PATH}/
-        fi
-        ''')
+        utils.syncCredentialsIfInRemoteSession(["FEDORA_MESSAGING_CONF",
+                                                "FEDORA_MESSAGING_X509_CERT_PATH"])
         body()
     }
 }


### PR DESCRIPTION
```
commit 6427fd9113ce38ff545a094d7317f2459bae7203
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Oct 21 00:49:17 2022 -0400

    jobs/{build,build-arch}: add stage names for kola runs
    
    This should make the output in our blue ocean pipeline view
    a bit easier to view.

commit 6ba3b0a9dd18255a63e596df0866761abd2cdf13
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Oct 21 00:46:09 2022 -0400

    jobs/{build,build-arch}: only run tests if artifacts exist
    
    Let's conditionalize running ISO tests and cloud tests if the
    necessary artifacts for those tests exist in our build metadata
    for the current run.
    
    Structuring it like this enables us to easily comment out artifacts
    in the pipeline config.yaml and seamlessly disable running the tests
    for the artifact rather than having to comment out code.

commit 4b093599b614e90c63e50402583c3e7b9f3d59b2
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Oct 21 00:38:51 2022 -0400

    jobs/{build,build-arch}: use credentialsExist function for cloud test jobs
    
    It's a bit easier to understand if we use a traditional If (condition)
    here rather than the tryWithCredentials() with a closure. Let's convert
    to that model now that utils.credentialsExist() exists.

commit 0f36a47263bb6352b11d7845ee7e50b4945da1ae
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Oct 21 00:15:56 2022 -0400

    tree-wide: update code to use syncCredentialsIfInRemoteSession()
    
    This new function was added in coreos-ci-lib. Let's take advantage
    of it in the existing pipeline code where we can.

```
