### PR TITLE
utils: add build_artifacts() function; use it

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -268,17 +268,15 @@ def build_artifacts(pipecfg, stream, basearch) {
     // Next let's do some massaging of the inputs based on two problems we
     // need to consider:
     //
-    // 1. We can't start too many parallel processes because we bump up into
+    // 1. The `live` build depends on `metal` and `metal4k` artifacts to exist.
+    // 2. We can't start too many parallel processes because we bump up into
     //    PID limits in the pipeline. See 24c5265.
-    // 2. The `live` build depends on `metal` and `metal4k` artifacts to exist.
 
-    // For 1. we'll run at most 10 tasks in parallel
-    def maxRuns = 10
-
-    // For 2. we'll sort the artifact list such that `metal` and `metal4k`
+    // For 1. we'll sort the artifact list such that `metal` and `metal4k`
     // are at the front of the list and `live` is at the end. We'll also
     // force there to be at least two parallel runs so metal* can finish
     // before live is started..
+    def maxRuns
     if (artifacts.contains('live')) {
         artifacts.remove("metal")
         artifacts.remove("metal4k")
@@ -294,6 +292,11 @@ def build_artifacts(pipecfg, stream, basearch) {
         // is allowed but `staticMethod java.lang.Math round java.math.BigDecimal`
         // gives scriptsecurity.sandbox.RejectedAccessException.
         maxRuns = Math.round(artifacts.size().div(2) as Float) as Integer
+    }
+
+    // For 2. we'll run at most 10 tasks in parallel
+    if (maxRuns > 10) {
+        maxRuns = 10
     }
 
     // Define the parallel jobs in a map


### PR DESCRIPTION
Hoist the code used to build the secondary artifacts into our
pipeline utils.groovy file so we can share that code between the
two main jobs. Also rework it a bit to use a different maxRuns
heuristic to achieve the same goal it had before.
