### PR TITLE
jobs/{build,build-arch}: fix AMI detection logic for cloud test

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -443,7 +443,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         parallelruns = [:]
         if (uploading) {
             // Kick off the Kola AWS job if we have an uploaded image and credentials for running those tests.
-            if (shwrapCapture("cosa meta --get-value aws") != "None" &&
+            if (shwrapCapture("cosa meta --get-value amis") != "None" &&
                 utils.credentialsExist([file(variable: 'AWS_KOLA_TESTS_CONFIG',
                                              credentialsId: 'aws-kola-tests-config')])) {
                 parallelruns['Kola:AWS'] = {

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -347,7 +347,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             // artifacts list for aarch64 and delete below code and knob) once platforms.yaml
             // exists everywhere. https://github.com/coreos/fedora-coreos-config/pull/1181
             if (basearch == "aarch64") {
-                stage('aws') {
+                stage('💽:aws') {
                     if (pipecfg.aws_aarch64_serial_console_hack) {
                         shwrap("""
                         if ! cosa shell -- test -e src/config/platforms.yaml; then

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -449,10 +449,9 @@ lock(resource: "build-${params.STREAM}") {
         // so there isn't much benefit in running them in parallel, but it
         // makes the UI view have less columns, which is useful.
         parallelruns = [:]
-
         if (uploading) {
             // Kick off the Kola AWS job if we have an uploaded image and credentials for running those tests.
-            if (shwrapCapture("cosa meta --get-value aws") != "None" &&
+            if (shwrapCapture("cosa meta --get-value amis") != "None" &&
                 utils.credentialsExist([file(variable: 'AWS_KOLA_TESTS_CONFIG',
                                              credentialsId: 'aws-kola-tests-config')])) {
                 parallelruns['Kola:AWS'] = {
@@ -523,7 +522,6 @@ lock(resource: "build-${params.STREAM}") {
                 }
             }
         }
-
         // process this batch
         parallel parallelruns
 


### PR DESCRIPTION
The key in the meta.json is `amis`, not `aws`.

Fixes 0779a76.

Also add emoji to build-arch job aws build stage.
