### PR TITLE
jobs/release: fix missing closing quote in GCP image promotion

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -130,8 +130,8 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
                             --log-level=INFO \
                             --project=${meta.gcp.project} \
                             --json-key \${GCP_IMAGE_UPLOAD_CONFIG} \
-                            --family "${meta.gcp.family} \
-                            --image "${meta.gcp.image}"
+                            --family=${meta.gcp.family} \
+                            --image=${meta.gcp.image}
                         """)
                     }
                 }


### PR DESCRIPTION
Actually just remove the quotes here as they aren't needed.

Fixes f2d2628