### PR TITLE
factor out cloud test kickoff into run_cloud_tests() function

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -85,6 +85,7 @@ clouds:
     test_resource_group: fedora-coreos-testing
     test_storage_account: fedoracoreostesting
     test_storage_container: fedora-coreos-testing-image-blobs
+    test_architectures: [x86_64]
   gcp:
     bucket: fedora-coreos-cloud-image-uploads/image-import
     description: "Fedora, Fedora CoreOS ${STREAM}, ${BUILDID}, ${BASEARCH} published on ${DATE}"
@@ -93,3 +94,5 @@ clouds:
     licenses:
       - "fedora-coreos-${STREAM}"
       - "https://compute.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
+  openstack:
+    test_architectures: [x86_64, aarch64]

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -87,6 +87,8 @@ clouds:
     # REQUIRED (if AWS build upload credentials provided): the bucket+prefix
     # where image files are uploaded to then initiate an image import.
     bucket: fedora-coreos-image-uploads/ami-import
+    # OPTIONAL: list of architectures to limit cloud testing to.
+    test_architectures: [x86_64]
   aliyun:
     # REQUIRED (if Aliyun build upload credentials provided): the region to do
     # initial image creation in.
@@ -94,6 +96,8 @@ clouds:
     # REQUIRED (if Aliyun image upload credentials provided): the bucket+prefix
     # where image files are uploaded to then initiate an image import.
     bucket: fedora-coreos-image-uploads/ami-import
+    # OPTIONAL: list of architectures to limit cloud testing to.
+    test_architectures: [x86_64]
   azure:
     # REQUIRED (if Azure image upload credentials provided): resource group, storage
     # account, and storage container to use for image file uploads
@@ -105,6 +109,8 @@ clouds:
     test_resource_group: fedora-coreos-testing
     test_storage_account: fedoracoreostesting
     test_storage_container: fedora-coreos-testing-image-blobs
+    # OPTIONAL: list of architectures to limit cloud testing to.
+    test_architectures: [x86_64]
   gcp:
     # REQUIRED (if GCP image upload credentials provided): the bucket+prefix
     # where image files are uploaded to then initiate an image import.
@@ -122,6 +128,11 @@ clouds:
     licenses:
       - "fedora-coreos-${STREAM}"
       - "https://compute.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
+    # OPTIONAL: list of architectures to limit cloud testing to.
+    test_architectures: [x86_64]
+  openstack:
+    # OPTIONAL: list of architectures to limit cloud testing to.
+    test_architectures: [x86_64, aarch64]
   powervs:
     # REQUIRED (if POWERVS image upload credentials provided): the object storage
     # service instance to use.

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -436,75 +436,13 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             }
         }
 
-        // Now that the metadata is uploaded go ahead and kick off some tests
-        // These can all be kicked off in parallel. These take little time
-        // so there isn't much benefit in running them in parallel, but it
-        // makes the UI view have less columns, which is useful.
-        parallelruns = [:]
+        // Now that the metadata is uploaded go ahead and kick off some followup tests.
         if (uploading) {
-            // Kick off the Kola AWS job if we have an uploaded image and credentials for running those tests.
-            if (shwrapCapture("cosa meta --get-value amis") != "None" &&
-                utils.credentialsExist([file(variable: 'AWS_KOLA_TESTS_CONFIG',
-                                             credentialsId: 'aws-kola-tests-config')])) {
-                parallelruns['Kola:AWS'] = {
-                    // We consider the AWS kola tests to be a followup job, so we use `wait: false` here.
-                    build job: 'kola-aws', wait: false, parameters: [
-                        string(name: 'STREAM', value: params.STREAM),
-                        string(name: 'VERSION', value: newBuildID),
-                        string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-                        string(name: 'ARCH', value: basearch),
-                        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
-                    ]
-                }
-            }
-            // Kick off the Kola Azure job if we have an artifact and credentials for running those tests.
-            if (shwrapCapture("cosa meta --get-value images.azure") != "None" &&
-                utils.credentialsExist([file(variable: 'AZURE_KOLA_TESTS_CONFIG_AUTH',
-                                             credentialsId: 'azure-kola-tests-config-auth'),
-                                        file(variable: 'AZURE_KOLA_TESTS_CONFIG_PROFILE',
-                                             credentialsId: 'azure-kola-tests-config-profile')])) {
-                parallelruns['Kola:Azure'] = {
-                    // We consider the Azure kola tests to be a followup job, so we use `wait: false` here.
-                    build job: 'kola-azure', wait: false, parameters: [
-                        string(name: 'STREAM', value: params.STREAM),
-                        string(name: 'VERSION', value: newBuildID),
-                        string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-                        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
-                    ]
-                }
-            }
-            // Kick off the Kola GCP job if we have an uploaded image and credentials for running those tests.
-            if (shwrapCapture("cosa meta --get-value gcp") != "None" &&
-                utils.credentialsExist([file(variable: 'GCP_KOLA_TESTS_CONFIG',
-                                             credentialsId: 'gcp-kola-tests-config')])) {
-                parallelruns['Kola:GCP'] = {
-                    // We consider the GCP kola tests to be a followup job, so we use `wait: false` here.
-                    build job: 'kola-gcp', wait: false, parameters: [
-                        string(name: 'STREAM', value: params.STREAM),
-                        string(name: 'VERSION', value: newBuildID),
-                        string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-                        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
-                    ]
-                }
-            }
-            // Kick off the Kola OpenStack job if we have an artifact and credentials for running those tests.
-            if (shwrapCapture("cosa meta --get-value images.openstack") != "None" &&
-                utils.credentialsExist([file(variable: 'OPENSTACK_KOLA_TESTS_CONFIG',
-                                             credentialsId: 'openstack-kola-tests-config')])) {
-                parallelruns['Kola:OpenStack'] = {
-                    // We consider the OpenStack kola tests to be a followup job, so we use `wait: false` here.
-                    build job: 'kola-openstack', wait: false, parameters: [
-                        string(name: 'STREAM', value: params.STREAM),
-                        string(name: 'VERSION', value: newBuildID),
-                        string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-                        string(name: 'ARCH', value: basearch),
-                        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
-                    ]
-                }
+            stage('Cloud Tests') {
+                pipeutils.run_cloud_tests(pipecfg, params.STREAM, newBuildID,
+                                          s3_stream_dir, basearch, src_config_commit)
             }
         }
-        // process this batch
-        parallel parallelruns
 
         stage('Destroy Remote') {
             shwrap("cosa remote-session destroy")

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -444,86 +444,13 @@ lock(resource: "build-${params.STREAM}") {
             }
         }
 
-        // Now that the metadata is uploaded go ahead and kick off some tests
-        // These can all be kicked off in parallel. These take little time
-        // so there isn't much benefit in running them in parallel, but it
-        // makes the UI view have less columns, which is useful.
-        parallelruns = [:]
+        // Now that the metadata is uploaded go ahead and kick off some followup tests.
         if (uploading) {
-            // Kick off the Kola AWS job if we have an uploaded image and credentials for running those tests.
-            if (shwrapCapture("cosa meta --get-value amis") != "None" &&
-                utils.credentialsExist([file(variable: 'AWS_KOLA_TESTS_CONFIG',
-                                             credentialsId: 'aws-kola-tests-config')])) {
-                parallelruns['Kola:AWS'] = {
-                    // We consider the AWS kola tests to be a followup job, so we use `wait: false` here.
-                    build job: 'kola-aws', wait: false, parameters: [
-                        string(name: 'STREAM', value: params.STREAM),
-                        string(name: 'VERSION', value: newBuildID),
-                        string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-                        string(name: 'ARCH', value: basearch),
-                        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
-                    ]
-                }
-              // XXX: This is failing right now. Disable until the New
-              // Year when someone can dig into the problem.
-              //parallelruns['Kola:Kubernetes'] = {
-              //    // We consider the Kubernetes kola tests to be a followup job, so we use `wait: false` here.
-              //    build job: 'kola-kubernetes', wait: false, parameters: [
-              //        string(name: 'STREAM', value: params.STREAM),
-              //        string(name: 'VERSION', value: newBuildID),
-              //        string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-              //        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
-              //    ]
-              //}
-            }
-            // Kick off the Kola Azure job if we have an artifact and credentials for running those tests.
-            if (shwrapCapture("cosa meta --get-value images.azure") != "None" &&
-                utils.credentialsExist([file(variable: 'AZURE_KOLA_TESTS_CONFIG_AUTH',
-                                             credentialsId: 'azure-kola-tests-config-auth'),
-                                        file(variable: 'AZURE_KOLA_TESTS_CONFIG_PROFILE',
-                                             credentialsId: 'azure-kola-tests-config-profile')])) {
-                parallelruns['Kola:Azure'] = {
-                    // We consider the Azure kola tests to be a followup job, so we use `wait: false` here.
-                    build job: 'kola-azure', wait: false, parameters: [
-                        string(name: 'STREAM', value: params.STREAM),
-                        string(name: 'VERSION', value: newBuildID),
-                        string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-                        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
-                    ]
-                }
-            }
-            // Kick off the Kola GCP job if we have an uploaded image and credentials for running those tests.
-            if (shwrapCapture("cosa meta --get-value gcp") != "None" &&
-                utils.credentialsExist([file(variable: 'GCP_KOLA_TESTS_CONFIG',
-                                             credentialsId: 'gcp-kola-tests-config')])) {
-                parallelruns['Kola:GCP'] = {
-                    // We consider the GCP kola tests to be a followup job, so we use `wait: false` here.
-                    build job: 'kola-gcp', wait: false, parameters: [
-                        string(name: 'STREAM', value: params.STREAM),
-                        string(name: 'VERSION', value: newBuildID),
-                        string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-                        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
-                    ]
-                }
-            }
-            // Kick off the Kola OpenStack job if we have an artifact and credentials for running those tests.
-            if (shwrapCapture("cosa meta --get-value images.openstack") != "None" &&
-                utils.credentialsExist([file(variable: 'OPENSTACK_KOLA_TESTS_CONFIG',
-                                             credentialsId: 'openstack-kola-tests-config')])) {
-                parallelruns['Kola:OpenStack'] = {
-                    // We consider the OpenStack kola tests to be a followup job, so we use `wait: false` here.
-                    build job: 'kola-openstack', wait: false, parameters: [
-                        string(name: 'STREAM', value: params.STREAM),
-                        string(name: 'VERSION', value: newBuildID),
-                        string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
-                        string(name: 'ARCH', value: basearch),
-                        string(name: 'SRC_CONFIG_COMMIT', value: src_config_commit)
-                    ]
-                }
+            stage('Cloud Tests') {
+                pipeutils.run_cloud_tests(pipecfg, params.STREAM, newBuildID,
+                                          s3_stream_dir, basearch, src_config_commit)
             }
         }
-        // process this batch
-        parallel parallelruns
 
         // For now, we auto-release all non-production streams builds. That
         // way, we can e.g. test testing-devel AMIs easily.


### PR DESCRIPTION
```
commit 197e3cd3f5f7595e1974e7607c5f91dd8c91e28e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Oct 21 23:12:32 2022 -0400

    config: add cloud.test_architectures key
    
    This key is used to limit which architecures we attempt to run cloud
    tests for on a given cloud/platform. For example, we create OpenStack
    artifacts for every architecture, but we don't have an OpenStack that
    we can test in that has all of those architectures so we need to limit
    the architectures that those tests are attempted on.

commit 8648df677b414e181e0997d2b2f1e4900b17f4d8
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Oct 21 22:35:34 2022 -0400

    factor out cloud test kickoff into run_cloud_tests() function
    
    This code is now pretty much duplicated. Let's factor it out and
    simplify it.

```

Requires #705 
