### PR TITLE
utils: set maxRuns to 10 when not building `live` artifacts

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -295,12 +295,12 @@ def build_artifacts(pipecfg, stream, basearch) {
     }
 
     // For 2. we'll run at most 10 tasks in parallel
-    if (maxRuns > 10) {
+    if (!maxRuns || maxRuns > 10) {
         maxRuns = 10
     }
 
     // Define the parallel jobs in a map
-    parallelruns = artifacts.collectEntries {
+    def parallelruns = artifacts.collectEntries {
         ["💽:${it}", { shwrap("cosa buildextend-${it}") }]
     }
 


### PR DESCRIPTION
In the case where we're not building live artifacts we were passing in a maxRuns value of `null` to the utils.ParallelRuns() function. Let's add a condition such that we'll set it to 10 if maxRuns is still uninitialized (`null`).

Fixes 8af6653