### PR TITLE
config.yaml: support artifacts in common for all arches

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -35,24 +35,17 @@ registry_repos:
   oscontainer_old: quay.io/coreos-assembler/fcos
 
 default_artifacts:
+  all:
+    - metal
+    - metal4k
+    - live
+    - openstack
   aarch64:
     - azure
-    - openstack
-    - live
-    - metal
-    - metal4k
   ppc64le:
-    - openstack
     - powervs
-    - live
-    - metal
-    - metal4k
   s390x:
     - ibmcloud
-    - openstack
-    - live
-    - metal
-    - metal4k
   x86_64:
     - aliyun
     - aws
@@ -62,11 +55,7 @@ default_artifacts:
     - exoscale
     - gcp
     - ibmcloud
-    - live
     - nutanix
-    - metal
-    - metal4k
-    - openstack
     - virtualbox
     - vmware
     - vultr

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -10,15 +10,16 @@ source_config:
 
 # OPTIONAL: default artifacts to build per architecture
 default_artifacts:
-  aarch64:
-    - openstack
-    - metal
-  x86_64:
-    - aws
-    - vmware
+  # default artifacts on all arches
+  all:
     - metal
     - metal4k
     - live
+  aarch64:
+    - openstack
+  x86_64:
+    - aws
+    - vmware
 
 # REQUIRED: streams to build
 streams:

--- a/utils.groovy
+++ b/utils.groovy
@@ -248,6 +248,7 @@ def get_artifacts_to_build(pipecfg, stream, basearch) {
     if (artifacts == null) {
         // Get the list difference from default with skip artifacts
         artifacts = pipecfg.default_artifacts."${basearch}" ?: []
+        artifacts += pipecfg.default_artifacts.all ?: []
         artifacts -= pipecfg.streams[stream].skip_artifacts?."${basearch}" ?: []
     }
     return artifacts.unique()

--- a/utils.groovy
+++ b/utils.groovy
@@ -243,18 +243,12 @@ def get_push_trigger() {
 
 // Gets desired artifacts to build from pipeline config
 def get_artifacts_to_build(pipecfg, stream, basearch) {
-    def artifacts = []
-    if  (pipecfg.streams[stream].artifacts?."${basearch}" != null) {
-        artifacts = pipecfg.streams[stream]['artifacts'][basearch]
-    } else { // Get the list difference from default with skip artifacts
-        def default_artifacts =  pipecfg['default_artifacts'][basearch]
-        def skip_artifacts = pipecfg.streams[stream].skip_artifacts?."${basearch}"
-        if (default_artifacts != null) {
-            artifacts = default_artifacts
-        }
-        if (skip_artifacts != null) {
-            artifacts -= skip_artifacts
-        }
+    // Explicit stream-level override takes precedence
+    def artifacts = pipecfg.streams[stream].artifacts?."${basearch}"
+    if (artifacts == null) {
+        // Get the list difference from default with skip artifacts
+        artifacts = pipecfg.default_artifacts."${basearch}" ?: []
+        artifacts -= pipecfg.streams[stream].skip_artifacts?."${basearch}" ?: []
     }
     return artifacts.unique()
 }


### PR DESCRIPTION
Every arch supports metal, metal4k, live, and openstack artifacts.
Instead of repeating it four times, add support for a generic "all" key
which is merged on all arches.

Prep for adding more artifacts in that key.