### PR TITLE
libupload: a few fixes for corner cases

### DIFF
--- a/libupload.groovy
+++ b/libupload.groovy
@@ -41,7 +41,10 @@ def upload_to_clouds(pipecfg, basearch, buildID, stream) {
             withCredentials(creds) {
                 utils.syncCredentialsIfInRemoteSession(["AWS_BUILD_UPLOAD_CONFIG"])
                 def c = pipecfg.clouds.aws
-                def grant_user_args = c.test_accounts?.collect{"--grant-user ${it}"}.join(" ")
+                def grant_user_args = ""
+                if (c.test_accounts) {
+                    grant_user_args = c.test_accounts.collect{"--grant-user ${it}"}.join(" ")
+                }
                 shwrap("""
                 cosa buildextend-aws \
                     --upload \

--- a/libupload.groovy
+++ b/libupload.groovy
@@ -75,8 +75,7 @@ def upload_to_clouds(pipecfg, basearch, buildID, stream) {
                     --build=${buildID} \
                     --resource-group ${c.resource_group} \
                     --storage-account ${c.storage_account} \
-                    --container=${c.storage_container} \
-                    --force
+                    --container=${c.storage_container}
                  """)
             }
         }


### PR DESCRIPTION
```
commit 6413b25f8ae3bb8fd995d3913e8a65b96dfb4ff5
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Oct 25 14:30:11 2022 -0400

    libupload: don't buildextend with --force for azure
    
    If we make it to the cloud uploads in the pipeline then we've
    reserved a build ID and any new runs will reserved a different
    build ID. We shouldn't need to pass `--force` here.
    
    In it's current form we're building the azure image in the
    "Build Artifacts" stage and again in the "Cloud Upload" stage
    befause `--force` tells `buildextend-azure` to ignore the
    existing built artifact.

commit bbf300c3b011f584b9eaa9b5502ae086533dc805
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Oct 25 14:28:02 2022 -0400

    libcloud: avoid null pointer exception
    
    If there are no AWS test accounts specified then the `.join()` will
    end up getting called on a null object. Let's check first if there
    is an entry for test accounts before we try to collect/join.

```
