### PR TITLE
support uploading to AWS govcloud

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -123,6 +123,31 @@ oc annotate secret/aws-kola-tests-config \
 
 NOTE: For the prod pipeline these secrets can be found in BitWarden
 
+### [OPTIONAL] Creating AWS GovCloud credentials configs
+
+If you want to upload to AWS GovCloud you can create a separate
+set of credentials for performing that action:
+
+```
+cat <<'EOF' > /path/to/aws-govcloud-image-upload-config
+[default]
+aws_access_key_id=keyid
+aws_secret_access_key=key
+EOF
+```
+
+Then create the secret in OpenShift:
+
+```
+oc create secret generic aws-govcloud-image-upload-config \
+    --from-literal=filename=aws_config_file \
+    --from-file=data=/path/to/aws-govcloud-image-upload-config
+oc label secret/aws-govcloud-image-upload-config \
+    jenkins.io/credentials-type=secretFile
+oc annotate secret/aws-govcloud-image-upload-config \
+    jenkins.io/credentials-description="AWS GovCloud image upload credentials config"
+```
+
 ### [OPTIONAL] Creating GCP credentials configs
 
 If you are in production where we upload images to GCP OR you want to

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -90,6 +90,16 @@ clouds:
     bucket: fedora-coreos-image-uploads/ami-import
     # OPTIONAL: list of architectures to limit cloud testing to.
     test_architectures: [x86_64]
+    # REQUIRED (if AWS GovCloud image upload credentials provided):
+    # separate set of data for GovCloud uploads
+    govcloud:
+      # OPTIONAL: accounts to share newly created AMIs with
+      test_accounts:
+        - "1234567890"
+      # REQUIRED: the region to do initial image creation in.
+      primary_region: us-gov-east-1
+      # REQUIRED: the bucket+prefix where image files are uploaded to then initiate an image import.
+      bucket: fedora-coreos-govcloud-image-uploads/ami-import
   aliyun:
     # REQUIRED (if Aliyun build upload credentials provided): the region to do
     # initial image creation in.


### PR DESCRIPTION
This adds another entry in our clouds config in our config.yaml and also documents support for an aws-govcloud-image-upload-config secret.