### PR TITLE
jobs/kola-{azure,openstack}: bump memory request

### DIFF
--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -59,8 +59,8 @@ lock(resource: "kola-azure-${params.ARCH}") {
         s3_stream_dir = "${pipecfg.s3_bucket}/prod/streams/${params.STREAM}"
     }
 
-    // Go with 1Gi here because we download/decompress/upload the image
-    def cosa_memory_request_mb = 1024
+    // Go with 1.5Gi here because we download/decompress/upload the image
+    def cosa_memory_request_mb = 1536
     try { timeout(time: 75, unit: 'MINUTES') {
         cosaPod(memory: "${cosa_memory_request_mb}Mi", kvm: false,
                 image: params.COREOS_ASSEMBLER_IMAGE) {

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -60,8 +60,8 @@ lock(resource: "kola-openstack-${params.ARCH}") {
         s3_stream_dir = "${pipecfg.s3_bucket}/prod/streams/${params.STREAM}"
     }
 
-    // Go with 1Gi here because we download/decompress/upload the image
-    def cosa_memory_request_mb = 1024
+    // Go with 1.5Gi here because we download/decompress/upload the image
+    def cosa_memory_request_mb = 1536
     try { timeout(time: 90, unit: 'MINUTES') {
         cosaPod(memory: "${cosa_memory_request_mb}Mi", kvm: false,
                 image: params.COREOS_ASSEMBLER_IMAGE) {


### PR DESCRIPTION
As brought up in #713, setting a memory limit for xz decompression doesn't cause it to adapt the limit, but rather to automatically abort if the limit is reached.

Keep limiting it because the error mode is clearer to debug than otherwise, but also increase the memory request since we know 1Gi is currently not enough.