### PR TITLE
libupload: add support for passing `--public` to buildextend-aws

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -65,11 +65,13 @@ aws_aarch64_serial_console_hack: true
 
 clouds:
   aws:
+    bucket: fcos-builds/ami-import
+    primary_region: us-east-1
+    # we make our images public in the release job via plume
+    public: false
     # Accounts to share newly created AMIs with
     test_accounts:
       - "013116697141"
-    bucket: fcos-builds/ami-import
-    primary_region: us-east-1
   azure:
     test_resource_group: fedora-coreos-testing
     test_storage_account: fedoracoreostesting

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -88,6 +88,8 @@ clouds:
     # REQUIRED (if AWS build upload credentials provided): the bucket+prefix
     # where image files are uploaded to then initiate an image import.
     bucket: fedora-coreos-image-uploads/ami-import
+    # OPTIONAL: boolean: whether or not to set the image/snapshot as public
+    public: true
     # OPTIONAL: list of architectures to limit cloud testing to.
     test_architectures: [x86_64]
     # REQUIRED (if AWS GovCloud image upload credentials provided):
@@ -100,6 +102,8 @@ clouds:
       primary_region: us-gov-east-1
       # REQUIRED: the bucket+prefix where image files are uploaded to then initiate an image import.
       bucket: fedora-coreos-govcloud-image-uploads/ami-import
+      # OPTIONAL: boolean: whether or not to set the image/snapshot as public
+      public: true
   aliyun:
     # REQUIRED (if Aliyun build upload credentials provided): the region to do
     # initial image creation in.

--- a/libupload.groovy
+++ b/libupload.groovy
@@ -41,18 +41,22 @@ def upload_to_clouds(pipecfg, basearch, buildID, stream) {
             withCredentials(creds) {
                 utils.syncCredentialsIfInRemoteSession(["AWS_BUILD_UPLOAD_CONFIG"])
                 def c = pipecfg.clouds.aws
-                def grant_user_args = ""
+                def extraArgs = []
                 if (c.test_accounts) {
-                    grant_user_args = c.test_accounts.collect{"--grant-user ${it}"}.join(" ")
+                    extraArgs += c.test_accounts.collect{"--grant-user=${it}"}
+                }
+                if (c.public) {
+                    extraArgs += "--public"
                 }
                 shwrap("""
                 cosa buildextend-aws \
                     --upload \
                     --arch=${basearch} \
                     --build=${buildID} \
-                    --region=${c.primary_region} ${grant_user_args} \
+                    --region=${c.primary_region} \
                     --bucket=s3://${c.bucket} \
                     --credentials-file=\${AWS_BUILD_UPLOAD_CONFIG}
+                    ${extraArgs.join(' ')} 
                 """)
             }
         }
@@ -65,18 +69,22 @@ def upload_to_clouds(pipecfg, basearch, buildID, stream) {
             withCredentials(creds) {
                 utils.syncCredentialsIfInRemoteSession(["AWS_GOVCLOUD_IMAGE_UPLOAD_CONFIG"])
                 def c = pipecfg.clouds.aws.govcloud
-                def grant_user_args = ""
+                def extraArgs = []
                 if (c.test_accounts) {
-                    grant_user_args = c.test_accounts.collect{"--grant-user ${it}"}.join(" ")
+                    extraArgs += c.test_accounts.collect{"--grant-user=${it}"}
+                }
+                if (c.public) {
+                    extraArgs += "--public"
                 }
                 shwrap("""
                 cosa buildextend-aws \
                     --upload \
                     --arch=${basearch} \
                     --build=${buildID} \
-                    --region=${c.primary_region} ${grant_user_args} \
+                    --region=${c.primary_region} \
                     --bucket=s3://${c.bucket} \
-                    --credentials-file=\${AWS_GOVCLOUD_IMAGE_UPLOAD_CONFIG}
+                    --credentials-file=\${AWS_GOVCLOUD_IMAGE_UPLOAD_CONFIG} \
+                    ${extraArgs.join(' ')} 
                 """)
             }
         }


### PR DESCRIPTION
Some RHCOS pipelines make their AMI public during initial publishing. Let's make it configurable.