### PR TITLE
libupload: fix buildextend-aliyun step

### DIFF
--- a/libupload.groovy
+++ b/libupload.groovy
@@ -27,8 +27,8 @@ def upload_to_clouds(pipecfg, basearch, buildID, stream) {
                     --arch=${basearch} \
                     --build=${buildID} \
                     --region=${c.primary_region} \
-                    --bucket=s3://${c.bucket} \
-                    --credentials-file=\${ALIYUN_IMAGE_UPLOAD_CONFIG}
+                    --bucket=${c.bucket} \
+                    --config=\${ALIYUN_IMAGE_UPLOAD_CONFIG}
                 """)
             }
         }


### PR DESCRIPTION
Right now the CLI accepts `--config` for the file with credentials. It also doesn't need `s3://` (or `oss://`, which would be more appropriate for Aliyun) prepended to the bucket.