### PR TITLE
jobs/release: put new oscontainer under `oscontainer` key

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -61,10 +61,12 @@ s3_bucket: fcos-builds
 # OPTIONAL: container registry-related keys
 registry_repos:
   # OPTIONAL: repo to which to push oscontainer
+  # CONFLICTS WITH: legacy_oscontainer
   oscontainer: quay.io/fedora/fedora-coreos
   # OPTIONAL/TEMPORARY: additional repo to which to push oscontainer
   oscontainer_old: quay.io/coreos-assembler/fcos
   # OPTIONAL: repo to which to push legacy oscontainer
+  # CONFLICTS WITH: oscontainer
   legacy_oscontainer: quay.io/openshift-release-dev/rhel-coreos-dev
   # OPTIONAL/TEMPORARY: additional repo to which to push oscontainer
   legacy_oscontainer_old: registry.ci.openshift.org/rhcos/rhel-coreos

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -189,7 +189,7 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
         // could be made configurable in the future. For now since FCOS doesn't need it and
         // OCP ART doesn't actually care what the tag name is (it's just to stop GC), we
         // hardcode it.
-        def push_containers = ['oscontainer': ['ostree', 'base-oscontainer', ''],
+        def push_containers = ['oscontainer': ['ostree', 'oscontainer', ''],
                                'extensions': ['extensions-container', 'extensions-container', '-extensions'],
                                'legacy_oscontainer': ['legacy-oscontainer', 'oscontainer', '-legacy']]
 
@@ -209,6 +209,11 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
         }
 
         if (push_containers) {
+            // Sanity-check we're not asked to push both the legacy oscontainer and new one.
+            // cosa will also error on this, but we can give a clearer message.
+            if ('oscontainer' in push_containers && 'legacy_oscontainer' in push_containers) {
+                error("Cannot push both oscontainer and legacy_oscontainer")
+            }
             stage("Push Containers") {
                 parallel push_containers.collectEntries{configname, val -> [configname, {
                     withCredentials([file(variable: 'REGISTRY_SECRET',


### PR DESCRIPTION
It turns out that we won't need to support building *both* the legacy oscontainer and the new one for 4.12. In the new transition plan, the new format will directly take the place of the old one as `oscontainer` in `meta.json` and `machine-os-content` in the release payload. This minimizes the impact on OpenShift tooling.

Update the release job to set the `oscontainer` key for the new container and verify that we're not pushing both the legacy and new container since they would conflict.

This change almost matches the latest behaviour of the old RHCOS pipeline. One difference is that we're no longer setting the key `base-oscontainer`. I think we should delete it from the schema eventually.

See also: https://issues.redhat.com/browse/MCO-392