### PR TITLE
utils: enhance per-stream artifact set modifications

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -248,9 +248,13 @@ def get_artifacts_to_build(pipecfg, stream, basearch) {
     // Explicit stream-level override takes precedence
     def artifacts = pipecfg.streams[stream].artifacts?."${basearch}"
     if (artifacts == null) {
-        // Get the list difference from default with skip artifacts
-        artifacts = pipecfg.default_artifacts."${basearch}" ?: []
+        // calculate artifacts from defaults + additional - skip
+        artifacts = []
         artifacts += pipecfg.default_artifacts.all ?: []
+        artifacts += pipecfg.default_artifacts."${basearch}" ?: []
+        artifacts += pipecfg.streams[stream].additional_artifacts?.all ?: []
+        artifacts += pipecfg.streams[stream].additional_artifacts?."${basearch}" ?: []
+        artifacts -= pipecfg.streams[stream].skip_artifacts?.all ?: []
         artifacts -= pipecfg.streams[stream].skip_artifacts?."${basearch}" ?: []
     }
     return artifacts.unique()


### PR DESCRIPTION
RHCOS 4.11 and older do not want to build the `extensions-container` artifact. The artifact is for all arches. Support `all` for `skip_artifacts` to make skipping it less verbose.

RHCOS 4.11 and older want to build the `legacy-oscontainer` artifact. RHCOS 4.12 and newer do not. Support enhancing the default set by bringing back the `additional_artifacts` key. The artifact is for all arches. Support the `all` key to make adding it less verbose.

For consistency with the other keys, also support `additional_artifacts` per architecture.