### PR TITLE
utils: add AWSBuildUpload credential helper functions

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -103,16 +103,11 @@ lock(resource: "build-${params.STREAM}") {
         currentBuild.description = "[${params.STREAM}][${basearch}] Running"
 
 
-        // Add in AWS Build Upload credentials here if they exist. In
-        // the future we might choose to be more granular about when
-        // we load this.
-        pipeutils.tryWithOrWithoutCredentials([file(variable: 'AWS_BUILD_UPLOAD_CONFIG',
-                                                    credentialsId: 'aws-build-upload-config')]) {
 
         // this is defined IFF we *should* and we *can* upload to S3
         def s3_stream_dir
 
-        if (pipecfg.s3_bucket && utils.pathExists("\${AWS_BUILD_UPLOAD_CONFIG}")) {
+        if (pipecfg.s3_bucket && pipeutils.AWSBuildUploadCredentialExists()) {
             // see bucket layout in https://github.com/coreos/fedora-coreos-tracker/issues/189
             s3_stream_dir = "${pipecfg.s3_bucket}/prod/streams/${params.STREAM}"
         }
@@ -174,14 +169,14 @@ lock(resource: "build-${params.STREAM}") {
         // buildfetch previous build info
         stage('BuildFetch') {
             if (s3_stream_dir) {
-                shwrap("""
+                pipeutils.shwrapWithAWSBuildUploadCredentials("""
                 cosa buildfetch --arch=${basearch} \
                     --url s3://${s3_stream_dir}/builds \
                     --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG}
                 """)
                 if (parent_version != "") {
                     // also fetch the parent version; this is used by cosa to do the diff
-                    shwrap("""
+                    pipeutils.shwrapWithAWSBuildUploadCredentials("""
                     cosa buildfetch --arch=${basearch} \
                         --build ${parent_version} \
                         --url s3://${s3_stream_dir}/builds \
@@ -264,7 +259,7 @@ lock(resource: "build-${params.STREAM}") {
         if (official && uploading) {
             pipeutils.tryWithMessagingCredentials() {
                 stage('Sign OSTree') {
-                    shwrap("""
+                    pipeutils.shwrapWithAWSBuildUploadCredentials("""
                     cosa sign --build=${newBuildID} --arch=${basearch} \
                         robosignatory --s3 ${s3_stream_dir}/builds \
                         --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
@@ -319,18 +314,18 @@ lock(resource: "build-${params.STREAM}") {
         // reserving our build ID before we fork off multi-arch builds.
         stage('Archive OSTree') {
             if (uploading) {
-              // run with --force here in case the previous run of the
-              // pipeline died in between buildupload and bump_builds_json()
-              shwrap("""
-              export AWS_CONFIG_FILE=\${AWS_BUILD_UPLOAD_CONFIG}
-              cosa buildupload --force --skip-builds-json --artifact=ostree \
-                  s3 --acl=public-read ${s3_stream_dir}/builds
-              """)
-              pipeutils.bump_builds_json(
-                  params.STREAM,
-                  newBuildID,
-                  basearch,
-                  s3_stream_dir)
+                // run with --force here in case the previous run of the
+                // pipeline died in between buildupload and bump_builds_json()
+                pipeutils.shwrapWithAWSBuildUploadCredentials("""
+                cosa buildupload --force --skip-builds-json --artifact=ostree \
+                    s3 --aws-config-file=\${AWS_BUILD_UPLOAD_CONFIG} \
+                    --acl=public-read ${s3_stream_dir}/builds
+                """)
+                pipeutils.bump_builds_json(
+                    params.STREAM,
+                    newBuildID,
+                    basearch,
+                    s3_stream_dir)
             }
         }
 
@@ -395,22 +390,22 @@ lock(resource: "build-${params.STREAM}") {
             }
 
             if (uploading) {
-              // just upload as public-read for now, but see discussions in
-              // https://github.com/coreos/fedora-coreos-tracker/issues/189
-              shwrap("""
-              cosa buildupload --skip-builds-json s3 \
-                  --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
-                  --acl=public-read ${s3_stream_dir}/builds
-              """)
+                // just upload as public-read for now, but see discussions in
+                // https://github.com/coreos/fedora-coreos-tracker/issues/189
+                pipeutils.shwrapWithAWSBuildUploadCredentials("""
+                cosa buildupload --skip-builds-json s3 \
+                    --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
+                    --acl=public-read ${s3_stream_dir}/builds
+                """)
             } else {
-              // Without an S3 server, just archive into the PVC
-              // itself. Otherwise there'd be no other way to retrieve the
-              // artifacts. But note we only keep one build at a time.
-              shwrap("""
-              rm -rf ${local_builddir}
-              mkdir -p ${local_builddir}
-              rsync -avh builds/ ${local_builddir}
-              """)
+                // Without an S3 server, just archive into the PVC
+                // itself. Otherwise there'd be no other way to retrieve the
+                // artifacts. But note we only keep one build at a time.
+                shwrap("""
+                rm -rf ${local_builddir}
+                mkdir -p ${local_builddir}
+                rsync -avh builds/ ${local_builddir}
+                """)
             }
         }
 
@@ -423,7 +418,7 @@ lock(resource: "build-${params.STREAM}") {
             pipeutils.tryWithMessagingCredentials() {
                 parallelruns = [:]
                 parallelruns['Sign Images'] = {
-                    shwrap("""
+                    pipeutils.shwrapWithAWSBuildUploadCredentials("""
                     cosa sign --build=${newBuildID} --arch=${basearch} \
                         robosignatory --s3 ${s3_stream_dir}/builds \
                         --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
@@ -474,8 +469,7 @@ lock(resource: "build-${params.STREAM}") {
 
         currentBuild.result = 'SUCCESS'
 
-// tryWithOrWithoutCredentials and main try finish here
-}} catch (e) {
+} catch (e) {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
@@ -515,4 +509,4 @@ lock(resource: "build-${params.STREAM}") {
             """)
         }
     }
-}}}} // try-catch-finally, cosaPod, timeout, and locks finish here
+}}}} // finally, cosaPod, timeout, and locks finish here


### PR DESCRIPTION
This adds the following functions:

- withAWSBuildUploadCredentials(Closure body)
- shwrapWithAWSBuildUploadCredentials(cmds)
- AWSBuildUploadCredentialExists()

and changes code throughout the repo to take advantage of them.

This has the side effect of dropping the use of tryWithOrWithoutCredentials at the top of the build and build-arch jobs.