### PR TITLE
Add hack knob to skip SecureBoot tests

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -21,6 +21,11 @@ default_artifacts:
     - aws
     - vmware
 
+# OPTIONAL: hotfix-related keys
+hotfix:
+  # OPTIONAL/TEMPORARY: skip all tests that require a signed kernel
+  skip_secureboot_tests_hack: true
+
 # OPTIONAL: coreos-assembler image to build with. supports ${STREAM} variable.
 # If unset, defaults to `quay.io/coreos-assembler/coreos-assembler:main`.
 cosa_img: quay.io/jlebon/coreos-assembler:pr3139-${STREAM}

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -305,7 +305,8 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         stage("Kola") {
             def n = 4 // VMs are 2G each and arch builders have approx 32G
             kola(cosaDir: env.WORKSPACE, parallel: n, arch: basearch,
-                 allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE)
+                 allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
+                 skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack)
         }
 
         // Build the remaining artifacts
@@ -334,7 +335,8 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         // Run Kola TestISO tests for metal artifacts
         if (shwrapCapture("cosa meta --get-value images.live-iso") != "None") {
             stage("Kola:TestISO") {
-                kolaTestIso(cosaDir: env.WORKSPACE, arch: basearch)
+                kolaTestIso(cosaDir: env.WORKSPACE, arch: basearch,
+                            skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack)
             }
         }
 

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -306,7 +306,8 @@ lock(resource: "build-${params.STREAM}") {
         stage("Kola") {
             def n = ncpus - 1 // remove 1 for upgrade test
             kola(cosaDir: env.WORKSPACE, parallel: n, arch: basearch,
-                 allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE)
+                 allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
+                 skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack)
         }
 
         // If we are uploading results then let's do an early archive
@@ -356,7 +357,8 @@ lock(resource: "build-${params.STREAM}") {
         // Run Kola TestISO tests for metal artifacts
         if (shwrapCapture("cosa meta --get-value images.live-iso") != "None") {
             stage("Kola:TestISO") {
-                kolaTestIso(cosaDir: env.WORKSPACE, arch: basearch)
+                kolaTestIso(cosaDir: env.WORKSPACE, arch: basearch,
+                            skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack)
                 // For now we want to notify ourselves when a particular workaround is observed.
                 // It won't fail the build, just give us information.
                 // https://github.com/coreos/fedora-coreos-tracker/issues/1233


### PR DESCRIPTION
For the ART hotfix process, we sometimes need to be able to build with an unsigned kernel. This means that UEFI SecureBoot tests will fail. We should support skipping UEFI tests from the src config repo via e.g. `kola-denylist.yaml`. But to do this properly, we need to first lower `cosa kola --basic-qemu-scenarios` into kola proper, and also ideally merge `kola testiso` into `kola run` (maybe as external tests?) or introduce a new `kola-testiso-denylist.yaml` file (or change the schema of the existing `kola-denylist.yaml`).

Short-term, let's just hack around this by adding a `skip_secureboot_tests_hack` knob in the pipecfg which automatically tells `kola()` and `kolaTestIso()` to skip over SecureBoot tests.

Requires: https://github.com/coreos/coreos-ci-lib/pull/133