### PR TITLE
Support pushing containers in v2s2 format

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -90,6 +90,8 @@ registry_repos:
   extensions: quay.io/openshift-release-dev/rhel-coreos-extensions-dev
   # OPTIONAL: whether to also tag images with build ID
   add_build_tag: true
+  # OPTIONAL: whether to push in v2s2 format rather than OCI
+  v2s2: true
 
 # OPTIONAL/TEMPORARY: enable AWS aarch64 hack; see comment in `build-arch.Jenkinsfile`.
 aws_aarch64_serial_console_hack: true

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -223,7 +223,10 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
                                           credentialsId: 'oscontainer-push-registry-secret')]) {
                         def repo = registry_repos[configname]
                         def (artifact, metajsonname, tag_suffix) = val
-                        def arch_args = basearches.collect{"--arch ${it}"}.join(" ")
+                        def extra_args = basearches.collect{"--arch ${it}"}.join(" ")
+                        if (registry_repos.v2s2) {
+                            extra_args += " --v2s2"
+                        }
                         def tag_args = " --tag=${params.STREAM}${tag_suffix}"
                         if (registry_repos.add_build_tag) {
                             tag_args += " --tag ${params.VERSION}${tag_suffix}"
@@ -232,7 +235,7 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
                         cosa push-container-manifest --auth=\${REGISTRY_SECRET} \
                             --repo=${repo} ${tag_args} \
                             --artifact=${artifact} --metajsonname=${metajsonname} \
-                            --build=${params.VERSION} ${arch_args}
+                            --build=${params.VERSION} ${extra_args}
                         """)
 
                         def old_repo = registry_repos["${configname}_old"]

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -223,19 +223,19 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
                                           credentialsId: 'oscontainer-push-registry-secret')]) {
                         def repo = registry_repos[configname]
                         def (artifact, metajsonname, tag_suffix) = val
-                        def extra_args = basearches.collect{"--arch ${it}"}.join(" ")
+                        def extra_args = basearches.collect{"--arch ${it}"}
                         if (registry_repos.v2s2) {
-                            extra_args += " --v2s2"
+                            extra_args += "--v2s2"
                         }
-                        def tag_args = " --tag=${params.STREAM}${tag_suffix}"
+                        def tag_args = ["--tag=${params.STREAM}${tag_suffix}"]
                         if (registry_repos.add_build_tag) {
-                            tag_args += " --tag ${params.VERSION}${tag_suffix}"
+                            tag_args += "--tag=${params.VERSION}${tag_suffix}"
                         }
                         shwrap("""
                         cosa push-container-manifest --auth=\${REGISTRY_SECRET} \
-                            --repo=${repo} ${tag_args} \
+                            --repo=${repo} ${tag_args.join(' ')} \
                             --artifact=${artifact} --metajsonname=${metajsonname} \
-                            --build=${params.VERSION} ${extra_args}
+                            --build=${params.VERSION} ${extra_args.join(' ')}
                         """)
 
                         def old_repo = registry_repos["${configname}_old"]
@@ -249,7 +249,7 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
                                     authArg += " --dest-authfile=\${OLD_REGISTRY_SECRET}"
                                 }
                                 shwrap("""
-                                cosa copy-container ${authArg} ${tag_args} \
+                                cosa copy-container ${authArg} ${tag_args.join(' ')} \
                                     --manifest-list-to-arch-tag=auto \
                                     ${repo} ${old_repo}
                                 """)


### PR DESCRIPTION
A bunch of tooling around OpenShift don't support the OCI format yet, so
for the RHCOS images we need to push in v2s2 format.

For FCOS, we want to keep pushing in OCI format. Add a new config.yaml
knob to override this for RHCOS.

Related: https://github.com/coreos/coreos-assembler/pull/2726