### PR TITLE
add in workarounds for new restricted permissions in OCP 4.11

### DIFF
--- a/jobs/build-cosa.Jenkinsfile
+++ b/jobs/build-cosa.Jenkinsfile
@@ -136,6 +136,8 @@ try {
                     images += " --image=docker://${params.CONTAINER_REGISTRY_STAGING_REPO}:${arch}-${shortcommit}"
                 }
                 shwrap("""
+                mkdir /var/tmp/builder
+                export HOME=/var/tmp/builder # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668147
                 cosa push-container-manifest --v2s2 \
                     --auth=\$REGISTRY_SECRET --tag ${gitref} \
                     --repo ${params.CONTAINER_REGISTRY_REPO} ${images}
@@ -145,6 +147,7 @@ try {
                 // that would be preferable.
                 if (gitref == "main") {
                     shwrap("""
+                    export HOME=/var/tmp/builder # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668147
                     skopeo copy --all --authfile \$REGISTRY_SECRET   \
                         docker://${params.CONTAINER_REGISTRY_REPO}:main \
                         docker://${params.CONTAINER_REGISTRY_REPO}:latest
@@ -155,6 +158,7 @@ try {
             stage('Delete Intermediate Tags') {
                 parallel basearches.collectEntries{arch -> [arch, {
                     shwrap("""
+                    export HOME=/var/tmp/builder # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668147
                     skopeo delete --authfile=\$REGISTRY_SECRET \
                         docker://${params.CONTAINER_REGISTRY_STAGING_REPO}:${arch}-${shortcommit}
                     """)

--- a/jobs/build-cosa.Jenkinsfile
+++ b/jobs/build-cosa.Jenkinsfile
@@ -136,8 +136,7 @@ try {
                     images += " --image=docker://${params.CONTAINER_REGISTRY_STAGING_REPO}:${arch}-${shortcommit}"
                 }
                 shwrap("""
-                mkdir /var/tmp/builder
-                export HOME=/var/tmp/builder # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668147
+                export STORAGE_DRIVER=vfs # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668507
                 cosa push-container-manifest --v2s2 \
                     --auth=\$REGISTRY_SECRET --tag ${gitref} \
                     --repo ${params.CONTAINER_REGISTRY_REPO} ${images}
@@ -147,7 +146,7 @@ try {
                 // that would be preferable.
                 if (gitref == "main") {
                     shwrap("""
-                    export HOME=/var/tmp/builder # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668147
+                    export STORAGE_DRIVER=vfs # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668507
                     skopeo copy --all --authfile \$REGISTRY_SECRET   \
                         docker://${params.CONTAINER_REGISTRY_REPO}:main \
                         docker://${params.CONTAINER_REGISTRY_REPO}:latest
@@ -158,7 +157,7 @@ try {
             stage('Delete Intermediate Tags') {
                 parallel basearches.collectEntries{arch -> [arch, {
                     shwrap("""
-                    export HOME=/var/tmp/builder # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668147
+                    export STORAGE_DRIVER=vfs # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668507
                     skopeo delete --authfile=\$REGISTRY_SECRET \
                         docker://${params.CONTAINER_REGISTRY_STAGING_REPO}:${arch}-${shortcommit}
                     """)

--- a/jobs/build-fcos-buildroot.Jenkinsfile
+++ b/jobs/build-fcos-buildroot.Jenkinsfile
@@ -147,6 +147,8 @@ try {
                     images += " --image=docker://${params.CONTAINER_REGISTRY_STAGING_REPO}:${arch}-${shortcommit}"
                 }
                 shwrap("""
+                mkdir /var/tmp/builder
+                export HOME=/var/tmp/builder # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668147
                 cosa push-container-manifest \
                     --auth=\$REGISTRY_SECRET --tag ${gitref} \
                     --repo ${params.CONTAINER_REGISTRY_REPO} ${images}
@@ -156,6 +158,7 @@ try {
             stage('Delete Intermediate Tags') {
                 parallel basearches.collectEntries{arch -> [arch, {
                     shwrap("""
+                    export HOME=/var/tmp/builder # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668147
                     skopeo delete --authfile=\$REGISTRY_SECRET \
                         docker://${params.CONTAINER_REGISTRY_STAGING_REPO}:${arch}-${shortcommit}
                     """)

--- a/jobs/build-fcos-buildroot.Jenkinsfile
+++ b/jobs/build-fcos-buildroot.Jenkinsfile
@@ -147,8 +147,7 @@ try {
                     images += " --image=docker://${params.CONTAINER_REGISTRY_STAGING_REPO}:${arch}-${shortcommit}"
                 }
                 shwrap("""
-                mkdir /var/tmp/builder
-                export HOME=/var/tmp/builder # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668147
+                export STORAGE_DRIVER=vfs # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668507
                 cosa push-container-manifest \
                     --auth=\$REGISTRY_SECRET --tag ${gitref} \
                     --repo ${params.CONTAINER_REGISTRY_REPO} ${images}
@@ -158,7 +157,7 @@ try {
             stage('Delete Intermediate Tags') {
                 parallel basearches.collectEntries{arch -> [arch, {
                     shwrap("""
-                    export HOME=/var/tmp/builder # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668147
+                    export STORAGE_DRIVER=vfs # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668507
                     skopeo delete --authfile=\$REGISTRY_SECRET \
                         docker://${params.CONTAINER_REGISTRY_STAGING_REPO}:${arch}-${shortcommit}
                     """)

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -239,8 +239,7 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
                             tag_args += "--tag=${params.VERSION}${tag_suffix}"
                         }
                         shwrap("""
-                        mkdir -p /var/tmp/builder
-                        export HOME=/var/tmp/builder # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668147
+                        export STORAGE_DRIVER=vfs # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668507
                         cosa push-container-manifest --auth=\${REGISTRY_SECRET} \
                             --repo=${repo} ${tag_args.join(' ')} \
                             --artifact=${artifact} --metajsonname=${metajsonname} \
@@ -258,7 +257,7 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
                                     authArg += " --dest-authfile=\${OLD_REGISTRY_SECRET}"
                                 }
                                 shwrap("""
-                                export HOME=/var/tmp/builder # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668147
+                                export STORAGE_DRIVER=vfs # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668507
                                 cosa copy-container ${authArg} ${tag_args.join(' ')} \
                                     --manifest-list-to-arch-tag=auto \
                                     ${repo} ${old_repo}

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -239,6 +239,8 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
                             tag_args += "--tag=${params.VERSION}${tag_suffix}"
                         }
                         shwrap("""
+                        mkdir -p /var/tmp/builder
+                        export HOME=/var/tmp/builder # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668147
                         cosa push-container-manifest --auth=\${REGISTRY_SECRET} \
                             --repo=${repo} ${tag_args.join(' ')} \
                             --artifact=${artifact} --metajsonname=${metajsonname} \
@@ -256,6 +258,7 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
                                     authArg += " --dest-authfile=\${OLD_REGISTRY_SECRET}"
                                 }
                                 shwrap("""
+                                export HOME=/var/tmp/builder # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668147
                                 cosa copy-container ${authArg} ${tag_args.join(' ')} \
                                     --manifest-list-to-arch-tag=auto \
                                     ${repo} ${old_repo}


### PR DESCRIPTION
```
commit 02ba886a0337c9e7805533fd49b41e47d20c02ab
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Oct 31 20:30:07 2022 -0400

    tree-wide: use VFS storage driver for container pushes
    
    This is a less hacky workaround for
    https://github.com/coreos/fedora-coreos-pipeline/issues/723
    
    Since we're just pushing containers the performance hit won't be
    much.

commit f3a0dc7b175455998f9ef2c23b810deba3a02682
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Oct 31 16:50:04 2022 -0400

    tree-wide: use different home dir to workaround podman mount issue
    
    This is to address https://github.com/coreos/fedora-coreos-pipeline/issues/723
    
    One workaround I've found is to change my `$HOME` to a different
    filesystem (`/var/tmp`, which is overlayfs) and it seems to workaround
    the offending check [1].
    
    This shouldn't work because there is another check [2] that should fail
    if we're on an overlay filesystem, but it doesn't in this case. I suspect
    we're hitting some kind of corner case.
    
    [1] https://github.com/containers/storage/blob/232bf398bd68595d2a6e53ec07d8b3c4424be3c0/drivers/overlay/check.go#L158-L164
    [2] https://github.com/containers/storage/blob/232bf398bd68595d2a6e53ec07d8b3c4424be3c0/drivers/overlay/overlay.go#L314-L318
```

There's a lot going on in the commit messages.. TL;DR use the `vfs`
storage driver to workaround https://github.com/coreos/fedora-coreos-pipeline/issues/723
