### PR TITLE
Lower FCOS S3 bucket prefix into config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,8 +24,10 @@ additional_arches: [aarch64, ppc64le, s390x]
 source_config:
   url: https://github.com/coreos/fedora-coreos-config
 
-# remove to disable S3 uploads
-s3_bucket: fcos-builds
+s3:
+  bucket: fcos-builds
+  # see bucket layout in https://github.com/coreos/fedora-coreos-tracker/issues/189
+  builds_key: "prod/streams/${STREAM}"
 
 registry_repos:
   oscontainer: quay.io/fedora/fedora-coreos

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -26,7 +26,7 @@ hotfix:
   # OPTIONAL/TEMPORARY: skip all tests that require a signed kernel
   skip_secureboot_tests_hack: true
 
-# OPTIONAL: coreos-assembler image to build with. supports ${STREAM} variable.
+# OPTIONAL: coreos-assembler image to build with. Supports ${STREAM} variable.
 # If unset, defaults to `quay.io/coreos-assembler/coreos-assembler:main`.
 cosa_img: quay.io/jlebon/coreos-assembler:pr3139-${STREAM}
 
@@ -71,8 +71,14 @@ streams:
 # REQUIRED: other architectures supported other than x86_64
 additional_arches: [aarch64, ppc64le, s390x]
 
-# OPTIONAL: S3 bucket to which to upload build artifacts
-s3_bucket: fcos-builds
+# OPTIONAL: S3 bucket and key to which to upload build artifacts. For reference,
+# the builds.json file will be located at
+# `${s3.bucket}/${s3.builds_key}/builds/builds.json`.
+s3:
+  # REQUIRED: S3 bucket name
+  bucket: rhcos-jlebon
+  # OPTIONAL: S3 bucket subkey. Supports `${STREAM}` variable.
+  builds_key: "streams/${STREAM}"
 
 # OPTIONAL: container registry-related keys
 registry_repos:

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -114,9 +114,8 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         // this is defined IFF we *should* and we *can* upload to S3
         def s3_stream_dir
 
-        if (pipecfg.s3_bucket && pipeutils.AWSBuildUploadCredentialExists()) {
-            // see bucket layout in https://github.com/coreos/fedora-coreos-tracker/issues/189
-            s3_stream_dir = "${pipecfg.s3_bucket}/prod/streams/${params.STREAM}"
+        if (pipecfg.s3 && pipeutils.AWSBuildUploadCredentialExists()) {
+            s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
         }
 
         // Now, determine if we should do any uploads to remote s3 buckets or clouds

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -102,14 +102,11 @@ lock(resource: "build-${params.STREAM}") {
         basearch = shwrapCapture("cosa basearch")
         currentBuild.description = "[${params.STREAM}][${basearch}] Running"
 
-
-
         // this is defined IFF we *should* and we *can* upload to S3
         def s3_stream_dir
 
-        if (pipecfg.s3_bucket && pipeutils.AWSBuildUploadCredentialExists()) {
-            // see bucket layout in https://github.com/coreos/fedora-coreos-tracker/issues/189
-            s3_stream_dir = "${pipecfg.s3_bucket}/prod/streams/${params.STREAM}"
+        if (pipecfg.s3 && pipeutils.AWSBuildUploadCredentialExists()) {
+            s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
         }
 
         // Now, determine if we should do any uploads to remote s3 buckets or clouds

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -48,7 +48,7 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSIO
 
 def s3_stream_dir = params.S3_STREAM_DIR
 if (s3_stream_dir == "") {
-    s3_stream_dir = "${pipecfg.s3_bucket}/prod/streams/${params.STREAM}"
+    s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 }
 
 try { timeout(time: 90, unit: 'MINUTES') {

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -20,10 +20,6 @@ properties([
              description: 'Target architecture',
              defaultValue: 'x86_64',
              trim: true),
-      string(name: 'S3_STREAM_DIR',
-             description: 'Override the Fedora CoreOS S3 stream directory',
-             defaultValue: '',
-             trim: true),
       string(name: 'KOLA_TESTS',
              description: 'Override tests to run',
              defaultValue: "",
@@ -46,10 +42,7 @@ properties([
 
 currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSION}"
 
-def s3_stream_dir = params.S3_STREAM_DIR
-if (s3_stream_dir == "") {
-    s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
-}
+def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
 try { timeout(time: 90, unit: 'MINUTES') {
     cosaPod(memory: "512Mi", kvm: false,

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -20,10 +20,6 @@ properties([
              description: 'Target architecture',
              defaultValue: 'x86_64',
              trim: true),
-      string(name: 'S3_STREAM_DIR',
-             description: 'Override the Fedora CoreOS S3 stream directory',
-             defaultValue: '',
-             trim: true),
       string(name: 'KOLA_TESTS',
              description: 'Override tests to run',
              defaultValue: "",
@@ -54,10 +50,7 @@ lock(resource: "kola-azure-${params.ARCH}") {
     // Use eastus region for now
     def region = "eastus"
 
-    def s3_stream_dir = params.S3_STREAM_DIR
-    if (s3_stream_dir == "") {
-        s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
-    }
+    def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
     // Go with 1.5Gi here because we download/decompress/upload the image
     def cosa_memory_request_mb = 1536

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -56,7 +56,7 @@ lock(resource: "kola-azure-${params.ARCH}") {
 
     def s3_stream_dir = params.S3_STREAM_DIR
     if (s3_stream_dir == "") {
-        s3_stream_dir = "${pipecfg.s3_bucket}/prod/streams/${params.STREAM}"
+        s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
     }
 
     // Go with 1.5Gi here because we download/decompress/upload the image

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -48,7 +48,7 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSIO
 
 def s3_stream_dir = params.S3_STREAM_DIR
 if (s3_stream_dir == "") {
-    s3_stream_dir = "${pipecfg.s3_bucket}/prod/streams/${params.STREAM}"
+    s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 }
 
 try { timeout(time: 30, unit: 'MINUTES') {

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -20,10 +20,6 @@ properties([
              description: 'Target architecture',
              defaultValue: 'x86_64',
              trim: true),
-      string(name: 'S3_STREAM_DIR',
-             description: 'Override the Fedora CoreOS S3 stream directory',
-             defaultValue: '',
-             trim: true),
       string(name: 'KOLA_TESTS',
              description: 'Override tests to run',
              defaultValue: "",
@@ -46,10 +42,7 @@ properties([
 
 currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSION}"
 
-def s3_stream_dir = params.S3_STREAM_DIR
-if (s3_stream_dir == "") {
-    s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
-}
+def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
 try { timeout(time: 30, unit: 'MINUTES') {
     cosaPod(memory: "512Mi", kvm: false,

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -20,10 +20,6 @@ properties([
              description: 'Target architecture',
              defaultValue: 'x86_64',
              trim: true),
-      string(name: 'S3_STREAM_DIR',
-             description: 'Override the Fedora CoreOS S3 stream directory',
-             defaultValue: '',
-             trim: true),
       string(name: 'COREOS_ASSEMBLER_IMAGE',
              description: 'Override the coreos-assembler image to use',
              defaultValue: "quay.io/coreos-assembler/coreos-assembler:main",
@@ -42,10 +38,7 @@ properties([
 
 currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSION}"
 
-def s3_stream_dir = params.S3_STREAM_DIR
-if (s3_stream_dir == "") {
-    s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
-}
+def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
 try { timeout(time: 60, unit: 'MINUTES') {
     cosaPod(memory: "512Mi", kvm: false,

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -44,7 +44,7 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSIO
 
 def s3_stream_dir = params.S3_STREAM_DIR
 if (s3_stream_dir == "") {
-    s3_stream_dir = "${pipecfg.s3_bucket}/prod/streams/${params.STREAM}"
+    s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 }
 
 try { timeout(time: 60, unit: 'MINUTES') {

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -20,10 +20,6 @@ properties([
              description: 'Target architecture',
              defaultValue: 'x86_64',
              trim: true),
-      string(name: 'S3_STREAM_DIR',
-             description: 'Override the Fedora CoreOS S3 stream directory',
-             defaultValue: '',
-             trim: true),
       string(name: 'KOLA_TESTS',
              description: 'Override tests to run',
              defaultValue: "",
@@ -55,10 +51,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
     // image uploads to ams1.
     def region = "ca-ymq-1"
 
-    def s3_stream_dir = params.S3_STREAM_DIR
-    if (s3_stream_dir == "") {
-        s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
-    }
+    def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
     // Go with 1.5Gi here because we download/decompress/upload the image
     def cosa_memory_request_mb = 1536

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -57,7 +57,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
 
     def s3_stream_dir = params.S3_STREAM_DIR
     if (s3_stream_dir == "") {
-        s3_stream_dir = "${pipecfg.s3_bucket}/prod/streams/${params.STREAM}"
+        s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
     }
 
     // Go with 1.5Gi here because we download/decompress/upload the image

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -106,7 +106,7 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
             // We need to fetch a few artifacts if they were built. This assumes if
             // it was built for one platform it was built for all.
             def fetch_artifacts = ['ostree', 'extensions-container', 'legacy-oscontainer']
-            def meta = readJSON(text: shwrapCapture("cosa meta --arch=x86_64 --dump"))
+            def meta = readJSON(text: shwrapCapture("cosa meta --build=${params.VERSION} --arch=x86_64 --dump"))
             fetch_artifacts.retainAll(meta.images.keySet())
 
             def fetch_args = basearches.collect{"--arch=${it}"}
@@ -121,7 +121,7 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
         }
 
         for (basearch in basearches) {
-            def meta = readJSON(text: shwrapCapture("cosa meta --arch=${basearch} --dump"))
+            def meta = readJSON(text: shwrapCapture("cosa meta --build=${params.VERSION} --arch=${basearch} --dump"))
 
             // For production streams, import the OSTree into the prod
             // OSTree repo.
@@ -201,7 +201,7 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
 
         // filter out those not built. this step makes the assumption that if an
         // image isn't built for x86_64, then we don't upload it at all
-        def meta_x86_64 = readJSON(text: shwrapCapture("cosa meta --arch=x86_64 --dump"))
+        def meta_x86_64 = readJSON(text: shwrapCapture("cosa meta --build=${params.VERSION} --arch=x86_64 --dump"))
         def artifacts = meta_x86_64.images.keySet()
 
         // in newer Groovy, retainAll can take a closure, which would be nicer here

--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -31,14 +31,14 @@ cosaPod() {
         // if so
         production_streams.each{stream ->
             for (subdir in ["streams", "updates"]) {
-                shwrap("aws s3 cp s3://${pipecfg.s3_bucket}/${subdir}/${stream}.json ${subdir}/${stream}.json")
+                shwrap("aws s3 cp s3://${pipecfg.s3.bucket}/${subdir}/${stream}.json ${subdir}/${stream}.json")
             }
             if (shwrapRc("git diff --exit-code") != 0) {
                 shwrap("git reset --hard HEAD")
                 for (subdir in ["streams", "updates"]) {
                     shwrap("""
                         aws s3 cp --acl public-read --cache-control 'max-age=60' \
-                            ${subdir}/${stream}.json s3://${pipecfg.s3_bucket}/${subdir}/${stream}.json
+                            ${subdir}/${stream}.json s3://${pipecfg.s3.bucket}/${subdir}/${stream}.json
                     """)
                 }
                 pipeutils.tryWithMessagingCredentials() {
@@ -56,7 +56,7 @@ cosaPod() {
                 python3 -c 'import sys, yaml, json; json.dump(yaml.safe_load(sys.stdin.read()), sys.stdout)' \
                     < release-notes/${stream}.yml > release-notes/${stream}.json
                 aws s3 cp --acl public-read --cache-control 'max-age=60' \
-                    release-notes/${stream}.json s3://${pipecfg.s3_bucket}/release-notes/${stream}.json
+                    release-notes/${stream}.json s3://${pipecfg.s3.bucket}/release-notes/${stream}.json
             """)
         }
     }

--- a/utils.groovy
+++ b/utils.groovy
@@ -347,7 +347,6 @@ def run_cloud_tests(pipecfg, stream, version, s3_stream_dir, basearch, commit) {
     // Define a set of parameters that are common to all test.
     def params = [string(name: 'STREAM', value: stream),
                   string(name: 'VERSION', value: version),
-                  string(name: 'S3_STREAM_DIR', value: s3_stream_dir),
                   string(name: 'ARCH', value: basearch),
                   string(name: 'SRC_CONFIG_COMMIT', value: commit)]
 

--- a/utils.groovy
+++ b/utils.groovy
@@ -57,6 +57,15 @@ boolean checkKolaSuccess(file) {
     return true
 }
 
+def get_s3_streams_dir(pipecfg, stream) {
+    def s = pipecfg.s3.bucket
+    if (pipecfg.s3.builds_key) {
+        def key = utils.substituteStr(pipecfg.s3.builds_key, [STREAM: stream])
+        s += "/${key}"
+    }
+    return s
+}
+
 def aws_s3_cp_allow_noent(src, dest) {
     // see similar code in `cosa buildfetch`
     shwrapWithAWSBuildUploadCredentials("""

--- a/utils.groovy
+++ b/utils.groovy
@@ -351,7 +351,7 @@ def run_cloud_tests(pipecfg, stream, version, s3_stream_dir, basearch, commit) {
                   string(name: 'SRC_CONFIG_COMMIT', value: commit)]
 
     // Kick off the Kola AWS job if we have an uploaded image, credentials, and testing is enabled.
-    if (shwrapCapture("cosa meta --get-value amis") != "None" &&
+    if (shwrapCapture("cosa meta --build=${version} --get-value amis") != "None" &&
         cloud_testing_enabled_for_arch(pipecfg, 'aws', basearch) &&
         utils.credentialsExist([file(variable: 'AWS_KOLA_TESTS_CONFIG',
                                      credentialsId: 'aws-kola-tests-config')])) {
@@ -362,7 +362,7 @@ def run_cloud_tests(pipecfg, stream, version, s3_stream_dir, basearch, commit) {
     }
 
     // Kick off the Kola Azure job if we have an artifact, credentials, and testing is enabled.
-    if (shwrapCapture("cosa meta --get-value images.azure") != "None" &&
+    if (shwrapCapture("cosa meta --build=${version} --get-value images.azure") != "None" &&
         cloud_testing_enabled_for_arch(pipecfg, 'azure', basearch) &&
         utils.credentialsExist([file(variable: 'AZURE_KOLA_TESTS_CONFIG_AUTH',
                                      credentialsId: 'azure-kola-tests-config-auth'),
@@ -372,7 +372,7 @@ def run_cloud_tests(pipecfg, stream, version, s3_stream_dir, basearch, commit) {
     }
 
     // Kick off the Kola GCP job if we have an uploaded image, credentials, and testing is enabled.
-    if (shwrapCapture("cosa meta --get-value gcp") != "None" &&
+    if (shwrapCapture("cosa meta --build=${version} --get-value gcp") != "None" &&
         cloud_testing_enabled_for_arch(pipecfg, 'gcp', basearch) &&
         utils.credentialsExist([file(variable: 'GCP_KOLA_TESTS_CONFIG',
                                      credentialsId: 'gcp-kola-tests-config')])) {
@@ -380,7 +380,7 @@ def run_cloud_tests(pipecfg, stream, version, s3_stream_dir, basearch, commit) {
     }
 
     // Kick off the Kola OpenStack job if we have an artifact, credentials, and testing is enabled.
-    if (shwrapCapture("cosa meta --get-value images.openstack") != "None" &&
+    if (shwrapCapture("cosa meta --build=${version} --get-value images.openstack") != "None" &&
         cloud_testing_enabled_for_arch(pipecfg, 'openstack', basearch) &&
         utils.credentialsExist([file(variable: 'OPENSTACK_KOLA_TESTS_CONFIG',
                                      credentialsId: 'openstack-kola-tests-config')])) {


### PR DESCRIPTION
The `prod/streams/${params.STREAM}` is an FCOS thing. Let's have the `s3_bucket` key in the `config.yaml` also incorporate the subpath.

This will allow the RHCOS config to specify its own subpath and is prep for hotfix builds specifying a different subpath.