### PR TITLE
Add basic support for hotfix builds

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -71,7 +71,7 @@ streams:
     rawhide:
       type: mechanical
 
-# REQUIRED: other architectures supported other than x86_64
+# REQUIRED: architectures to build for other than x86_64
 additional_arches: [aarch64, ppc64le, s390x]
 
 # OPTIONAL: S3 bucket and key to which to upload build artifacts. For reference,

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -23,6 +23,8 @@ default_artifacts:
 
 # OPTIONAL: hotfix-related keys
 hotfix:
+  # REQUIRED: name for hotfix used to tag pushed resources
+  name: art1234
   # OPTIONAL/TEMPORARY: skip all tests that require a signed kernel
   skip_secureboot_tests_hack: true
 

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -24,7 +24,7 @@ properties([
              trim: true),
       string(name: 'ARCH',
              description: 'The target architecture',
-             choices: pipecfg.additional_arches,
+             choices: pipeutils.get_supported_additional_arches(),
              trim: true),
       booleanParam(name: 'FORCE',
                    defaultValue: false,

--- a/jobs/build-cosa.Jenkinsfile
+++ b/jobs/build-cosa.Jenkinsfile
@@ -1,10 +1,9 @@
-def pipeutils, pipecfg
+def pipeutils
 def gitref, commit, shortcommit
 def containername = 'coreos-assembler'
 node {
     checkout scm
     pipeutils = load("utils.groovy")
-    pipecfg = pipeutils.load_pipecfg()
 }
 
 properties([
@@ -32,7 +31,7 @@ properties([
     parameters([
       string(name: 'ARCHES',
              description: 'Space-separated list of target architectures',
-             defaultValue: "x86_64" + " " + pipecfg.additional_arches.join(" "),
+             defaultValue: "x86_64" + " " + pipeutils.get_supported_additional_arches().join(" "),
              trim: true),
       string(name: 'COREOS_ASSEMBLER_GIT_URL',
              description: 'Override the coreos-assembler git repo to use',

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -11,7 +11,6 @@ node {
 // Base URL through which to download artifacts
 BUILDS_BASE_HTTP_URL = "https://builds.coreos.fedoraproject.org/prod/streams"
 
-
 properties([
     pipelineTriggers([]),
     parameters([
@@ -23,7 +22,8 @@ properties([
              defaultValue: '',
              trim: true),
       string(name: 'ADDITIONAL_ARCHES',
-             description: 'Override default additional target architectures (space-separated)',
+             description: "Override additional architectures (space-separated). " +
+                          "Supported: ${pipeutils.get_supported_additional_arches().join(' ')}",
              defaultValue: "",
              trim: true),
       booleanParam(name: 'FORCE',

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -17,7 +17,8 @@ properties([
              defaultValue: '',
              trim: true),
       string(name: 'ADDITIONAL_ARCHES',
-             description: 'Override additional target architectures (space-separated)',
+             description: "Override additional architectures (space-separated). " +
+                          "Supported: ${pipeutils.get_supported_additional_arches().join(' ')}",
              defaultValue: "",
              trim: true),
       booleanParam(name: 'ALLOW_MISSING_ARCHES',


### PR DESCRIPTION
ART needs the ability to perform hotfix builds, i.e. builds outside the
regular stream for a specific purpose. These builds must not pollute
production stream references.

Support this via the new `hotfix` section of the pipecfg. Require a
`name` subkey which is then used to modify the S3 subpath we upload to
and the oscontainer tags we push to. Add new hotfix parameters to the
`build`, `build-arch`, and `release` jobs which will be used to pass the
repo containing the hotfix pipecfg.

Don't support hotfix cloud uploads since it's not yet needed and
requires plumbing of the hotfix prefix.

Requires: https://github.com/coreos/fedora-coreos-pipeline/pull/739