### PR TITLE
jobs/release: allow pushing both legacy and new oscontainer

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -77,12 +77,10 @@ s3_bucket: fcos-builds
 # OPTIONAL: container registry-related keys
 registry_repos:
   # OPTIONAL: repo to which to push oscontainer
-  # CONFLICTS WITH: legacy_oscontainer
   oscontainer: quay.io/fedora/fedora-coreos
   # OPTIONAL/TEMPORARY: additional repo to which to push oscontainer
   oscontainer_old: quay.io/coreos-assembler/fcos
   # OPTIONAL: repo to which to push legacy oscontainer
-  # CONFLICTS WITH: oscontainer
   legacy_oscontainer: quay.io/openshift-release-dev/rhel-coreos-dev
   # OPTIONAL/TEMPORARY: additional repo to which to push oscontainer
   legacy_oscontainer_old: registry.ci.openshift.org/rhcos/rhel-coreos


### PR DESCRIPTION
The latest plan for 4.12 is to go back to shipping both the legacy and new oscontainers to not break existing workflows of teams consuming it. So we need to undo some of the recent changes made.

Related: https://issues.redhat.com/browse/MCO-295
Related: https://issues.redhat.com/browse/MCO-392