### PR TITLE
ci: add basic syntax checking of Groovy files

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -3,8 +3,32 @@
 node {
     checkout scm
 
-    stage("Test") {
-        // for now, just sanity check all the manifests
+    stage("Check Groovy") {
+        // hacky way to convert Jenkinsfiles into a "library" without executing it
+        shwrap("""
+        find . -type f -name '*.Jenkinsfile' -exec sed -i -e '1i\\return this' '{}' +
+        """)
+
+        def files = findFiles(glob: '**/*.groovy') + findFiles(glob: '**/*.Jenkinsfile')
+        def found_error = false
+        files.each {
+            try {
+                def l = load(it.path)
+                println("${it.path}: OK")
+            } catch (e) {
+                println("${it.path}: ERROR")
+                println(e)
+                found_error = true
+            }
+        }
+
+        if (found_error) {
+            error "Syntax errors found"
+        }
+    }
+
+    stage("Check Manifests") {
+        // just sanity check all the manifests
         shwrap("""
         find manifests/ -iname '*.yaml' | xargs -n 1 oc create --dry-run -f
         """)


### PR DESCRIPTION
I realized recently that we could use `load()` in CI as a way to syntax-check our Groovy files. Add a CI check that uses this.

This works for regular Jenkinsfiles too (since it's still just the same custom Groovy interpreter). But `load()` will try to execute them, which is not what we want. Hack around this by adding a `return this` at the top. The parser will still actually scan the full file.

This only catches basic syntax errors like unbalanced parentheses or brackets, and not semantic errors like typoed function names or variables. We should be able to add a more complete CI run here in the future that e.g. could execute a part of the pipeline, but it requires some thought.