### PR TITLE
ci: tweak syntax error and path printing

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -13,11 +13,9 @@ node {
         def found_error = false
         files.each {
             try {
-                def l = load(it.path)
-                println("${it.path}: OK")
+                println("${it.path}")
+                load(it.path)
             } catch (e) {
-                println("${it.path}: ERROR")
-                println(e)
                 found_error = true
             }
         }


### PR DESCRIPTION
Don't reprint the error since `load` already prints it.

Print the path being tested before `load` otherwise there's a weird rendering issue where the error message is associated with the previous file tested.