### PR TITLE
utils: modify bump_builds_json to work if non x86_64 first

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -153,6 +153,10 @@ def bump_builds_json(stream, buildid, arch, s3_stream_dir) {
             insert_build ${buildid} \$TMPD ${arch}
             mkdir -p builds
             cp \$TMPD/builds/builds.json builds/builds.json
+        elif [ -n "\${COREOS_ASSEMBLER_REMOTE_SESSION:-}" ]; then
+            # If in a remote session then copy the builds.json back local
+            mkdir -p ./builds # make local builds directory first
+            cosa shell -- cat builds/builds.json > builds/builds.json
         fi
         """)
         shwrapWithAWSBuildUploadCredentials("""


### PR DESCRIPTION
In the case that there is a one-off mArch build that runs first for a particular stream then we need to copy the builds.json back to the local node before we upload.