### PR TITLE
Support skipping or overriding additional arches per stream

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,19 @@
 streams:
     stable:
       type: production
+      skip_additional_arches:
+        # https://github.com/coreos/fedora-coreos-tracker/issues/1247#issuecomment-1261286872
+        - ppc64le
     testing:
       type: production
+      skip_additional_arches:
+        # https://github.com/coreos/fedora-coreos-tracker/issues/1247#issuecomment-1261286872
+        - ppc64le
     next:
       type: production
+      skip_additional_arches:
+        # https://github.com/coreos/fedora-coreos-tracker/issues/1247#issuecomment-1261286872
+        - ppc64le
     testing-devel:
       type: development
       default: true

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -70,8 +70,14 @@ streams:
       # building with a cosa too old to support `cosa remote-session`, which
       # should only be the case for RHCOS 4.11 and older.
       cosa_controller_img_hack: quay.io/coreos-assembler/coreos-assembler:latest
+      # OPTIONAL: override additional architectures to build for
+      additional_arches:
+        - s390x
     rawhide:
       type: mechanical
+      # OPTIONAL: additional architectures to skip building for
+      skip_additional_arches:
+        - s390x
 
 # REQUIRED: architectures to build for other than x86_64
 additional_arches: [aarch64, ppc64le, s390x]

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -66,7 +66,7 @@ if (params.PIPECFG_HOTFIX_REPO || params.PIPECFG_HOTFIX_REF) {
 def cosa_img = params.COREOS_ASSEMBLER_IMAGE
 cosa_img = cosa_img ?: pipeutils.get_cosa_img(pipecfg, params.STREAM)
 def additional_arches = params.ADDITIONAL_ARCHES.split()
-additional_arches = additional_arches ?: pipecfg.additional_arches
+additional_arches = additional_arches ?: pipeutils.get_additional_arches(pipecfg, params.STREAM)
 
 def stream_info = pipecfg.streams[params.STREAM]
 

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -83,7 +83,7 @@ try { lock(resource: "bump-${params.STREAM}") { timeout(time: 120, unit: 'MINUTE
 
     def lockfile, pkgChecksum, pkgTimestamp
     def skip_tests_arches = params.SKIP_TESTS_ARCHES.split()
-    def arches = pipecfg.additional_arches.plus("x86_64")
+    def arches = pipeutils.get_additional_arches(pipecfg, params.STREAM).plus("x86_64")
     def archinfo = arches.collectEntries{[it, [:]]}
     for (architecture in archinfo.keySet()) {
         def arch = architecture

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -58,7 +58,7 @@ if (params.VERSION == "") {
 def cosa_img = params.COREOS_ASSEMBLER_IMAGE
 cosa_img = cosa_img ?: pipeutils.get_cosa_img(pipecfg, params.STREAM)
 def basearches = params.ADDITIONAL_ARCHES.split() as List
-basearches = basearches ?: pipecfg.additional_arches
+basearches = basearches ?: pipeutils.get_additional_arches(pipecfg, params.STREAM)
 
 // we always release for x86_64
 basearches += 'x86_64'

--- a/utils.groovy
+++ b/utils.groovy
@@ -499,6 +499,14 @@ def get_cosa_img(pipecfg, stream) {
     return utils.substituteStr(cosa_img, [STREAM: stream])
 }
 
+def get_additional_arches(pipecfg, stream) {
+    // stream-level override takes precedence over top-level
+    def arches = pipecfg.streams[stream].additional_arches ?: pipecfg.additional_arches
+    // apply stream-level skips
+    arches -= pipecfg.streams[stream].skip_additional_arches ?: []
+    return arches
+}
+
 // Run a closure inside a context that has access to the AWS Build
 // Upload credentials.
 def withAWSBuildUploadCredentials(Closure body) {


### PR DESCRIPTION
Add support for `skip_additional_arches` and `additional_arches` keys in
the stream-level section. E.g. currently for FCOS, we're not shipping
ppc64le for the production streams.

This will also be useful for RHCOS in the future when e.g. keeping older
streams alive on only a subset of arches.