### PR TITLE
jobs/release: don't push base-oscontainer on releases missing it

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -194,6 +194,14 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
                                'extensions': ['extensions-container', 'extensions-container', '-extensions'],
                                'legacy_oscontainer': ['legacy-oscontainer', 'oscontainer', '-legacy']]
 
+        // XXX: hack: on releases that don't support pushing the
+        // base-oscontainer, remove it from the list.
+        def schema = "/usr/lib/coreos-assembler/v1.json"
+        assert utils.pathExists(schema) : "cosa image missing ${schema}"
+        if (shwrapRc("jq -e '.optional|contains([\"base-oscontainer\"])' ${schema}") != 0) {
+            push_containers.remove('oscontainer')
+        }
+
         // filter out those not defined in the config
         push_containers.keySet().retainAll(registry_repos.keySet())
 


### PR DESCRIPTION
For RHCOS 4.11 and older, there is no native oscontainer to push so we don't want to even try. But unlike other cloud-y things, the artifact does exist (`ostree`), so we can't just rely on the fact that we're not building it.

Rather than adding more temporary knobs at the pipecfg, hack around this by checking if the cosa schema supports `base-oscontainer` and if not, don't try to push it.