### PR TITLE
jobs/{build,bump-lockfile}: bump up memory for testISO failure

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -81,7 +81,9 @@ def strict_build_param = stream_info.type == "mechanical" ? "" : "--strict"
 // without lots of memory takes lots of time. For now we just hardcode these
 // here; we can look into making them configurable through the template if
 // developers really need to tweak them.
-def cosa_memory_request_mb = 8.5 * 1024 as Integer
+// XXX bump an extra 2G (to 10.5) because of an error we are seeing in
+// testiso: https://github.com/coreos/fedora-coreos-tracker/issues/1339
+def cosa_memory_request_mb = 10.5 * 1024 as Integer
 
 // Now that we've established the memory constraint based on xz above, derive
 // kola parallelism from that. We leave 512M for overhead and VMs are at most

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -58,7 +58,7 @@ def getLockfileInfo(lockfile) {
 }
 
 // Keep in sync with build.Jenkinsfile
-def cosa_memory_request_mb = 8.5 * 1024 as Integer
+def cosa_memory_request_mb = 10.5 * 1024 as Integer
 def ncpus = ((cosa_memory_request_mb - 512) / 1536) as Integer
 
 try { lock(resource: "bump-${params.STREAM}") { timeout(time: 120, unit: 'MINUTES') { 


### PR DESCRIPTION
We're seeing an obscure `Got EOF from completion channel` error when running testISO. The running theory is that we're running out of memory and that seems to be accurate in a test I did earlier today. Let's bump for now and investigate when we have more time.

See https://github.com/coreos/fedora-coreos-tracker/issues/1339