### PR TITLE
jobs/release: bump memory for release job

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -79,7 +79,7 @@ currentBuild.description = "${build_description} Waiting"
 // Also lock version-arch-specific locks to make sure these builds are finished.
 def locks = basearches.collect{[resource: "release-${params.VERSION}-${it}"]}
 lock(resource: "release-${params.STREAM}", extra: locks) {
-    cosaPod(cpu: "1", memory: "512Mi", image: cosa_img) {
+    cosaPod(cpu: "1", memory: "1Gi", image: cosa_img) {
     try {
 
         currentBuild.description = "${build_description} Running"


### PR DESCRIPTION
We've seen the buildfetch getting killed and we think it's because we are spiking briefly above the 512Mi limit we had set for ourselves.