### PR TITLE
add in hacks for rhcos 

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -34,6 +34,8 @@ hacks:
   skip_upgrade_tests: true
   # OPTIONAL: skip calling plume in the release job
   skip_plume_release_task: true
+  # OPTIONAL: skip UEFI on older RHCOS
+  skip_uefi_tests_on_older_rhcos: true
 
 # OPTIONAL/TEMPORARY: whether to use `versionary` to derive version numbers
 versionary_hack: true

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -36,6 +36,8 @@ hacks:
   skip_plume_release_task: true
   # OPTIONAL: skip UEFI on older RHCOS
   skip_uefi_tests_on_older_rhcos: true
+  # OPTIONAL: implement the yumrepos branch workaround
+  use_yumrepos_branch_workaround: true
 
 # OPTIONAL/TEMPORARY: whether to use `versionary` to derive version numbers
 versionary_hack: true

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -28,6 +28,11 @@ hotfix:
   # OPTIONAL/TEMPORARY: skip all tests that require a signed kernel
   skip_secureboot_tests_hack: true
 
+# OPTIONAL/TEMPORARY: hacks-related keys
+hacks:
+  # OPTIONAL: skip upgrade kola tests
+  skip_upgrade_tests: true
+
 # OPTIONAL/TEMPORARY: whether to use `versionary` to derive version numbers
 versionary_hack: true
 

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -32,6 +32,8 @@ hotfix:
 hacks:
   # OPTIONAL: skip upgrade kola tests
   skip_upgrade_tests: true
+  # OPTIONAL: skip calling plume in the release job
+  skip_plume_release_task: true
 
 # OPTIONAL/TEMPORARY: whether to use `versionary` to derive version numbers
 versionary_hack: true

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -295,6 +295,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         stage("Kola") {
             def n = 4 // VMs are 2G each and arch builders have approx 32G
             kola(cosaDir: env.WORKSPACE, parallel: n, arch: basearch,
+                 skipUpgrade: pipecfg.hacks?.skip_upgrade_tests,
                  allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
                  skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack)
         }

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -302,6 +302,7 @@ lock(resource: "build-${params.STREAM}") {
         stage("Kola") {
             def n = ncpus - 1 // remove 1 for upgrade test
             kola(cosaDir: env.WORKSPACE, parallel: n, arch: basearch,
+                 skipUpgrade: pipecfg.hacks?.skip_upgrade_tests,
                  allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
                  skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack)
         }

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -288,20 +288,22 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
                     --acl=public-read ${s3_stream_dir}/builds
                 """)
 
-                // Run plume to publish official builds; This will handle modifying
-                // object ACLs, modifying AMI image attributes,
-                // and creating/modifying the releases.json metadata index
-                // Note here we pass the bucket instead of `s3_stream_dir` but
-                // plume currently only actually interacts with objects under
-                // the `s3_stream_dir` key (i.e. `pipecfg.s3.builds_key`).
-                // We'll make this more explicit in the future.
-                shwrap("""
-                cosa shell -- plume release --distro fcos \
-                    --version ${params.VERSION} \
-                    --stream ${params.STREAM} \
-                    --bucket ${pipecfg.s3.bucket} \
-                    --aws-credentials \${AWS_BUILD_UPLOAD_CONFIG}
-                """)
+                if (!pipecfg.hacks?.skip_plume_release_task) {
+                    // Run plume to publish official builds; This will handle modifying
+                    // object ACLs, modifying AMI image attributes,
+                    // and creating/modifying the releases.json metadata index
+                    // Note here we pass the bucket instead of `s3_stream_dir` but
+                    // plume currently only actually interacts with objects under
+                    // the `s3_stream_dir` key (i.e. `pipecfg.s3.builds_key`).
+                    // We'll make this more explicit in the future.
+                    shwrap("""
+                    cosa shell -- plume release --distro fcos \
+                        --version ${params.VERSION} \
+                        --stream ${params.STREAM} \
+                        --bucket ${pipecfg.s3.bucket} \
+                        --aws-credentials \${AWS_BUILD_UPLOAD_CONFIG}
+                    """)
+                }
             }
 
             pipeutils.tryWithMessagingCredentials() {


### PR DESCRIPTION
We want to drop these hacks in the near future, but for now we need to carry them so that we don't have to fork the pipeline.

```
commit 918b4d628c16baf7dfd941c65fd24f457f026b17
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Nov 14 16:54:03 2022 -0500

    add hacks.use_yumrepos_branch_workaround
    
    For the moment the git repo that we are pulling our yum repo files
    from has a branch per stream of RHCOS (i.e. 4.9, 4.10...). The plan
    is to get to a single branch that has all the yum repo files. Until
    that happens let's bake in a hack to support what currently exists.

commit 283d5d4a3cad3a75f85ba248cb1ecd0cba465035
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Nov 14 16:52:41 2022 -0500

    add hacks.skip_uefi_tests_on_older_rhcos
    
    On older RHCOS (i.e. 4.9) the UEFI+`iso-live-login` test isn't passing
    right now and the `iso-as-disk` test doesn't exist at all. Let's skip
    these for now. This will last until we either investigate and fix the
    failures or 4.9 no longer exists.

commit 4c08ef2ad220ba333f596a99a9ec965cd0e68901
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Nov 14 16:51:35 2022 -0500

    add hacks.skip_plume_release_task
    
    In the RHCOS pipeline for now we aren't running this `plume release`
    call. Let's add a hack to enable us to not run it for now while we
    further evaluate the need in the RHCOS pipeline.

commit 6f1f954f0931a7fccd5bb2f34156e70356e64825
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Nov 14 16:50:20 2022 -0500

    add hacks.skip_upgrade_tests
    
    We'll set this in the RHCOS pipeline until we figure out a more
    elegant way to get around the fact that we need to not run the upgrade
    tests in the RHCOS pipeline for now.

```
