### PR TITLE
Add hacks.override_compression_format

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -38,6 +38,8 @@ hacks:
   skip_uefi_tests_on_older_rhcos: true
   # OPTIONAL: implement the yumrepos branch workaround
   use_yumrepos_branch_workaround: true
+  # OPTIONAL: use a different compression format when archiving
+  override_compression_format: gzip
 
 # OPTIONAL/TEMPORARY: whether to use `versionary` to derive version numbers
 versionary_hack: true

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -355,9 +355,9 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         }
 
         stage('Archive') {
-            shwrap("""
-            cosa compress --compressor xz
-            """)
+            def format = pipecfg.hacks?.override_compression_format
+            format = format ?: 'xz' // Default to xz
+            shwrap("cosa compress --compressor ${format}")
 
             if (uploading) {
                 // just upload as public-read for now, but see discussions in

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -416,7 +416,9 @@ lock(resource: "build-${params.STREAM}") {
         stage('Archive') {
             // lower to make sure we don't go over and account for overhead
             pipeutils.withXzMemLimit(cosa_memory_request_mb - 256) {
-                shwrap("cosa compress --compressor xz")
+                def format = pipecfg.hacks?.override_compression_format
+                format = format ?: 'xz' // Default to xz
+                shwrap("cosa compress --compressor ${format}")
             }
 
             if (uploading) {


### PR DESCRIPTION
This allows us to override the compression format to gzip for the RHCOS pipeline for now.