### PR TITLE
utils: update namespace for RHCOS devel pipeline

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -8,7 +8,7 @@ import org.yaml.snakeyaml.Yaml
 PROTECTED_JENKINSES = [
     'https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/':
         ['fcos-builds', 'prod/streams/${STREAM}', false],
-    'https://jenkins-rhcos.apps.ocp-virt.prod.psi.redhat.com/':
+    'https://jenkins-rhcos-devel.apps.ocp-virt.prod.psi.redhat.com/':
         ['rhcos-ci', 'prod/streams/${STREAM}', true],
     'https://jenkins-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/':
         ['art-rhcos-ci', 'prod/streams/${STREAM}', true]


### PR DESCRIPTION
The project name was `rhcos`, now it's `rhcos-devel`.