### PR TITLE
jobs/build: add EARLY_ARCH_JOBS parameter

### DIFF
--- a/jobs/build-development.Jenkinsfile
+++ b/jobs/build-development.Jenkinsfile
@@ -23,7 +23,8 @@ node {
     stream = pipeutils.stream_from_branch(change.GIT_BRANCH)
     if (stream in development_streams) {
         build job: 'build', wait: false, parameters: [
-          string(name: 'STREAM', value: stream)
+          string(name: 'STREAM', value: stream),
+          booleanParam(name: 'EARLY_ARCH_JOBS', value: false)
         ]
     }
 }

--- a/jobs/build-mechanical.Jenkinsfile
+++ b/jobs/build-mechanical.Jenkinsfile
@@ -34,7 +34,8 @@ node {
         // cron or manual build: build all mechanical streams
         mechanical_streams.each{
             build job: 'build', wait: false, parameters: [
-              string(name: 'STREAM', value: it)
+              string(name: 'STREAM', value: it),
+              booleanParam(name: 'EARLY_ARCH_JOBS', value: false)
             ]
         }
     }


### PR DESCRIPTION
This will give us control of when the multi-arch jobs are kicked off. In some cases we want them to be kicked off early (to save time). Unfortunately in that case if the x86_64 build later fails (which means the build ID can no longer be used) the work done by the multi-arch builds gets trashed as well.

Let's add a knob so we can kick them off early when desired, but allow for them to be kicked off later in situations where time isn't a large factor.