### PR TITLE
jenkins/config: add empty `room` field

### DIFF
--- a/jenkins/config/slack.yaml
+++ b/jenkins/config/slack.yaml
@@ -2,3 +2,5 @@ unclassified:
   slackNotifier:
     teamDomain: coreos
     tokenCredentialId: slack-api-token
+    # https://github.com/jenkinsci/slack-plugin/issues/857
+    room: ""


### PR DESCRIPTION
After 27693a6, the Slack plugin fails to send messages on new Jenkins instances with:

    java.lang.IllegalArgumentException: Project Channel or Slack User ID
    must be specified.

This seems to be due to some bug in the plugin where without a `room` setting, it doesn't know to rely on the default room associated with the token. This is filed upstream in:

https://github.com/jenkinsci/slack-plugin/issues/857

Short-term, let's just work around this by specifying an empty `room`.