### PR TITLE
streams: disable next-devel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,8 +17,8 @@ streams:
     testing-devel:
       type: development
       default: true
-    next-devel:         # do not touch; line managed by `next-devel/manage.py`
-      type: development # do not touch; line managed by `next-devel/manage.py`
+    # next-devel:         # do not touch; line managed by `next-devel/manage.py`
+      # type: development # do not touch; line managed by `next-devel/manage.py`
     rawhide:
       type: mechanical
     # branched:

--- a/next-devel/badge.json
+++ b/next-devel/badge.json
@@ -2,6 +2,6 @@
     "schemaVersion": 1,
     "style": "for-the-badge",
     "label": "next-devel",
-    "message": "open",
-    "color": "green"
+    "message": "closed",
+    "color": "lightgrey"
 }

--- a/next-devel/status.json
+++ b/next-devel/status.json
@@ -1,3 +1,3 @@
 {
-    "enabled": true
+    "enabled": false
 }


### PR DESCRIPTION
testing-devel and next-devel are now redundant after two events:

- The Fedora 37 release
- The platforms.yaml console work landing in `testing-devel`, which will happen tomorrow.