### PR TITLE
tree-wide: include catch/finally in cosaPod() block

### DIFF
--- a/jobs/build-fcos-buildroot.Jenkinsfile
+++ b/jobs/build-fcos-buildroot.Jenkinsfile
@@ -101,11 +101,11 @@ currentBuild.description = "[${gitref}@${shortcommit}] Waiting"
 // Get the list of requested architectures to build for
 def basearches = params.ARCHES.split() as Set
 
-try {
-    lock(resource: "build-${containername}") {
+lock(resource: "build-${containername}") {
     timeout(time: 60, unit: 'MINUTES') {
     cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
             memory: "256Mi", kvm: false) {
+    try {
 
         currentBuild.description = "[${gitref}@${shortcommit}] Running"
 
@@ -164,18 +164,19 @@ try {
             }
         }
         currentBuild.result = 'SUCCESS'
+            
+    } catch (e) {
+        currentBuild.result = 'FAILURE'
+        throw e
+    } finally {
+        if (currentBuild.result == 'SUCCESS') {
+            currentBuild.description = "[${gitref}@${shortcommit}] ⚡"
+        } else {
+            currentBuild.description = "[${gitref}@${shortcommit}] ❌"
+        }
+        if (currentBuild.result != 'SUCCESS') {
+            message = "build-${containername} <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${gitref}@${shortcommit}]"
+            pipeutils.trySlackSend(color: 'danger', message: message)
+        }
     }
-}}} catch (e) {
-    currentBuild.result = 'FAILURE'
-    throw e
-} finally {
-    if (currentBuild.result == 'SUCCESS') {
-        currentBuild.description = "[${gitref}@${shortcommit}] ⚡"
-    } else {
-        currentBuild.description = "[${gitref}@${shortcommit}] ❌"
-    }
-    if (currentBuild.result != 'SUCCESS') {
-        message = "build-${containername} <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${gitref}@${shortcommit}]"
-        pipeutils.trySlackSend(color: 'danger', message: message)
-    }
-}
+}}} // cosaPod, timeout, and lock finish here

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -61,235 +61,240 @@ def getLockfileInfo(lockfile) {
 def cosa_memory_request_mb = 10.5 * 1024 as Integer
 def ncpus = ((cosa_memory_request_mb - 512) / 1536) as Integer
 
-try { lock(resource: "bump-${params.STREAM}") { timeout(time: 120, unit: 'MINUTES') { 
+lock(resource: "bump-${params.STREAM}") {
+    timeout(time: 120, unit: 'MINUTES') { 
     cosaPod(image: cosa_img,
             cpu: "${ncpus}", memory: "${cosa_memory_request_mb}Mi") {
-    currentBuild.description = "[${params.STREAM}] Running"
+    try {
 
-    // add any additional root CA cert before we do anything that fetches
-    pipeutils.addOptionalRootCA()
+        currentBuild.description = "[${params.STREAM}] Running"
 
-    // set up git user upfront
-    shwrap("""
-      git config --global user.name "CoreOS Bot"
-      git config --global user.email "coreosbot@fedoraproject.org"
-    """)
+        // add any additional root CA cert before we do anything that fetches
+        pipeutils.addOptionalRootCA()
 
-    def branch = params.STREAM
-    def forceTimestamp = false
-    def haveChanges = false
-    def src_config_commit = shwrapCapture("git ls-remote https://github.com/${repo} ${branch} | cut -d \$'\t' -f 1")
-    shwrap("cosa init --branch ${branch} --commit=${src_config_commit} https://github.com/${repo}")
+        // set up git user upfront
+        shwrap("""
+          git config --global user.name "CoreOS Bot"
+          git config --global user.email "coreosbot@fedoraproject.org"
+        """)
 
-    def lockfile, pkgChecksum, pkgTimestamp
-    def skip_tests_arches = params.SKIP_TESTS_ARCHES.split()
-    def arches = pipeutils.get_additional_arches(pipecfg, params.STREAM).plus("x86_64")
-    def archinfo = arches.collectEntries{[it, [:]]}
-    for (architecture in archinfo.keySet()) {
-        def arch = architecture
-        // initialize some data
-        archinfo[arch]['session'] = ""
-        lockfile = "src/config/manifest-lock.${arch}.json"
-        (pkgChecksum, pkgTimestamp) = getLockfileInfo(lockfile)
-        archinfo[arch]['prevPkgChecksum'] = pkgChecksum
-        archinfo[arch]['prevPkgTimestamp'] = pkgTimestamp
-    }
+        def branch = params.STREAM
+        def forceTimestamp = false
+        def haveChanges = false
+        def src_config_commit = shwrapCapture("git ls-remote https://github.com/${repo} ${branch} | cut -d \$'\t' -f 1")
+        shwrap("cosa init --branch ${branch} --commit=${src_config_commit} https://github.com/${repo}")
 
-    // Initialize the sessions on the remote builders
-    stage("Initialize Remotes") {
-        parallel archinfo.keySet().collectEntries{arch -> [arch, {
-            if (arch != "x86_64") {
-                pipeutils.withPodmanRemoteArchBuilder(arch: arch) {
-                    archinfo[arch]['session'] = shwrapCapture("""
-                    cosa remote-session create --image ${cosa_img} --expiration 4h --workdir ${env.WORKSPACE}
-                    """)
-                    withEnv(["COREOS_ASSEMBLER_REMOTE_SESSION=${archinfo[arch]['session']}"]) {
-                        shwrap("""
-                        cosa init --branch ${branch} --commit=${src_config_commit} https://github.com/${repo}
-                        """)
-                    }
-                }
-            }
-        }]}
-    }
-
-    // do a first fetch where we only fetch metadata; no point in
-    // importing RPMs if nothing actually changed. We also do a
-    // buildfetch here so we can see in the build output (that happens
-    // later) what packages changed.
-    stage("Fetch Metadata") {
-        def parallelruns = [:]
+        def lockfile, pkgChecksum, pkgTimestamp
+        def skip_tests_arches = params.SKIP_TESTS_ARCHES.split()
+        def arches = pipeutils.get_additional_arches(pipecfg, params.STREAM).plus("x86_64")
+        def archinfo = arches.collectEntries{[it, [:]]}
         for (architecture in archinfo.keySet()) {
             def arch = architecture
-            parallelruns[arch] = {
-                if (arch == "x86_64") {
-                    shwrap("""
-                    cosa buildfetch --arch=${arch} --find-build-for-arch \
-                        --url=${BUILDS_BASE_HTTP_URL}/${branch}/builds
-                    cosa fetch --update-lockfile --dry-run
-                    """)
-                } else {
-                    pipeutils.withExistingCosaRemoteSession(
-                        arch: arch, session: archinfo[arch]['session']) {
+            // initialize some data
+            archinfo[arch]['session'] = ""
+            lockfile = "src/config/manifest-lock.${arch}.json"
+            (pkgChecksum, pkgTimestamp) = getLockfileInfo(lockfile)
+            archinfo[arch]['prevPkgChecksum'] = pkgChecksum
+            archinfo[arch]['prevPkgTimestamp'] = pkgTimestamp
+        }
+
+        // Initialize the sessions on the remote builders
+        stage("Initialize Remotes") {
+            parallel archinfo.keySet().collectEntries{arch -> [arch, {
+                if (arch != "x86_64") {
+                    pipeutils.withPodmanRemoteArchBuilder(arch: arch) {
+                        archinfo[arch]['session'] = shwrapCapture("""
+                        cosa remote-session create --image ${cosa_img} --expiration 4h --workdir ${env.WORKSPACE}
+                        """)
+                        withEnv(["COREOS_ASSEMBLER_REMOTE_SESSION=${archinfo[arch]['session']}"]) {
+                            shwrap("""
+                            cosa init --branch ${branch} --commit=${src_config_commit} https://github.com/${repo}
+                            """)
+                        }
+                    }
+                }
+            }]}
+        }
+
+        // do a first fetch where we only fetch metadata; no point in
+        // importing RPMs if nothing actually changed. We also do a
+        // buildfetch here so we can see in the build output (that happens
+        // later) what packages changed.
+        stage("Fetch Metadata") {
+            def parallelruns = [:]
+            for (architecture in archinfo.keySet()) {
+                def arch = architecture
+                parallelruns[arch] = {
+                    if (arch == "x86_64") {
                         shwrap("""
                         cosa buildfetch --arch=${arch} --find-build-for-arch \
                             --url=${BUILDS_BASE_HTTP_URL}/${branch}/builds
                         cosa fetch --update-lockfile --dry-run
-                        cosa remote-session sync {:,}src/config/manifest-lock.${arch}.json
                         """)
+                    } else {
+                        pipeutils.withExistingCosaRemoteSession(
+                            arch: arch, session: archinfo[arch]['session']) {
+                            shwrap("""
+                            cosa buildfetch --arch=${arch} --find-build-for-arch \
+                                --url=${BUILDS_BASE_HTTP_URL}/${branch}/builds
+                            cosa fetch --update-lockfile --dry-run
+                            cosa remote-session sync {:,}src/config/manifest-lock.${arch}.json
+                            """)
+                        }
                     }
                 }
             }
+            parallel parallelruns
         }
-        parallel parallelruns
-    }
 
-    for (architecture in archinfo.keySet()) {
-        def arch = architecture
-        lockfile = "src/config/manifest-lock.${arch}.json"
-        (pkgChecksum, pkgTimestamp) = getLockfileInfo(lockfile)
-        archinfo[arch]['newPkgChecksum'] = pkgChecksum
-        archinfo[arch]['newPkgTimestamp'] = pkgTimestamp
-
-        if (archinfo[arch]['newPkgChecksum'] != archinfo[arch]['prevPkgChecksum']) {
-            haveChanges = true
-        }
-        if ((archinfo[arch]['newPkgTimestamp'] - archinfo[arch]['prevPkgTimestamp']) > (2*24*60*60)) {
-            // Let's update the timestamp after two days even if no packages were updated.
-            // This will bump the date in the version number for FCOS, which is an indicator
-            // of how fresh the package set is.
-            println("2 days and no package updates. Pushing anyway to update timestamps.")
-            forceTimestamp = true
-        }
-    }
-
-    if (!haveChanges && !forceTimestamp) {
-        currentBuild.result = 'SUCCESS'
-        currentBuild.description = "[${params.STREAM}] 💤 (no change)"
-        return
-    }
-
-    // sanity-check only base lockfiles were changed
-    shwrap("""
-      # do this separately so set -e kicks in if it fails
-      files=\$(git -C src/config ls-files --modified --deleted)
-      for f in \${files}; do
-        if ! [[ \${f} =~ ^manifest-lock\\.[0-9a-z_]+\\.json ]]; then
-          echo "Unexpected modified file \${f}"
-          exit 1
-        fi
-      done
-    """)
-
-    // The bulk of the work (build, test, etc) is done in the following.
-    // We only need to do that work if we have changes.
-    if (haveChanges) {
-        // Run tests across all architectures in parallel
-        def outerparallelruns = [:]
         for (architecture in archinfo.keySet()) {
             def arch = architecture
-            if (arch in skip_tests_arches) {
-                // The user has explicitly told us that it is OK to
-                // skip tests on this architecture. Presumably because
-                // they already passed in a previous run.
-                continue
+            lockfile = "src/config/manifest-lock.${arch}.json"
+            (pkgChecksum, pkgTimestamp) = getLockfileInfo(lockfile)
+            archinfo[arch]['newPkgChecksum'] = pkgChecksum
+            archinfo[arch]['newPkgTimestamp'] = pkgTimestamp
+
+            if (archinfo[arch]['newPkgChecksum'] != archinfo[arch]['prevPkgChecksum']) {
+                haveChanges = true
             }
-            outerparallelruns[arch] = {
-                def buildAndTest = {
-                    def parallelruns = [:]
-                    stage("${arch}:Fetch") {
-                        shwrap("cosa fetch --strict")
-                    }
-                    stage("${arch}:Build") {
-                        shwrap("cosa build --force --strict")
-                    }
-                    def n = ncpus - 1 // remove 1 for upgrade test
-                    kola(cosaDir: env.WORKSPACE, parallel: n, arch: arch,
-                         marker: arch, allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE)
-                    stage("${arch}:Build Metal") {
-                        shwrap("cosa buildextend-metal")
-                        shwrap("cosa buildextend-metal4k")
-                    }
-                    stage("${arch}:Build Live") {
-                        shwrap("cosa buildextend-live --fast")
-                        // Test metal4k with an uncompressed image and metal with a
-                        // compressed one
-                        shwrap("cosa compress --artifact=metal")
-                    }
-                    kolaTestIso(cosaDir: env.WORKSPACE, arch: arch, marker: arch)
+            if ((archinfo[arch]['newPkgTimestamp'] - archinfo[arch]['prevPkgTimestamp']) > (2*24*60*60)) {
+                // Let's update the timestamp after two days even if no packages were updated.
+                // This will bump the date in the version number for FCOS, which is an indicator
+                // of how fresh the package set is.
+                println("2 days and no package updates. Pushing anyway to update timestamps.")
+                forceTimestamp = true
+            }
+        }
+
+        if (!haveChanges && !forceTimestamp) {
+            currentBuild.result = 'SUCCESS'
+            currentBuild.description = "[${params.STREAM}] 💤 (no change)"
+            return
+        }
+
+        // sanity-check only base lockfiles were changed
+        shwrap("""
+          # do this separately so set -e kicks in if it fails
+          files=\$(git -C src/config ls-files --modified --deleted)
+          for f in \${files}; do
+            if ! [[ \${f} =~ ^manifest-lock\\.[0-9a-z_]+\\.json ]]; then
+              echo "Unexpected modified file \${f}"
+              exit 1
+            fi
+          done
+        """)
+
+        // The bulk of the work (build, test, etc) is done in the following.
+        // We only need to do that work if we have changes.
+        if (haveChanges) {
+            // Run tests across all architectures in parallel
+            def outerparallelruns = [:]
+            for (architecture in archinfo.keySet()) {
+                def arch = architecture
+                if (arch in skip_tests_arches) {
+                    // The user has explicitly told us that it is OK to
+                    // skip tests on this architecture. Presumably because
+                    // they already passed in a previous run.
+                    continue
                 }
-                if (arch == "x86_64") {
-                    buildAndTest()
-                } else {
+                outerparallelruns[arch] = {
+                    def buildAndTest = {
+                        def parallelruns = [:]
+                        stage("${arch}:Fetch") {
+                            shwrap("cosa fetch --strict")
+                        }
+                        stage("${arch}:Build") {
+                            shwrap("cosa build --force --strict")
+                        }
+                        def n = ncpus - 1 // remove 1 for upgrade test
+                        kola(cosaDir: env.WORKSPACE, parallel: n, arch: arch,
+                             marker: arch, allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE)
+                        stage("${arch}:Build Metal") {
+                            shwrap("cosa buildextend-metal")
+                            shwrap("cosa buildextend-metal4k")
+                        }
+                        stage("${arch}:Build Live") {
+                            shwrap("cosa buildextend-live --fast")
+                            // Test metal4k with an uncompressed image and metal with a
+                            // compressed one
+                            shwrap("cosa compress --artifact=metal")
+                        }
+                        kolaTestIso(cosaDir: env.WORKSPACE, arch: arch, marker: arch)
+                    }
+                    if (arch == "x86_64") {
+                        buildAndTest()
+                    } else {
+                        pipeutils.withExistingCosaRemoteSession(
+                            arch: arch, session: archinfo[arch]['session']) {
+                            buildAndTest()
+                      }
+                    }
+                } // end outerparallelruns
+            } // end for loop
+            parallel outerparallelruns
+        }
+
+        // Destroy the remote sessions. We don't need them anymore
+        stage("Destroy Remotes") {
+            parallel archinfo.keySet().collectEntries{arch -> [arch, {
+                if (arch != "x86_64") {
                     pipeutils.withExistingCosaRemoteSession(
                         arch: arch, session: archinfo[arch]['session']) {
-                        buildAndTest()
-                  }
+                        shwrap("cosa remote-session destroy")
+                    }
                 }
-            } // end outerparallelruns
-        } // end for loop
-        parallel outerparallelruns
-    }
+            }]}
+        }
 
-    // Destroy the remote sessions. We don't need them anymore
-    stage("Destroy Remotes") {
-        parallel archinfo.keySet().collectEntries{arch -> [arch, {
-            if (arch != "x86_64") {
-                pipeutils.withExistingCosaRemoteSession(
-                    arch: arch, session: archinfo[arch]['session']) {
-                    shwrap("cosa remote-session destroy")
-                }
+        // OK, we're ready to push: just push to the branch. In the future, we might be
+        // fancier here; e.g. if tests fail, just open a PR, or if tests passed but a
+        // package was added or removed.
+        stage("Push") {
+            def message="lockfiles: bump to latest"
+            if (!haveChanges && forceTimestamp) {
+                message="lockfiles: bump timestamp"
             }
-        }]}
-    }
-
-    // OK, we're ready to push: just push to the branch. In the future, we might be
-    // fancier here; e.g. if tests fail, just open a PR, or if tests passed but a
-    // package was added or removed.
-    stage("Push") {
-        def message="lockfiles: bump to latest"
-        if (!haveChanges && forceTimestamp) {
-            message="lockfiles: bump timestamp"
-        }
-        shwrap("git -C src/config add manifest-lock.*.json")
-        shwrap("git -C src/config commit -m '${message}' -m 'Job URL: ${env.BUILD_URL}' -m 'Job definition: https://github.com/coreos/fedora-coreos-pipeline/blob/main/jobs/bump-lockfile.Jenkinsfile'")
-        withCredentials([usernamePassword(credentialsId: botCreds,
-                                          usernameVariable: 'GHUSER',
-                                          passwordVariable: 'GHTOKEN')]) {
-          // gracefully handle race conditions
-          sh("""
-            rev=\$(git -C src/config rev-parse origin/${branch})
-            if ! git -C src/config push https://\${GHUSER}:\${GHTOKEN}@github.com/${repo} ${branch}; then
-                git -C src/config fetch origin
-                if [ "\$rev" != \$(git -C src/config rev-parse origin/${branch}) ]; then
-                    touch ${env.WORKSPACE}/rerun
-                else
-                    exit 1
+            shwrap("git -C src/config add manifest-lock.*.json")
+            shwrap("git -C src/config commit -m '${message}' -m 'Job URL: ${env.BUILD_URL}' -m 'Job definition: https://github.com/coreos/fedora-coreos-pipeline/blob/main/jobs/bump-lockfile.Jenkinsfile'")
+            withCredentials([usernamePassword(credentialsId: botCreds,
+                                              usernameVariable: 'GHUSER',
+                                              passwordVariable: 'GHTOKEN')]) {
+              // gracefully handle race conditions
+              sh("""
+                rev=\$(git -C src/config rev-parse origin/${branch})
+                if ! git -C src/config push https://\${GHUSER}:\${GHTOKEN}@github.com/${repo} ${branch}; then
+                    git -C src/config fetch origin
+                    if [ "\$rev" != \$(git -C src/config rev-parse origin/${branch}) ]; then
+                        touch ${env.WORKSPACE}/rerun
+                    else
+                        exit 1
+                    fi
                 fi
-            fi
-          """)
+              """)
+            }
+        }
+        if (utils.pathExists("rerun")) {
+            build job: 'bump-lockfile', wait: false, parameters: [
+                string(name: 'STREAM', value: params.STREAM)
+            ]
+            currentBuild.description = "[${params.STREAM}] ⚡ (retriggered)"
+        } else if (!haveChanges && forceTimestamp) {
+            currentBuild.description = "[${params.STREAM}] ⚡ (pushed timestamp update)"
+        } else {
+            currentBuild.description = "[${params.STREAM}] ⚡ (pushed)"
+        }
+        currentBuild.result = 'SUCCESS'
+
+    } catch (e) {
+        currentBuild.result = 'FAILURE'
+        throw e
+    } finally {
+        def color = 'danger'
+        if (currentBuild.result == 'UNSTABLE') {
+            color = 'warning'
+        }
+        if (currentBuild.result != 'SUCCESS') {
+            pipeutils.trySlackSend(color: color, message: "<${env.BUILD_URL}|bump-lockfile #${env.BUILD_NUMBER} (${params.STREAM})>")
         }
     }
-    if (utils.pathExists("rerun")) {
-        build job: 'bump-lockfile', wait: false, parameters: [
-            string(name: 'STREAM', value: params.STREAM)
-        ]
-        currentBuild.description = "[${params.STREAM}] ⚡ (retriggered)"
-    } else if (!haveChanges && forceTimestamp) {
-        currentBuild.description = "[${params.STREAM}] ⚡ (pushed timestamp update)"
-    } else {
-        currentBuild.description = "[${params.STREAM}] ⚡ (pushed)"
-    }
-    currentBuild.result = 'SUCCESS'
-}}}} catch (e) {
-    currentBuild.result = 'FAILURE'
-    throw e
-} finally {
-    def color = 'danger'
-    if (currentBuild.result == 'UNSTABLE') {
-        color = 'warning'
-    }
-    if (currentBuild.result != 'SUCCESS') {
-        pipeutils.trySlackSend(color: color, message: "<${env.BUILD_URL}|bump-lockfile #${env.BUILD_NUMBER} (${params.STREAM})>")
-    }
-}
+}}} // cosaPod, timeout, and lock finish here

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -43,9 +43,10 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSIO
 
 def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
-try { timeout(time: 90, unit: 'MINUTES') {
+timeout(time: 90, unit: 'MINUTES') {
     cosaPod(memory: "512Mi", kvm: false,
             image: params.COREOS_ASSEMBLER_IMAGE) {
+    try {
 
         stage('Fetch Metadata') {
             def commitopt = ''
@@ -129,12 +130,13 @@ try { timeout(time: 90, unit: 'MINUTES') {
         }
 
         currentBuild.result = 'SUCCESS'
+
+    } catch (e) {
+        currentBuild.result = 'FAILURE'
+        throw e
+    } finally {
+        if (currentBuild.result != 'SUCCESS') {
+            pipeutils.trySlackSend(color: 'danger', message: ":aws: kola-aws <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
+        }
     }
-}} catch (e) {
-    currentBuild.result = 'FAILURE'
-    throw e
-} finally {
-    if (currentBuild.result != 'SUCCESS') {
-        pipeutils.trySlackSend(color: 'danger', message: ":aws: kola-aws <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
-    }
-}
+}} // cosaPod and timeout finish here

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -39,70 +39,116 @@ properties([
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 
-// Locking so we don't run multiple times on the same region. We are speeding up our testing by dividing
-// the load to different regions depending on the architecture. This allows us not to exceed our quota in
-// a single region while still being able to execute two test runs in parallel.
-lock(resource: "kola-azure-${params.ARCH}") {
+currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSION}"
 
-    currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSION}"
+// Use eastus region for now
+def region = "eastus"
 
-    // Use eastus region for now
-    def region = "eastus"
+def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
-    def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
+// Go with 1.5Gi here because we download/decompress/upload the image
+def cosa_memory_request_mb = 1536
+try { timeout(time: 75, unit: 'MINUTES') {
+    cosaPod(memory: "${cosa_memory_request_mb}Mi", kvm: false,
+            image: params.COREOS_ASSEMBLER_IMAGE) {
 
-    // Go with 1.5Gi here because we download/decompress/upload the image
-    def cosa_memory_request_mb = 1536
-    try { timeout(time: 75, unit: 'MINUTES') {
-        cosaPod(memory: "${cosa_memory_request_mb}Mi", kvm: false,
-                image: params.COREOS_ASSEMBLER_IMAGE) {
-
-            def azure_image_name, azure_image_filepath
-            stage('Fetch Metadata/Image') {
-                def commitopt = ''
-                if (params.SRC_CONFIG_COMMIT != '') {
-                    commitopt = "--commit=${params.SRC_CONFIG_COMMIT}"
+        def azure_image_name, azure_image_filepath
+        stage('Fetch Metadata/Image') {
+            def commitopt = ''
+            if (params.SRC_CONFIG_COMMIT != '') {
+                commitopt = "--commit=${params.SRC_CONFIG_COMMIT}"
+            }
+            // Grab the metadata. Also grab the image so we can upload it.
+            withCredentials([file(variable: 'AWS_CONFIG_FILE',
+                                  credentialsId: 'aws-build-upload-config')]) {
+                def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+                shwrap("""
+                cosa init --branch ${ref} ${commitopt} ${pipecfg.source_config.url}
+                cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
+                    --url=s3://${s3_stream_dir}/builds --artifact=azure
+                """)
+                pipeutils.withXzMemLimit(cosa_memory_request_mb - 256) {
+                    shwrap("cosa decompress --build=${params.VERSION} --artifact=azure")
                 }
-                // Grab the metadata. Also grab the image so we can upload it.
-                withCredentials([file(variable: 'AWS_CONFIG_FILE',
-                                      credentialsId: 'aws-build-upload-config')]) {
-                    def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
-                    shwrap("""
-                    cosa init --branch ${ref} ${commitopt} ${pipecfg.source_config.url}
-                    cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
-                        --url=s3://${s3_stream_dir}/builds --artifact=azure
-                    """)
-                    pipeutils.withXzMemLimit(cosa_memory_request_mb - 256) {
-                        shwrap("cosa decompress --build=${params.VERSION} --artifact=azure")
-                    }
-                    azure_image_filepath = shwrapCapture("""
-                    cosa meta --build=${params.VERSION} --arch=${params.ARCH} --image-path azure
-                    """)
-                }
-
-                // Use a consistent image name for this stream in case it gets left behind
-                azure_image_name = "kola-fedora-coreos-${params.STREAM}-${params.ARCH}.vhd"
+                azure_image_filepath = shwrapCapture("""
+                cosa meta --build=${params.VERSION} --arch=${params.ARCH} --image-path azure
+                """)
             }
 
-            withCredentials([file(variable: 'AZURE_KOLA_TESTS_CONFIG_PROFILE',
-                                  credentialsId: 'azure-kola-tests-config-profile'),
-                             file(variable: 'AZURE_KOLA_TESTS_CONFIG_AUTH',
-                                  credentialsId: 'azure-kola-tests-config-auth')]) {
+            // Use a consistent image name for this stream in case it gets left behind
+            azure_image_name = "kola-fedora-coreos-${params.STREAM}-${params.ARCH}.vhd"
+        }
 
-                def azure_testing_resource_group = pipecfg.clouds?.azure?.test_resource_group
-                def azure_testing_storage_account = pipecfg.clouds?.azure?.test_storage_account
-                def azure_testing_storage_container = pipecfg.clouds?.azure?.test_storage_container
+        withCredentials([file(variable: 'AZURE_KOLA_TESTS_CONFIG_PROFILE',
+                              credentialsId: 'azure-kola-tests-config-profile'),
+                         file(variable: 'AZURE_KOLA_TESTS_CONFIG_AUTH',
+                              credentialsId: 'azure-kola-tests-config-auth')]) {
 
-                stage('Upload/Create Image') {
-                    // Create the image in Azure
+            def azure_testing_resource_group = pipecfg.clouds?.azure?.test_resource_group
+            def azure_testing_storage_account = pipecfg.clouds?.azure?.test_storage_account
+            def azure_testing_storage_container = pipecfg.clouds?.azure?.test_storage_container
+
+            stage('Upload/Create Image') {
+                // Create the image in Azure
+                shwrap("""
+                # First delete the blob/image since we re-use it.
+                ore azure delete-image --log-level=INFO                 \
+                    --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
+                    --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
+                    --azure-location $region                            \
+                    --resource-group ${azure_testing_resource_group}    \
+                    --image-name ${azure_image_name}
+                ore azure delete-blob --log-level=INFO                  \
+                    --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
+                    --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
+                    --azure-location $region                            \
+                    --resource-group $azure_testing_resource_group      \
+                    --storage-account $azure_testing_storage_account    \
+                    --container $azure_testing_storage_container        \
+                    --blob-name $azure_image_name
+                # Then create them fresh
+                ore azure upload-blob --log-level=INFO                  \
+                    --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
+                    --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
+                    --azure-location $region                            \
+                    --resource-group $azure_testing_resource_group      \
+                    --storage-account $azure_testing_storage_account    \
+                    --container $azure_testing_storage_container        \
+                    --blob-name $azure_image_name                       \
+                    --file ${azure_image_filepath}
+                ore azure create-image --log-level=INFO                 \
+                    --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
+                    --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
+                    --resource-group $azure_testing_resource_group      \
+                    --azure-location $region                            \
+                    --image-name $azure_image_name                      \
+                    --image-blob "https://${azure_testing_storage_account}.blob.core.windows.net/${azure_testing_storage_container}/${azure_image_name}"
+                """)
+            }
+
+            // Since we don't have permanent images uploaded to Azure we'll
+            // skip the upgrade test.
+            try {
+                def azure_subscription = shwrapCapture("jq -r .subscriptionId \${AZURE_KOLA_TESTS_CONFIG_AUTH}")
+                kola(cosaDir: env.WORKSPACE, parallel: 10,
+                     build: params.VERSION, arch: params.ARCH,
+                     extraArgs: params.KOLA_TESTS,
+                     skipUpgrade: true,
+                     platformArgs: """-p=azure                               \
+                         --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
+                         --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
+                         --azure-location $region                            \
+                         --azure-disk-uri /subscriptions/${azure_subscription}/resourceGroups/${azure_testing_resource_group}/providers/Microsoft.Compute/images/${azure_image_name}""")
+            } finally {
+                parallel "Delete Image": {
+                    // Delete the image in Azure
                     shwrap("""
-                    # First delete the blob/image since we re-use it.
                     ore azure delete-image --log-level=INFO                 \
                         --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
                         --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
                         --azure-location $region                            \
-                        --resource-group ${azure_testing_resource_group}    \
-                        --image-name ${azure_image_name}
+                        --resource-group $azure_testing_resource_group      \
+                        --image-name $azure_image_name
                     ore azure delete-blob --log-level=INFO                  \
                         --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
                         --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
@@ -111,78 +157,26 @@ lock(resource: "kola-azure-${params.ARCH}") {
                         --storage-account $azure_testing_storage_account    \
                         --container $azure_testing_storage_container        \
                         --blob-name $azure_image_name
-                    # Then create them fresh
-                    ore azure upload-blob --log-level=INFO                  \
+                    """)
+                }, "Garbage Collection": {
+                    shwrap("""
+                    ore azure gc --log-level=INFO                           \
                         --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
                         --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
-                        --azure-location $region                            \
-                        --resource-group $azure_testing_resource_group      \
-                        --storage-account $azure_testing_storage_account    \
-                        --container $azure_testing_storage_container        \
-                        --blob-name $azure_image_name                       \
-                        --file ${azure_image_filepath}
-                    ore azure create-image --log-level=INFO                 \
-                        --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
-                        --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
-                        --resource-group $azure_testing_resource_group      \
-                        --azure-location $region                            \
-                        --image-name $azure_image_name                      \
-                        --image-blob "https://${azure_testing_storage_account}.blob.core.windows.net/${azure_testing_storage_container}/${azure_image_name}"
+                        --azure-location $region
                     """)
                 }
-
-                // Since we don't have permanent images uploaded to Azure we'll
-                // skip the upgrade test.
-                try {
-                    def azure_subscription = shwrapCapture("jq -r .subscriptionId \${AZURE_KOLA_TESTS_CONFIG_AUTH}")
-                    kola(cosaDir: env.WORKSPACE, parallel: 10,
-                         build: params.VERSION, arch: params.ARCH,
-                         extraArgs: params.KOLA_TESTS,
-                         skipUpgrade: true,
-                         platformArgs: """-p=azure                               \
-                             --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
-                             --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
-                             --azure-location $region                            \
-                             --azure-disk-uri /subscriptions/${azure_subscription}/resourceGroups/${azure_testing_resource_group}/providers/Microsoft.Compute/images/${azure_image_name}""")
-                } finally {
-                    parallel "Delete Image": {
-                        // Delete the image in Azure
-                        shwrap("""
-                        ore azure delete-image --log-level=INFO                 \
-                            --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
-                            --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
-                            --azure-location $region                            \
-                            --resource-group $azure_testing_resource_group      \
-                            --image-name $azure_image_name
-                        ore azure delete-blob --log-level=INFO                  \
-                            --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
-                            --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
-                            --azure-location $region                            \
-                            --resource-group $azure_testing_resource_group      \
-                            --storage-account $azure_testing_storage_account    \
-                            --container $azure_testing_storage_container        \
-                            --blob-name $azure_image_name
-                        """)
-                    }, "Garbage Collection": {
-                        shwrap("""
-                        ore azure gc --log-level=INFO                           \
-                            --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
-                            --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
-                            --azure-location $region
-                        """)
-                    }
-                }
-
             }
 
-            currentBuild.result = 'SUCCESS'
         }
-    }} catch (e) {
-        currentBuild.result = 'FAILURE'
-        throw e
-    } finally {
-        if (currentBuild.result != 'SUCCESS') {
-            pipeutils.trySlackSend(color: 'danger', message: ":azure: kola-azure <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
-        }
+
+        currentBuild.result = 'SUCCESS'
+    }} // cosaPod and timeout end here
+} catch (e) {
+    currentBuild.result = 'FAILURE'
+    throw e
+} finally {
+    if (currentBuild.result != 'SUCCESS') {
+        pipeutils.trySlackSend(color: 'danger', message: ":azure: kola-azure <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
     }
 }

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -39,9 +39,10 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSIO
 
 def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
-try { timeout(time: 60, unit: 'MINUTES') {
+timeout(time: 60, unit: 'MINUTES') {
     cosaPod(memory: "512Mi", kvm: false,
             image: params.COREOS_ASSEMBLER_IMAGE) {
+    try {
 
         stage('Fetch Metadata') {
             def commitopt = ''
@@ -71,12 +72,13 @@ try { timeout(time: 60, unit: 'MINUTES') {
         }
 
         currentBuild.result = 'SUCCESS'
+
+    } catch (e) {
+        currentBuild.result = 'FAILURE'
+        throw e
+    } finally {
+        if (currentBuild.result != 'SUCCESS') {
+            pipeutils.trySlackSend(color: 'danger', message: ":k8s: kola-kubernetes <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
+        }
     }
-}} catch (e) {
-    currentBuild.result = 'FAILURE'
-    throw e
-} finally {
-    if (currentBuild.result != 'SUCCESS') {
-        pipeutils.trySlackSend(color: 'danger', message: ":k8s: kola-kubernetes <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
-    }
-}
+}} // cosaPod and timeout finish here

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -52,90 +52,91 @@ def cosa_memory_request_mb = 1536
 
 // Locking so we only run max of 2 runs (1 x86_64 and 1 aarch64) at any given time.
 lock(resource: "kola-openstack-${params.ARCH}") {
-    try { timeout(time: 90, unit: 'MINUTES') {
-        cosaPod(memory: "${cosa_memory_request_mb}Mi", kvm: false,
-                image: params.COREOS_ASSEMBLER_IMAGE) {
+    timeout(time: 90, unit: 'MINUTES') {
+    cosaPod(memory: "${cosa_memory_request_mb}Mi", kvm: false,
+            image: params.COREOS_ASSEMBLER_IMAGE) {
+    try {
 
-            def openstack_image_name, openstack_image_filepath
-            stage('Fetch Metadata/Image') {
-                def commitopt = ''
-                if (params.SRC_CONFIG_COMMIT != '') {
-                    commitopt = "--commit=${params.SRC_CONFIG_COMMIT}"
+        def openstack_image_name, openstack_image_filepath
+        stage('Fetch Metadata/Image') {
+            def commitopt = ''
+            if (params.SRC_CONFIG_COMMIT != '') {
+                commitopt = "--commit=${params.SRC_CONFIG_COMMIT}"
+            }
+            // Grab the metadata. Also grab the image so we can upload it.
+            withCredentials([file(variable: 'AWS_CONFIG_FILE',
+                                  credentialsId: 'aws-build-upload-config')]) {
+                def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+                shwrap("""
+                cosa init --branch ${ref} ${commitopt} ${pipecfg.source_config.url}
+                cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
+                    --url=s3://${s3_stream_dir}/builds --artifact=openstack
+                """)
+                pipeutils.withXzMemLimit(cosa_memory_request_mb - 256) {
+                    shwrap("cosa decompress --build=${params.VERSION} --artifact=openstack")
                 }
-                // Grab the metadata. Also grab the image so we can upload it.
-                withCredentials([file(variable: 'AWS_CONFIG_FILE',
-                                      credentialsId: 'aws-build-upload-config')]) {
-                    def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
-                    shwrap("""
-                    cosa init --branch ${ref} ${commitopt} ${pipecfg.source_config.url}
-                    cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
-                        --url=s3://${s3_stream_dir}/builds --artifact=openstack
-                    """)
-                    pipeutils.withXzMemLimit(cosa_memory_request_mb - 256) {
-                        shwrap("cosa decompress --build=${params.VERSION} --artifact=openstack")
-                    }
-                    openstack_image_filepath = shwrapCapture("""
-                    cosa meta --build=${params.VERSION} --arch=${params.ARCH} --image-path openstack
-                    """)
-                }
-
-                // Use a consistent image name for this stream in case it gets left behind
-                openstack_image_name = "kola-fedora-coreos-${params.STREAM}-${params.ARCH}"
-
+                openstack_image_filepath = shwrapCapture("""
+                cosa meta --build=${params.VERSION} --arch=${params.ARCH} --image-path openstack
+                """)
             }
 
-            withCredentials([file(variable: 'OPENSTACK_KOLA_TESTS_CONFIG',
-                                  credentialsId: 'openstack-kola-tests-config')]) {
+            // Use a consistent image name for this stream in case it gets left behind
+            openstack_image_name = "kola-fedora-coreos-${params.STREAM}-${params.ARCH}"
 
-                stage('Upload/Create Image') {
-                    // Create the image in OpenStack
-                    shwrap("""
-                    # First delete it if it currently exists, then create it.
-                    ore openstack --config-file=\${OPENSTACK_KOLA_TESTS_CONFIG} \
-                        --region=${region} \
-                        delete-image --id=${openstack_image_name} || true
-                    ore openstack --config-file=\${OPENSTACK_KOLA_TESTS_CONFIG} \
-                        --region=${region} \
-                        create-image --file=${openstack_image_filepath} \
-                        --name=${openstack_image_name} --arch=${params.ARCH}
-                    """)
-                }
-            
-                // In VexxHost we'll use the network called "private" for the
-                // instance NIC, attach a floating IP from the "public" network and
-                // use the v3-starter-4 instance (ram=8GiB, CPUs=4).
-                // The clouds.yaml config should be located at $OPENSTACK_KOLA_TESTS_CONFIG.
-                //
-                // Since we don't have permanent images uploaded to VexxHost we'll
-                // skip the upgrade test.
-                try {
-                    kola(cosaDir: env.WORKSPACE, parallel: 5,
-                         build: params.VERSION, arch: params.ARCH,
-                         extraArgs: params.KOLA_TESTS,
-                         skipUpgrade: true,
-                         platformArgs: """-p=openstack                               \
-                             --allow-rerun-success                                   \
-                             --openstack-config-file=\${OPENSTACK_KOLA_TESTS_CONFIG} \
-                             --openstack-flavor=v3-starter-4                         \
-                             --openstack-network=private                             \
-                             --openstack-region=${region}                            \
-                             --openstack-floating-ip-network=public                  \
-                             --openstack-image=${openstack_image_name}""")
-                } finally {
-                    stage('Delete Image') {
-                        // Delete the image in OpenStack
-                        shwrap("""
-                        ore openstack --config-file=\${OPENSTACK_KOLA_TESTS_CONFIG} \
-                            --region=${region} delete-image --id=${openstack_image_name}
-                        """)
-                    }
-                }
-
-            }
-
-            currentBuild.result = 'SUCCESS'
         }
-    }} catch (e) {
+
+        withCredentials([file(variable: 'OPENSTACK_KOLA_TESTS_CONFIG',
+                              credentialsId: 'openstack-kola-tests-config')]) {
+
+            stage('Upload/Create Image') {
+                // Create the image in OpenStack
+                shwrap("""
+                # First delete it if it currently exists, then create it.
+                ore openstack --config-file=\${OPENSTACK_KOLA_TESTS_CONFIG} \
+                    --region=${region} \
+                    delete-image --id=${openstack_image_name} || true
+                ore openstack --config-file=\${OPENSTACK_KOLA_TESTS_CONFIG} \
+                    --region=${region} \
+                    create-image --file=${openstack_image_filepath} \
+                    --name=${openstack_image_name} --arch=${params.ARCH}
+                """)
+            }
+        
+            // In VexxHost we'll use the network called "private" for the
+            // instance NIC, attach a floating IP from the "public" network and
+            // use the v3-starter-4 instance (ram=8GiB, CPUs=4).
+            // The clouds.yaml config should be located at $OPENSTACK_KOLA_TESTS_CONFIG.
+            //
+            // Since we don't have permanent images uploaded to VexxHost we'll
+            // skip the upgrade test.
+            try {
+                kola(cosaDir: env.WORKSPACE, parallel: 5,
+                     build: params.VERSION, arch: params.ARCH,
+                     extraArgs: params.KOLA_TESTS,
+                     skipUpgrade: true,
+                     platformArgs: """-p=openstack                               \
+                         --allow-rerun-success                                   \
+                         --openstack-config-file=\${OPENSTACK_KOLA_TESTS_CONFIG} \
+                         --openstack-flavor=v3-starter-4                         \
+                         --openstack-network=private                             \
+                         --openstack-region=${region}                            \
+                         --openstack-floating-ip-network=public                  \
+                         --openstack-image=${openstack_image_name}""")
+            } finally {
+                stage('Delete Image') {
+                    // Delete the image in OpenStack
+                    shwrap("""
+                    ore openstack --config-file=\${OPENSTACK_KOLA_TESTS_CONFIG} \
+                        --region=${region} delete-image --id=${openstack_image_name}
+                    """)
+                }
+            }
+
+        }
+
+        currentBuild.result = 'SUCCESS'
+
+    } catch (e) {
         currentBuild.result = 'FAILURE'
         throw e
     } finally {
@@ -143,4 +144,4 @@ lock(resource: "kola-openstack-${params.ARCH}") {
             pipeutils.trySlackSend(color: 'danger', message: ":openstack: kola-openstack <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
         }
     }
-}
+}}} // cosaPod, timeout, and lock finish here


### PR DESCRIPTION
Also includes some re-organization/comment fixes.

```
commit 1fae67e20a7590c94582ece82b18d76617c5eb35
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Nov 18 16:12:22 2022 -0500

    jobs/kola-*: include catch/finally in cosaPod() block
    
    This will allow us to do more advanced things in the finally. For
    example the `oc` command that got added to `trySlackSend()` in
    4404730 needs to run from inside the cosaPod to work.

commit 8f10e97480d7313253724d648d902516a88c64ed
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Nov 18 16:07:54 2022 -0500

    jobs/kola-openstack: fix comments move around variables
    
    The comment was outdated since we aren't running tests on multiple
    regions any longer.
    
    Moved around the variables to prep for the next patch.

commit a8ffb28e69aaa39bd061e6dd770ae58fb0740330
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Nov 18 15:56:42 2022 -0500

    jobs/kola-azure: remove locking
    
    This was copy/pasted from the openstack job and doesn't apply
    to Azure. This is obvious because azure doesn't even test on multiple
    architectures at the moment.

```