### PR TITLE
config: drop support for `override_compression_format` hack

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -36,8 +36,6 @@ hacks:
   skip_plume_release_task: true
   # OPTIONAL: skip UEFI on older RHCOS
   skip_uefi_tests_on_older_rhcos: true
-  # OPTIONAL: use a different compression format when archiving
-  override_compression_format: gzip
 
 # OPTIONAL/TEMPORARY: whether to use `versionary` to derive version numbers
 versionary_hack: true

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -356,9 +356,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         }
 
         stage('Archive') {
-            def format = pipecfg.hacks?.override_compression_format
-            format = format ?: 'xz' // Default to xz
-            shwrap("cosa compress --compressor ${format}")
+            shwrap("cosa compress")
 
             if (uploading) {
                 def acl = pipecfg.s3.acl ?: 'public-read'

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -441,9 +441,7 @@ lock(resource: "build-${params.STREAM}") {
         stage('Archive') {
             // lower to make sure we don't go over and account for overhead
             pipeutils.withXzMemLimit(cosa_memory_request_mb - 256) {
-                def format = pipecfg.hacks?.override_compression_format
-                format = format ?: 'xz' // Default to xz
-                shwrap("cosa compress --compressor ${format}")
+                shwrap("cosa compress")
             }
 
             if (uploading) {


### PR DESCRIPTION
We don't need this anymore. On FCOS, the `xz` setting is part of `image.yaml` which `cosa compress` now knows to read from. On RHCOS, we rely on `cosa compress` defaulting to `gzip`. This works for both new and old RHCOS streams using a cosa without the `image.yaml` support.