### PR TITLE
Add temporary hack for skipping AWS GovCloud uploads

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -91,6 +91,10 @@ streams:
       # OPTIONAL: additional architectures to skip building for
       skip_additional_arches:
         - s390x
+      # OPTIONAL/TEMPORARY: don't upload to govcloud even if cloud is
+      # configured. Can be dropped when RHCOS 4.9 (last release that doesn't
+      # support GovCloud) is EOL.
+      skip_govcloud_hack: true
 
 # REQUIRED: architectures to build for other than x86_64
 additional_arches: [aarch64, ppc64le, s390x]

--- a/jobs/cloud-replicate.Jenkinsfile
+++ b/jobs/cloud-replicate.Jenkinsfile
@@ -118,7 +118,7 @@ lock(resource: "cloud-replicate-${params.VERSION}") {
         currentBuild.description = "${build_description} Running"
 
         for (basearch in basearches) {
-            libcloud.replicate_to_clouds(pipecfg, basearch, params.VERSION)
+            libcloud.replicate_to_clouds(pipecfg, basearch, params.VERSION, params.STREAM)
         }
 
         stage('Publish') {

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -191,7 +191,7 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
 
 
             if (params.CLOUD_REPLICATION) {
-                libcloud.replicate_to_clouds(pipecfg, basearch, params.VERSION)
+                libcloud.replicate_to_clouds(pipecfg, basearch, params.VERSION, params.STREAM)
             }
         }
 

--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -30,7 +30,10 @@ def replicate_to_clouds(pipecfg, basearch, buildID) {
     if (meta.amis) {
         replicators["☁️ 🔄:aws"] = {
             def replicated = false
-            def ids = ['aws-build-upload-config', 'aws-govcloud-image-upload-config']
+            def ids = ['aws-build-upload-config']
+            if (pipecfg.clouds?.aws?.govcloud) {
+                ids += 'aws-govcloud-image-upload-config'
+            }
             def c = pipecfg.clouds.aws
             for (id in ids) {
                 tryWithCredentials([file(variable: 'AWS_CONFIG_FILE', credentialsId: id)]) {

--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -48,7 +48,7 @@ def replicate_to_clouds(pipecfg, basearch, buildID) {
                 }
             }
             if (!replicated) {
-                        error("AWS Replication asked for but no credentials exist")
+                error("AWS Replication asked for but no credentials exist")
             }
         }
     }

--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -1,6 +1,6 @@
 
 // Replicate artifacts in various clouds
-def replicate_to_clouds(pipecfg, basearch, buildID) {
+def replicate_to_clouds(pipecfg, basearch, buildID, stream) {
 
     def meta = readJSON(text: shwrapCapture("cosa meta --arch=${basearch} --dump"))
     def replicators = [:]
@@ -31,7 +31,8 @@ def replicate_to_clouds(pipecfg, basearch, buildID) {
         replicators["☁️ 🔄:aws"] = {
             def replicated = false
             def ids = ['aws-build-upload-config']
-            if (pipecfg.clouds?.aws?.govcloud) {
+            if (pipecfg.clouds?.aws?.govcloud &&
+                pipecfg[stream]?.skip_govcloud_hack != true) {
                 ids += 'aws-govcloud-image-upload-config'
             }
             def c = pipecfg.clouds.aws
@@ -155,6 +156,7 @@ def upload_to_clouds(pipecfg, basearch, buildID, stream) {
     credentials = [file(variable: "AWS_GOVCLOUD_IMAGE_UPLOAD_CONFIG",
                         credentialsId: "aws-govcloud-image-upload-config")]
     if (pipecfg.clouds?.aws?.govcloud &&
+        pipecfg[stream]?.skip_govcloud_hack != true &&
         artifacts.contains("aws") &&
         utils.credentialsExist(credentials)) {
         def creds = credentials


### PR DESCRIPTION
RHCOS 4.9 and earlier did not upload to GovCloud so we need to temporarily support a hack to skip it on those streams.