### PR TITLE
libcloud: fixes for aws uploads

### DIFF
--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -39,6 +39,7 @@ def replicate_to_clouds(pipecfg, basearch, buildID, stream) {
                 --log-level=INFO \
                 --build=${buildID} \
                 --arch=${basearch} \
+                --source-region=${c.primary_region} \
                 --credentials-file=\${AWS_CONFIG_FILE}
             """)
         }

--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -97,7 +97,7 @@ def replicate_to_clouds(pipecfg, basearch, buildID, stream) {
 def upload_to_clouds(pipecfg, basearch, buildID, stream) {
 
     // Get a list of the artifacts that are currently built.
-    def images_json = readJSON(text: shwrapCapture("cosa meta --get-value images"))
+    def images_json = readJSON(text: shwrapCapture("cosa meta --arch=${basearch} --get-value images"))
     def artifacts = images_json.keySet()
 
     // Define an uploader closure for each artifact/cloud that we

--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -2,7 +2,9 @@
 // Replicate artifacts in various clouds
 def replicate_to_clouds(pipecfg, basearch, buildID, stream) {
 
-    def meta = readJSON(text: shwrapCapture("cosa meta --arch=${basearch} --dump"))
+    def meta = readJSON(text: shwrapCapture("""
+        cosa meta --build=${buildID} --arch=${basearch} --dump
+    """))
     def replicators = [:]
     def credentials
 
@@ -97,7 +99,9 @@ def replicate_to_clouds(pipecfg, basearch, buildID, stream) {
 def upload_to_clouds(pipecfg, basearch, buildID, stream) {
 
     // Get a list of the artifacts that are currently built.
-    def images_json = readJSON(text: shwrapCapture("cosa meta --arch=${basearch} --get-value images"))
+    def images_json = readJSON(text: shwrapCapture("""
+        cosa meta --build=${buildID} --arch=${basearch} --get-value images
+    """))
     def artifacts = images_json.keySet()
 
     // Define an uploader closure for each artifact/cloud that we

--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -55,7 +55,7 @@ def replicate_to_clouds(pipecfg, basearch, buildID, stream) {
         }
         credentials = [file(variable: "UNUSED", credentialsId: "aws-govcloud-image-upload-config")]
         if (pipecfg.clouds?.aws?.govcloud &&
-            (pipecfg[stream]?.skip_govcloud_hack != true) &&
+            (pipecfg.streams[stream]?.skip_govcloud_hack != true) &&
             utils.credentialsExist(credentials)) {
             replicators["☁️ 🔄:aws:govcloud"] = {
                 awsReplicateClosure.call(pipecfg.clouds.aws.govcloud,
@@ -172,7 +172,7 @@ def upload_to_clouds(pipecfg, basearch, buildID, stream) {
         }
         credentials = [file(variable: "UNUSED", credentialsId: "aws-govcloud-image-upload-config")]
         if (pipecfg.clouds?.aws?.govcloud &&
-            (pipecfg[stream]?.skip_govcloud_hack != true) &&
+            (pipecfg.streams[stream]?.skip_govcloud_hack != true) &&
             utils.credentialsExist(credentials)) {
             uploaders["☁️ ⬆️ :aws:govcloud"] = {
                 awsUploadClosure.call(pipecfg.clouds.aws.govcloud,


### PR DESCRIPTION
```
commit 5a0a12039a6b126cf368643d185a051af166d747
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Nov 23 15:19:40 2022 -0500

    libcloud: specify the source region for AWS replication
    
    Since we can upload to both AWS and AWS Govcloud we don't need to
    just let the code pick the first AMI in the list to use as the
    source AMI. We need to tell it which one is the source.

commit 8e58bea89ccfe89c01e2fa5cc904636b2010a9a9
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Nov 23 15:15:36 2022 -0500

    libcloud: create a separate replicator for AWS govcloud
    
    We can run the replication for govcloud in parallel. Let's
    use the same model we're using for the uploaders where we
    define a closure and then call that closure for primary
    AWS and for AWS Govcloud.

commit 6ad8e2d0b7073218717dd0542a50771a1286245f
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Nov 23 15:14:47 2022 -0500

    libcloud: dedupe AWS upload calls
    
    Let's define a closure and then call that for AWS and AWS Govcloud.

```