### PR TITLE
libcloud: also grant `createVolumePermission` to grant_users

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -82,7 +82,7 @@ clouds:
     # we make our images public in the release job via plume
     public: false
     # Accounts to share newly created AMIs with
-    test_accounts:
+    grant_users:
       - "013116697141"
   azure:
     test_resource_group: fedora-coreos-testing

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -134,7 +134,7 @@ aws_aarch64_serial_console_hack: true
 clouds:
   aws:
     # OPTIONAL: accounts to share newly created AMIs with
-    test_accounts:
+    grant_users:
       - "1234567890"
     # REQUIRED (if AWS build upload credentials provided): the region to do
     # initial image creation in.
@@ -150,7 +150,7 @@ clouds:
     # separate set of data for GovCloud uploads
     govcloud:
       # OPTIONAL: accounts to share newly created AMIs with
-      test_accounts:
+      grant_users:
         - "1234567890"
       # REQUIRED: the region to do initial image creation in.
       primary_region: us-gov-east-1

--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -149,6 +149,7 @@ def upload_to_clouds(pipecfg, basearch, buildID, stream) {
             def extraArgs = []
             if (c.grant_users) {
                 extraArgs += c.grant_users.collect{"--grant-user=${it}"}
+                extraArgs += c.grant_users.collect{"--grant-user-snapshot=${it}"}
             }
             if (c.public) {
                 extraArgs += "--public"

--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -147,8 +147,8 @@ def upload_to_clouds(pipecfg, basearch, buildID, stream) {
             utils.syncCredentialsIfInRemoteSession(["AWS_CONFIG_FILE"])
             def c = config
             def extraArgs = []
-            if (c.test_accounts) {
-                extraArgs += c.test_accounts.collect{"--grant-user=${it}"}
+            if (c.grant_users) {
+                extraArgs += c.grant_users.collect{"--grant-user=${it}"}
             }
             if (c.public) {
                 extraArgs += "--public"


### PR DESCRIPTION
We do want this for AWS Marketplace accounts at least. For test
accounts, it's not necessary but doesn't hurt either.