### PR TITLE
config: drop `skip_plume_release_task` hack, add `misc.generate_release_index`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -99,3 +99,6 @@ clouds:
       - "https://compute.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
   openstack:
     test_architectures: [x86_64, aarch64]
+
+misc:
+  generate_release_index: true

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -32,8 +32,6 @@ hotfix:
 hacks:
   # OPTIONAL: skip upgrade kola tests
   skip_upgrade_tests: true
-  # OPTIONAL: skip calling plume in the release job
-  skip_plume_release_task: true
   # OPTIONAL: skip UEFI on older RHCOS
   skip_uefi_tests_on_older_rhcos: true
   # OPTIONAL: implement the yumrepos branch workaround
@@ -142,7 +140,8 @@ clouds:
     # REQUIRED (if AWS build upload credentials provided): the bucket+prefix
     # where image files are uploaded to then initiate an image import.
     bucket: fedora-coreos-image-uploads/ami-import
-    # OPTIONAL: boolean: whether or not to set the image/snapshot as public
+    # OPTIONAL: boolean: whether or not to set the image/snapshot as public on
+    # initial upload (AMIs of released builds are always made public)
     public: true
     # OPTIONAL: list of architectures to limit cloud testing to.
     test_architectures: [x86_64]
@@ -229,3 +228,8 @@ clouds:
       - jp-osa
       - jp-tok
       - us-south
+
+# OPTIONAL: miscellaneous options
+misc:
+  # OPTIONAL: whether to generate a release index
+  generate_release_index: true


### PR DESCRIPTION
Rather than `plume release`, use the new `plume make-amis-public` and
`plume update-release-index` commands directly. Gate the former on
whether the AMIs were already made public on first upload. Gate the
latter on a new `misc.generate_release_index` since we only need it for
FCOS. Finally, get rid of the `skip_plume_release_task` knob.