### PR TITLE
Bake additional cert into Jenkins controller image

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -563,10 +563,10 @@ oc start-build --follow jenkins-with-cert
 oc start-build --follow jenkins-agent-base-with-cert
 ```
 
-We can now start a build of the Jenkins controller:
+We can now start an S2I build of the Jenkins controller:
 
 ```
-oc start-build --follow jenkins
+oc start-build --follow jenkins-s2i
 ```
 
 Once the Jenkins controller image is built, Jenkins should start up (verify

--- a/HACKING.md
+++ b/HACKING.md
@@ -564,7 +564,7 @@ oc start-build --follow jenkins
 If a root CA cert was provided, also start a build of the Jenkins agent:
 
 ```
-oc start-build --follow jenkins-agent
+oc start-build --follow jenkins-agent-base-with-cert
 ```
 
 Once the Jenkins controller image is built, Jenkins should start up (verify

--- a/HACKING.md
+++ b/HACKING.md
@@ -555,16 +555,18 @@ This will create:
 3. the Jenkins agent BuildConfig (if a root CA cert was provided),
 4. the jenkins-config configmap.
 
+If a root CA cert was provided, we need to build the base images that
+will bake in the cert in the controller and agent:
+
+```
+oc start-build --follow jenkins-with-cert
+oc start-build --follow jenkins-agent-base-with-cert
+```
+
 We can now start a build of the Jenkins controller:
 
 ```
 oc start-build --follow jenkins
-```
-
-If a root CA cert was provided, also start a build of the Jenkins agent:
-
-```
-oc start-build --follow jenkins-agent-base-with-cert
 ```
 
 Once the Jenkins controller image is built, Jenkins should start up (verify

--- a/deploy
+++ b/deploy
@@ -59,7 +59,7 @@ def process_template(args):
         templates += ['jenkins-with-cert.yaml']
         # we want :latest to be owned by our BuildConfig, so call the base
         # image :base instead of :latest
-        params['JENKINS_AGENT_BASE_TAG'] = "base"
+        params['JENKINS_BASE_TAG'] = "base"
 
     print("Parameters:")
     for k, v in params.items():

--- a/deploy
+++ b/deploy
@@ -56,7 +56,7 @@ def process_template(args):
     if args.pipecfg:
         params.update(params_from_git_refspec(args.pipecfg, 'PIPECFG'))
     if has_additional_root_ca(args):
-        templates += ['jenkins-agent.yaml']
+        templates += ['jenkins-with-cert.yaml']
         # we want :latest to be owned by our BuildConfig, so call the base
         # image :base instead of :latest
         params['JENKINS_AGENT_BASE_TAG'] = "base"

--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -16,6 +16,30 @@ parameters:
     description: Tag name of base OpenShift Jenkins agent image
     value: latest
 
+# Here's what the flow looks like when no cert is required:
+#
+# ┌─────────────────────┐   ┌────────────────┐   ┌─────────────┐   ┌─────────────┐
+# │ imagestream         │   │ imagestream    │   │ buildconfig │   │ imagestream │
+# │ openshift/jenkins:2 ├──►│ jenkins:latest ├──►│ jenkins-s2i ├──►│ jenkins:2   │
+# └─────────────────────┘   └────────────────┘   └─────────────┘   └─────────────┘
+#
+# ┌─────────────────────────────────────┐   ┌───────────────────────────┐
+# │ imagestream                         │   │ imagestream               │
+# │ openshift/jenkins-agent-base:latest ├──►│ jenkins-agent-base:latest │
+# └─────────────────────────────────────┘   └───────────────────────────┘
+#
+# And with cert required (see `jenkins-with-cert.yaml`):
+#
+# ┌─────────────────────┐   ┌───────────────────┐   ┌────────────────┐   ┌─────────────┐   ┌─────────────┐
+# │ imagestream         │   │ buildconfig       │   │ imagestream    │   │ buildconfig │   │ imagestream │
+# │ openshift/jenkins:2 ├──►│ jenkins-with-cert ├──►│ jenkins:latest ├──►│ jenkins-s2i ├──►│ jenkins:2   │
+# └─────────────────────┘   └───────────────────┘   └────────────────┘   └─────────────┘   └─────────────┘
+#
+# ┌─────────────────────────────────────┐   ┌──────────────────────────────┐   ┌───────────────────────────┐
+# │ imagestream                         │   │ buildconfig                  │   │ imagestream               │
+# │ openshift/jenkins-agent-base:latest ├──►│ jenkins-agent-base-with-cert ├──►│ jenkins-agent-base:latest │
+# └─────────────────────────────────────┘   └──────────────────────────────┘   └───────────────────────────┘
+
 objects:
 
   ### JENKINS CONTROLLER ###

--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -36,7 +36,7 @@ objects:
   - kind: BuildConfig
     apiVersion: v1
     metadata:
-      name: jenkins
+      name: jenkins-s2i
     # Note no triggers: we don't want e.g. git pushes/config changes to restart
     # Jenkins. Let's just require manual restarts here. XXX: Should investigate
     # if there's an easy way to auto-redeploy during downtimes.

--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -58,7 +58,7 @@ objects:
   - apiVersion: v1
     kind: ImageStream
     metadata:
-      name: jenkins-agent
+      name: jenkins-agent-base
     spec:
       lookupPolicy:
         # this allows e.g. the pipeline to directly reference the imagestream

--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -12,7 +12,7 @@ parameters:
   - description: Git branch/tag reference for Jenkins S2I
     name: JENKINS_S2I_REF
     value: main
-  - name: JENKINS_AGENT_BASE_TAG
+  - name: JENKINS_BASE_TAG
     description: Tag name of base OpenShift Jenkins agent image
     value: latest
 
@@ -64,7 +64,7 @@ objects:
         # this allows e.g. the pipeline to directly reference the imagestream
         local: true
       tags:
-        - name: ${JENKINS_AGENT_BASE_TAG}
+        - name: ${JENKINS_BASE_TAG}
           from:
             kind: ImageStreamTag
             name: jenkins-agent-base:latest

--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -24,6 +24,15 @@ objects:
     kind: ImageStream
     metadata:
       name: jenkins
+    spec:
+      tags:
+        - name: ${JENKINS_BASE_TAG}
+          from:
+            kind: ImageStreamTag
+            name: jenkins:2
+            namespace: openshift
+          referencePolicy:
+            type: Source
   - kind: BuildConfig
     apiVersion: v1
     metadata:
@@ -43,8 +52,7 @@ objects:
         sourceStrategy:
           from:
             kind: ImageStreamTag
-            name: jenkins:2
-            namespace: openshift
+            name: jenkins:latest
           forcePull: true
       output:
         to:

--- a/manifests/jenkins-with-cert.yaml
+++ b/manifests/jenkins-with-cert.yaml
@@ -5,15 +5,15 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: jenkins-agent
+  name: jenkins-with-cert
 labels:
   app: coreos-pipeline
-  template: coreos-pipeline-jenkins-agent-template
+  template: coreos-pipeline-jenkins-with-cert-template
 objects:
   - kind: BuildConfig
     apiVersion: v1
     metadata:
-      name: jenkins-agent
+      name: jenkins-agent-base-with-cert
     spec:
       source:
         dockerfile: |
@@ -34,7 +34,7 @@ objects:
       output:
         to:
           kind: ImageStreamTag
-          name: jenkins-agent:latest
+          name: jenkins-agent-base:latest
       successfulBuildsHistoryLimit: 2
       failedBuildsHistoryLimit: 2
       triggers:

--- a/manifests/jenkins-with-cert.yaml
+++ b/manifests/jenkins-with-cert.yaml
@@ -13,6 +13,41 @@ objects:
   - kind: BuildConfig
     apiVersion: v1
     metadata:
+      name: jenkins-with-cert
+    spec:
+      source:
+        dockerfile: |
+          FROM overridden
+          COPY cert/data /etc/pki/ca-trust/source/anchors/root-ca.crt
+          USER root
+          RUN update-ca-trust
+          # restore previous user ID
+          # https://github.com/openshift/jenkins/blob/7bae76f4412d28c18ed2b33aaf73306734b7f6d5/2/Dockerfile.rhel8#L107
+          USER 1001
+        secrets:
+          - destinationDir: cert
+            secret:
+              name: additional-root-ca-cert
+      strategy:
+        dockerStrategy:
+          from:
+            kind: ImageStreamTag
+            name: jenkins:2
+            namespace: openshift
+          forcePull: true
+      output:
+        to:
+          kind: ImageStreamTag
+          name: jenkins:latest
+      successfulBuildsHistoryLimit: 2
+      failedBuildsHistoryLimit: 2
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChange: {}
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
       name: jenkins-agent-base-with-cert
     spec:
       source:

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -92,7 +92,7 @@ objects:
             value: >-
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=900
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true
-              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage=jenkins-agent:latest
+              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage=jenkins-agent-base:latest
           # DELTA: Increase session timeout to 24h (for docs on each field, see:
           # https://support.cloudbees.com/hc/en-us/articles/4406750806427)
           - name: JENKINS_OPTS


### PR DESCRIPTION
Just like we did for the agent image, play a similar trick to have the
additional cert baked into the controller image. This is required if we
need to fetch resources from HTTPS URLs covered by the root CA in code
that runs directly on the controller. This situation comes up in RHCOS
where we want to be able to load the pipecfg from an internal repo early
on in jobs.