### PR TITLE
manifests/jenkins: bump memory request to 3Gi

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -225,7 +225,7 @@ parameters:
   displayName: Memory Limit
   name: MEMORY_LIMIT
   # DELTA: changed from 1Gi
-  value: 2Gi
+  value: 3Gi
 - description: Volume space available for data, e.g. 512Mi, 2Gi.
   displayName: Volume Capacity
   name: VOLUME_CAPACITY


### PR DESCRIPTION
We're hitting https://issues.jenkins.io/browse/JENKINS-55287 which according to some reports can be memory-related. Let's try bumping to 3Gi and see if it helps.