### PR TITLE
jobs/release: unconditionally send slack message

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -365,7 +365,6 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    if (currentBuild.result != 'SUCCESS') {
-        pipeutils.trySlackSend(color: 'danger', message: ":bullettrain_front: release <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${basearches.join(' ')}] (${params.VERSION})")
-    }
+    def color = currentBuild.result == 'SUCCESS' ? 'good' : 'danger'
+    pipeutils.trySlackSend(color: color, message: ":bullettrain_front: release <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${basearches.join(' ')}] (${params.VERSION})")
 }}} // try-catch-finally, cosaPod and lock finish here


### PR DESCRIPTION
Unconditionally sending the message means we can use the sent message as a synchronization point with other members of the team. i.e. if people were waiting on a build to complete we can point to the message when it gets sent.