### PR TITLE
manifests/jenkins: set resource limits and requests for jnlp container

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -93,6 +93,10 @@ objects:
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=900
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true
               -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage=jenkins-agent-base:latest
+              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultCpuRequest=1
+              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultMemoryRequest=256Mi
+              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultCpuLimit=1
+              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultMemoryLimit=256Mi
           # DELTA: Increase session timeout to 24h (for docs on each field, see:
           # https://support.cloudbees.com/hc/en-us/articles/4406750806427)
           - name: JENKINS_OPTS


### PR DESCRIPTION
Right now, we're letting it default to the default values of the limitrange, which is 4 for CPUs and 10G for RAMs. That's vastly overkill given that we don't actually do any work in them but rather in the cosa containers colocated in them.

The limits chosen here match the builtin defaults in the kubernetes-plugin.