### PR TITLE
jenkins/config: define kubernetes cloud ourselves and bump maxRequestsPerHost to 64

### DIFF
--- a/jenkins/config/k8s.yaml
+++ b/jenkins/config/k8s.yaml
@@ -1,7 +1,10 @@
 jenkins:
   clouds:
   - kubernetes:
-      # The keys below match
+      # mitigation for
+      # https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/client-and-managed-masters/considerations-for-kubernetes-clients-connection-when-using-kubernetes-plugin
+      maxRequestsPerHost: 64
+      # The remaining keys below match
       # https://github.com/openshift/jenkins/blob/7bae76f4412d/2/contrib/jenkins/kube-slave-common.sh#L75
       # except that we don't include the templates since we don't need them.
       # We also don't include the certificate; it's automatically fetched from
@@ -9,7 +12,7 @@ jenkins:
       name: "openshift"
       addMasterProxyEnvVars: true
       containerCap: 100
-      jenkinsTunnel: "${JENKINS_JNLP_SERVICE_HOST}:${JENKINS_JNLP_SERVICE_PORT_AGENT}"
+      jenkinsTunnel: "${JENKINS_JNLP_SERVICE_HOST}:${JENKINS_JNLP_SERVICE_PORT}"
       jenkinsUrl: "http://${JENKINS_SERVICE_HOST}:${JENKINS_SERVICE_PORT}"
       namespace: "${OPENSHIFT_BUILD_NAMESPACE}"
       serverUrl: "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"

--- a/jenkins/config/k8s.yaml
+++ b/jenkins/config/k8s.yaml
@@ -1,0 +1,15 @@
+jenkins:
+  clouds:
+  - kubernetes:
+      # The keys below match
+      # https://github.com/openshift/jenkins/blob/7bae76f4412d/2/contrib/jenkins/kube-slave-common.sh#L75
+      # except that we don't include the templates since we don't need them.
+      # We also don't include the certificate; it's automatically fetched from
+      # the serviceaccount, which is what the the s2i run script does anyway.
+      name: "openshift"
+      addMasterProxyEnvVars: true
+      containerCap: 100
+      jenkinsTunnel: "${JENKINS_JNLP_SERVICE_HOST}:${JENKINS_JNLP_SERVICE_PORT_AGENT}"
+      jenkinsUrl: "http://${JENKINS_SERVICE_HOST}:${JENKINS_SERVICE_PORT}"
+      namespace: "${OPENSHIFT_BUILD_NAMESPACE}"
+      serverUrl: "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"


### PR DESCRIPTION
```
jenkins/config: define kubernetes cloud ourselves

Rather than relying on the S2I run script to define the kubernetes
cloud, do it ourselves. This will allow us to further customize it for
our needs, which isn't currently possible with the S2I setup:

https://github.com/openshift/jenkins/issues/1505

The two major differences with what the S2I run script would've defined
are:
1. no defining of pod templates; we don't use those anyway, so this is a
   nice cleanup
2. no setting of the kube certificate; the kubernetes plugin is smart
   enough to get it from the mounted serviceaccount secret, which is
   what the S2I run script does anyway
```
---
```
jenkins/config: bump maxRequestsPerHost to 64

This is a conceptual revert of the revert in #583. Now that we own the
cloud config, we can safely do this.
```
