### PR TITLE
config: drop support for `yumrepos_branch_rhcos_hack`

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -56,8 +56,6 @@ streams:
       default: true
       # OPTIONAL: override source config ref to use for this stream
       source_config_ref: main
-      # OPTIONAL: implement the yumrepos branch workaround for this stream
-      yumrepos_branch_rhcos_hack: true
       # OPTIONAL: override OS variant to use for this stream
       variant: rhcos-9.0
     stable:

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -156,28 +156,11 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         }
 
         stage('Init') {
-            if (stream_info.yumrepos_branch_rhcos_hack) {
-                // Right now the git repo that has our yum repo files isn't a
-                // single branch, but a branch per stream. So let's work with
-                // that here.
-                def yumrepos_ref = params.STREAM
-                if (yumrepos_ref == '4.13') {
-                    yumrepos_ref = 'master'
-                }
-                shwrap("""
-                cosa shell -- mkdir ./yumrepos
-                cosa shell -- git clone --depth=1 --branch=${yumrepos_ref} ${pipecfg.source_config.yumrepos} ./yumrepos
-                yumrepos=\$(cosa shell -- readlink -f ./yumrepos)
-                cosa init --force --branch ${ref} --commit=${src_config_commit} --yumrepos=\${yumrepos} ${pipecfg.source_config.url}
-                """)
-            } else {
-                def yumrepos = pipecfg.source_config.yumrepos ? "--yumrepos ${pipecfg.source_config.yumrepos}" : ""
-                def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
-                shwrap("""
-                cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${variant} ${pipecfg.source_config.url}
-                """)
-            }
-
+            def yumrepos = pipecfg.source_config.yumrepos ? "--yumrepos ${pipecfg.source_config.yumrepos}" : ""
+            def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
+            shwrap("""
+            cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${variant} ${pipecfg.source_config.url}
+            """)
         }
 
         // Determine parent version/commit information

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -140,27 +140,11 @@ lock(resource: "build-${params.STREAM}") {
         def src_config_commit = shwrapCapture("git ls-remote ${pipecfg.source_config.url} ${ref} | cut -d \$'\t' -f 1")
 
         stage('Init') {
-            if (stream_info.yumrepos_branch_rhcos_hack) {
-                // Right now the git repo that has our yum repo files isn't a
-                // single branch, but a branch per stream. So let's work with
-                // that here.
-                def yumrepos_ref = params.STREAM
-                if (yumrepos_ref == '4.13') {
-                    yumrepos_ref = 'master'
-                }
-                shwrap("""
-                cosa shell -- mkdir ./yumrepos
-                cosa shell -- git clone --depth=1 --branch=${yumrepos_ref} ${pipecfg.source_config.yumrepos} ./yumrepos
-                yumrepos=\$(cosa shell -- readlink -f ./yumrepos)
-                cosa init --force --branch ${ref} --commit=${src_config_commit} --yumrepos=\${yumrepos} ${pipecfg.source_config.url}
-                """)
-            } else {
-                def yumrepos = pipecfg.source_config.yumrepos ? "--yumrepos ${pipecfg.source_config.yumrepos}" : ""
-                def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
-                shwrap("""
-                cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${variant} ${pipecfg.source_config.url}
-                """)
-            }
+            def yumrepos = pipecfg.source_config.yumrepos ? "--yumrepos ${pipecfg.source_config.yumrepos}" : ""
+            def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
+            shwrap("""
+            cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${variant} ${pipecfg.source_config.url}
+            """)
 
             // for now, just use the PVC to keep cache.qcow2 in a stream-specific dir
             def cache_img = "/srv/prod/${params.STREAM}/cache.qcow2"


### PR DESCRIPTION
All the streams we care about now use the main branch of the yumrepos git repo.