### PR TITLE
jobs/release: show warning status if missing architectures

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -418,13 +418,10 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             return
         }
         message = ":sparkles: ${message} - SUCCESS"
-        color = 'good';
     } else if (currentBuild.result == 'UNSTABLE') {
         message = ":warning: ${message} - WARNING"
-        color = 'warning';
     } else {
         message = ":fire: ${message} - FAILURE"
-        color = 'danger';
     }
 
     if (newBuildID) {
@@ -432,7 +429,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
     }
 
     echo message
-    pipeutils.trySlackSend(color: color, message: message)
+    pipeutils.trySlackSend(message: message)
     pipeutils.tryWithMessagingCredentials() {
         shwrap("""
         /usr/lib/coreos-assembler/fedmsg-broadcast --fedmsg-conf=\${FEDORA_MESSAGING_CONF} \

--- a/jobs/build-cosa.Jenkinsfile
+++ b/jobs/build-cosa.Jenkinsfile
@@ -176,7 +176,7 @@ lock(resource: "build-${containername}") {
         }
         if (currentBuild.result != 'SUCCESS') {
             message = "build-cosa <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${gitref}@${shortcommit}]"
-            pipeutils.trySlackSend(color: 'danger', message: message)
+            pipeutils.trySlackSend(message: message)
         }
     }
 }}} // cosaPod, timeout, and lock finish here

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -510,13 +510,10 @@ lock(resource: "build-${params.STREAM}") {
             return
         }
         message = ":sparkles: ${message} - SUCCESS"
-        color = 'good';
     } else if (currentBuild.result == 'UNSTABLE') {
         message = ":warning: ${message} - WARNING"
-        color = 'warning';
     } else {
         message = ":fire: ${message} - FAILURE"
-        color = 'danger';
     }
 
     if (newBuildID) {
@@ -524,7 +521,7 @@ lock(resource: "build-${params.STREAM}") {
     }
 
     echo message
-    pipeutils.trySlackSend(color: color, message: message)
+    pipeutils.trySlackSend(message: message)
     pipeutils.tryWithMessagingCredentials() {
         shwrap("""
         /usr/lib/coreos-assembler/fedmsg-broadcast --fedmsg-conf=\${FEDORA_MESSAGING_CONF} \

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -290,12 +290,8 @@ lock(resource: "bump-${params.STREAM}") {
         currentBuild.result = 'FAILURE'
         throw e
     } finally {
-        def color = 'danger'
-        if (currentBuild.result == 'UNSTABLE') {
-            color = 'warning'
-        }
         if (currentBuild.result != 'SUCCESS') {
-            pipeutils.trySlackSend(color: color, message: "<${env.BUILD_URL}|bump-lockfile #${env.BUILD_NUMBER} (${params.STREAM})>")
+            pipeutils.trySlackSend(message: "<${env.BUILD_URL}|bump-lockfile #${env.BUILD_NUMBER} (${params.STREAM})>")
         }
     }
 }}} // cosaPod, timeout, and lock finish here

--- a/jobs/cloud-replicate.Jenkinsfile
+++ b/jobs/cloud-replicate.Jenkinsfile
@@ -145,7 +145,5 @@ lock(resource: "cloud-replicate-${params.VERSION}") {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    if (currentBuild.result != 'SUCCESS') {
-        pipeutils.trySlackSend(message: ":cloud: :arrows_counterclockwise: cloud-replicate <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${basearches.join(' ')}] (${params.VERSION})")
-    }
+    pipeutils.trySlackSend(message: ":cloud: :arrows_counterclockwise: cloud-replicate <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${basearches.join(' ')}] (${params.VERSION})")
 }}} // try-catch-finally, cosaPod and lock finish here

--- a/jobs/cloud-replicate.Jenkinsfile
+++ b/jobs/cloud-replicate.Jenkinsfile
@@ -146,6 +146,6 @@ lock(resource: "cloud-replicate-${params.VERSION}") {
     throw e
 } finally {
     if (currentBuild.result != 'SUCCESS') {
-        pipeutils.trySlackSend(color: 'danger', message: ":cloud: :arrows_counterclockwise: cloud-replicate <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${basearches.join(' ')}] (${params.VERSION})")
+        pipeutils.trySlackSend(message: ":cloud: :arrows_counterclockwise: cloud-replicate <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${basearches.join(' ')}] (${params.VERSION})")
     }
 }}} // try-catch-finally, cosaPod and lock finish here

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -137,7 +137,7 @@ timeout(time: 90, unit: 'MINUTES') {
         throw e
     } finally {
         if (currentBuild.result != 'SUCCESS') {
-            pipeutils.trySlackSend(color: 'danger', message: ":aws: kola-aws <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
+            pipeutils.trySlackSend(message: ":aws: kola-aws <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
         }
     }
 }} // cosaPod and timeout finish here

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -181,7 +181,7 @@ timeout(time: 75, unit: 'MINUTES') {
         throw e
     } finally {
         if (currentBuild.result != 'SUCCESS') {
-            pipeutils.trySlackSend(color: 'danger', message: ":azure: kola-azure <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
+            pipeutils.trySlackSend(message: ":azure: kola-azure <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
         }
     }
 }} // cosaPod and timeout finish here

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -84,7 +84,7 @@ timeout(time: 30, unit: 'MINUTES') {
         throw e
     } finally {
         if (currentBuild.result != 'SUCCESS') {
-            pipeutils.trySlackSend(color: 'danger', message: ":gcp: kola-gcp <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
+            pipeutils.trySlackSend(message: ":gcp: kola-gcp <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
         }
     }
 }} // cosaPod and timeout finish here

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -79,7 +79,7 @@ timeout(time: 60, unit: 'MINUTES') {
         throw e
     } finally {
         if (currentBuild.result != 'SUCCESS') {
-            pipeutils.trySlackSend(color: 'danger', message: ":k8s: kola-kubernetes <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
+            pipeutils.trySlackSend(message: ":k8s: kola-kubernetes <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
         }
     }
 }} // cosaPod and timeout finish here

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -142,7 +142,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
         throw e
     } finally {
         if (currentBuild.result != 'SUCCESS') {
-            pipeutils.trySlackSend(color: 'danger', message: ":openstack: kola-openstack <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
+            pipeutils.trySlackSend(message: ":openstack: kola-openstack <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
         }
     }
 }}} // cosaPod, timeout, and lock finish here

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -375,17 +375,5 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    def color
-    switch(currentBuild.result) {
-        case 'SUCCESS':
-            color = 'good';
-            break;
-        case 'UNSTABLE':
-            color = 'warning';
-            break;
-        default:
-            color = 'danger';
-            break;
-    }
-    pipeutils.trySlackSend(color: color, message: ":bullettrain_front: release <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${basearches.join(' ')}] (${params.VERSION})")
+    pipeutils.trySlackSend(message: ":bullettrain_front: release <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${basearches.join(' ')}] (${params.VERSION})")
 }}} // try-catch-finally, cosaPod and lock finish here

--- a/utils.groovy
+++ b/utils.groovy
@@ -544,6 +544,21 @@ def getSlackEmojiPrefix() {
 // Emits Slack message if set up, otherwise does nothing.
 def trySlackSend(params) {
     if (utils.credentialsExist([string(credentialsId: 'slack-api-token', variable: 'UNUSED')])) {
+        // If not given a color, determine what color the message should
+        // be based on the current build results.
+        if (!params.color) {
+            switch(currentBuild.result) {
+                case 'SUCCESS':
+                    params.color = 'good';
+                    break;
+                case 'UNSTABLE':
+                    params.color = 'warning';
+                    break;
+                default:
+                    params.color = 'danger';
+                    break;
+            }
+        }
         // Prefix all slack messages with the emoji in the jenkins.io/emoji-prefix
         // annotation on the slack-api-token secret. If it doesn't exist then
         // default to just a generic CoreOS emoji.


### PR DESCRIPTION
This will make the job (and slack message) show up as yellow (warning) if there were missing architectures.

Fixes https://github.com/coreos/fedora-coreos-pipeline/issues/784