### PR TITLE
jobs/build: add support for reading variant from stream/pipeline config

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -58,6 +58,8 @@ streams:
       source_config_ref: main
       # OPTIONAL: implement the yumrepos branch workaround for this stream
       yumrepos_branch_rhcos_hack: true
+      # OPTIONAL: override OS variant to use for this stream
+      variant: rhcos-9.0
     stable:
       type: production
       # OPTIONAL: override cosa image to use for this stream

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -172,8 +172,9 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
                 """)
             } else {
                 def yumrepos = pipecfg.source_config.yumrepos ? "--yumrepos ${pipecfg.source_config.yumrepos}" : ""
+                def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                 shwrap("""
-                cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${pipecfg.source_config.url}
+                cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${variant} ${pipecfg.source_config.url}
                 """)
             }
 

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -156,8 +156,9 @@ lock(resource: "build-${params.STREAM}") {
                 """)
             } else {
                 def yumrepos = pipecfg.source_config.yumrepos ? "--yumrepos ${pipecfg.source_config.yumrepos}" : ""
+                def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                 shwrap("""
-                cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${pipecfg.source_config.url}
+                cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${variant} ${pipecfg.source_config.url}
                 """)
             }
 

--- a/jobs/cloud-replicate.Jenkinsfile
+++ b/jobs/cloud-replicate.Jenkinsfile
@@ -87,8 +87,9 @@ lock(resource: "cloud-replicate-${params.VERSION}") {
         // Fetch metadata files for the build we are interested in
         stage('Fetch Metadata') {
             def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+            def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
             pipeutils.shwrapWithAWSBuildUploadCredentials("""
-            cosa init --branch ${ref} ${pipecfg.source_config.url}
+            cosa init --branch ${ref} ${variant} ${pipecfg.source_config.url}
             cosa buildfetch --build=${params.VERSION} \
                 --arch=all --url=s3://${s3_stream_dir}/builds \
                 --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG}

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -43,6 +43,8 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSIO
 
 def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
+def stream_info = pipecfg.streams[params.STREAM]
+
 timeout(time: 90, unit: 'MINUTES') {
     cosaPod(memory: "512Mi", kvm: false,
             image: params.COREOS_ASSEMBLER_IMAGE,
@@ -57,8 +59,9 @@ timeout(time: 90, unit: 'MINUTES') {
             withCredentials([file(variable: 'AWS_CONFIG_FILE',
                                   credentialsId: 'aws-build-upload-config')]) {
                 def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+                def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                 shwrap("""
-                cosa init --branch ${ref} ${commitopt} ${pipecfg.source_config.url}
+                cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
                 cosa buildfetch --artifact=ostree --build=${params.VERSION} \
                     --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds
                 """)

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -41,6 +41,8 @@ properties([
 
 currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSION}"
 
+def stream_info = pipecfg.streams[params.STREAM]
+
 // Use eastus region for now
 def region = "eastus"
 
@@ -66,8 +68,9 @@ timeout(time: 75, unit: 'MINUTES') {
             withCredentials([file(variable: 'AWS_CONFIG_FILE',
                                   credentialsId: 'aws-build-upload-config')]) {
                 def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+                def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                 shwrap("""
-                cosa init --branch ${ref} ${commitopt} ${pipecfg.source_config.url}
+                cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
                 cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
                     --url=s3://${s3_stream_dir}/builds --artifact=azure
                 """)

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -43,6 +43,8 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSIO
 
 def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
+def stream_info = pipecfg.streams[params.STREAM]
+
 timeout(time: 30, unit: 'MINUTES') {
     cosaPod(memory: "512Mi", kvm: false,
             image: params.COREOS_ASSEMBLER_IMAGE,
@@ -57,8 +59,9 @@ timeout(time: 30, unit: 'MINUTES') {
             withCredentials([file(variable: 'AWS_CONFIG_FILE',
                                   credentialsId: 'aws-build-upload-config')]) {
                 def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+                def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                 shwrap("""
-                cosa init --branch ${ref} ${commitopt} ${pipecfg.source_config.url}
+                cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
                 cosa buildfetch --artifact=ostree --build=${params.VERSION} \
                     --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds
                 """)

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -39,6 +39,8 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSIO
 
 def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
+def stream_info = pipecfg.streams[params.STREAM]
+
 timeout(time: 60, unit: 'MINUTES') {
     cosaPod(memory: "512Mi", kvm: false,
             image: params.COREOS_ASSEMBLER_IMAGE,
@@ -53,8 +55,9 @@ timeout(time: 60, unit: 'MINUTES') {
             withCredentials([file(variable: 'AWS_CONFIG_FILE',
                                   credentialsId: 'aws-build-upload-config')]) {
                 def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+                def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                 shwrap("""
-                cosa init --branch ${ref} ${commitopt} ${pipecfg.source_config.url}
+                cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
                 cosa buildfetch --build=${params.VERSION} \
                     --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds
                 """)

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -41,6 +41,8 @@ properties([
 
 currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${params.VERSION}"
 
+def stream_info = pipecfg.streams[params.STREAM]
+
 // Use ca-ymq-1 for everything right now since we're having trouble with
 // image uploads to ams1.
 def region = "ca-ymq-1"
@@ -68,8 +70,9 @@ lock(resource: "kola-openstack-${params.ARCH}") {
             withCredentials([file(variable: 'AWS_CONFIG_FILE',
                                   credentialsId: 'aws-build-upload-config')]) {
                 def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+                def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                 shwrap("""
-                cosa init --branch ${ref} ${commitopt} ${pipecfg.source_config.url}
+                cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
                 cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
                     --url=s3://${s3_stream_dir}/builds --artifact=openstack
                 """)

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -96,8 +96,9 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
         // Fetch metadata files for the build we are interested in
         stage('Fetch Metadata') {
             def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+            def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
             pipeutils.shwrapWithAWSBuildUploadCredentials("""
-            cosa init --branch ${ref} ${pipecfg.source_config.url}
+            cosa init --branch ${ref} ${variant} ${pipecfg.source_config.url}
             cosa buildfetch --build=${params.VERSION} \
                 --arch=all --url=s3://${s3_stream_dir}/builds \
                 --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG}


### PR DESCRIPTION
Add support in `build.jenkinsfile` and `build-arch.jenkinsfile` for reading variant information from the pipeline config/stream and passing it into `cosa init`.

xref: https://gitlab.cee.redhat.com/coreos/rhcos-devel-pipecfg/-/merge_requests/3  &  https://gitlab.cee.redhat.com/coreos/rhcos-art-pipecfg/-/merge_requests/9

See [COS-1925](https://issues.redhat.com/browse/COS-1925)