### PR TITLE
jobs/build: don't include build result as string in Slack msg

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -417,11 +417,11 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             // SUCCESS, but no new builds? Must've been a no-op
             return
         }
-        message = ":sparkles: ${message} - SUCCESS"
+        message = ":sparkles: ${message}"
     } else if (currentBuild.result == 'UNSTABLE') {
-        message = ":warning: ${message} - WARNING"
+        message = ":warning: ${message}"
     } else {
-        message = ":fire: ${message} - FAILURE"
+        message = ":fire: ${message}"
     }
 
     if (newBuildID) {

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -509,11 +509,11 @@ lock(resource: "build-${params.STREAM}") {
             // SUCCESS, but no new builds? Must've been a no-op
             return
         }
-        message = ":sparkles: ${message} - SUCCESS"
+        message = ":sparkles: ${message}"
     } else if (currentBuild.result == 'UNSTABLE') {
-        message = ":warning: ${message} - WARNING"
+        message = ":warning: ${message}"
     } else {
-        message = ":fire: ${message} - FAILURE"
+        message = ":fire: ${message}"
     }
 
     if (newBuildID) {


### PR DESCRIPTION
It's redundant with the emojis and colour and isn't consistent with the other job notifications.