### PR TITLE
release: Add `time -v` as part of fetch cmd for debugging

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -146,7 +146,7 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
             fetch_args += fetch_artifacts.collect{"--artifact=${it}"}
 
             pipeutils.shwrapWithAWSBuildUploadCredentials("""
-            cosa buildfetch --build=${params.VERSION} \
+            /usr/bin/time -v cosa buildfetch --build=${params.VERSION} \
                 --url=s3://${s3_stream_dir}/builds    \
                 --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
                 ${fetch_args.join(' ')}


### PR DESCRIPTION
- We are having trouble detecting why fetch is failing from time to time. To track it a little better, let's add it for a while.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>