### PR TITLE
Revert "release: Add `time -v` as part of fetch cmd for debugging"

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -146,7 +146,7 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
             fetch_args += fetch_artifacts.collect{"--artifact=${it}"}
 
             pipeutils.shwrapWithAWSBuildUploadCredentials("""
-            /usr/bin/time -v cosa buildfetch --build=${params.VERSION} \
+            cosa buildfetch --build=${params.VERSION} \
                 --url=s3://${s3_stream_dir}/builds    \
                 --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
                 ${fetch_args.join(' ')}


### PR DESCRIPTION
This reverts commit 0358b7624c09c30ae111819fa70af86f6764c3bd.

We need to backport https://github.com/coreos/coreos-assembler/pull/3268 to older cosa first.