### PR TITLE
jobs/build-arch: use new autolock feature

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -11,7 +11,6 @@ node {
 // Base URL through which to download artifacts
 BUILDS_BASE_HTTP_URL = "https://builds.coreos.fedoraproject.org/prod/streams"
 
-
 properties([
     pipelineTriggers([]),
     parameters([
@@ -78,7 +77,7 @@ def stream_info = pipecfg.streams[params.STREAM]
 def cosa_controller_img = stream_info.cosa_controller_img_hack ?: cosa_img
 
 // If we are a mechanical stream then we can pin packages but we
-// don't maintin complete lockfiles so we can't build in strict mode.
+// don't maintain complete lockfiles so we can't build in strict mode.
 def strict_build_param = stream_info.type == "mechanical" ? "" : "--strict"
 
 // Note that the heavy lifting is done on a remote node via podman
@@ -114,7 +113,6 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
 
         currentBuild.description = "${build_description} Running"
 
-
         // this is defined IFF we *should* and we *can* upload to S3
         def s3_stream_dir
 
@@ -129,7 +127,6 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         } else {
             uploading = false
         }
-
 
         // Wrap a bunch of commands now inside the context of a remote
         // session. All `cosa` commands, other than `cosa remote-session`
@@ -284,7 +281,6 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         // Build the remaining artifacts
         stage("Build Artifacts") {
             pipeutils.build_artifacts(pipecfg, params.STREAM, basearch)
-
         }
 
         // Run Kola TestISO tests for metal artifacts
@@ -368,7 +364,6 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
 
         } // end withEnv
         } // end withPodmanRemoteArchBuilder
-
 
         currentBuild.result = 'SUCCESS'
 

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -57,7 +57,7 @@ properties([
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 
-def build_description = "[${params.STREAM}]"
+def build_description = "[${params.STREAM}][x86_64]"
 
 // Reload pipecfg if a hotfix build was provided. The reason we do this here
 // instead of loading the right one upfront is so that we don't modify the
@@ -65,7 +65,7 @@ def build_description = "[${params.STREAM}]"
 if (params.PIPECFG_HOTFIX_REPO || params.PIPECFG_HOTFIX_REF) {
     node {
         pipecfg = pipeutils.load_pipecfg(params.PIPECFG_HOTFIX_REPO, params.PIPECFG_HOTFIX_REF)
-        build_description = "[${params.STREAM}-${pipecfg.hotfix.name}]"
+        build_description = "[${params.STREAM}-${pipecfg.hotfix.name}][x86_64]"
     }
 }
 
@@ -81,7 +81,7 @@ if (params.ADDITIONAL_ARCHES != "none") {
 def stream_info = pipecfg.streams[params.STREAM]
 
 // If we are a mechanical stream then we can pin packages but we
-// don't maintin complete lockfiles so we can't build in strict mode.
+// don't maintain complete lockfiles so we can't build in strict mode.
 def strict_build_param = stream_info.type == "mechanical" ? "" : "--strict"
 
 // Note the supermin VM just uses 2G. The really hungry part is xz, which
@@ -115,7 +115,6 @@ lock(resource: "build-${params.STREAM}") {
     try {
 
         basearch = shwrapCapture("cosa basearch")
-        build_description += "[${basearch}]"
         currentBuild.description = "${build_description} Running"
 
         // this is defined IFF we *should* and we *can* upload to S3
@@ -252,7 +251,6 @@ lock(resource: "build-${params.STREAM}") {
 
         newBuildID = buildID
         currentBuild.description = "${build_description} ⚡ ${newBuildID}"
-
 
         pipeutils.tryWithMessagingCredentials() {
             shwrap("""


### PR DESCRIPTION
This makes use of the new autolock feature in cosa to force multi-arch
builds to be consistent with the x86_64 build. This takes effect when
building a stream which doesn't currently use lockfiles.

The primary use case is RHCOS, but even once we start using lockfiles
there, this will still be useful for the FCOS rawhide stream.

