### PR TITLE
jobs/build: rerun `build-arch` if previous build is incomplete

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -1,6 +1,6 @@
 import org.yaml.snakeyaml.Yaml;
 
-def pipeutils, pipecfg, uploading, libcloud
+def pipeutils, pipecfg, libcloud
 node {
     checkout scm
     pipeutils = load("utils.groovy")
@@ -122,10 +122,9 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
 
         // Now, determine if we should do any uploads to remote s3 buckets or clouds
         // Don't upload if the user told us not to or we're debugging with KOLA_RUN_SLEEP
+        def uploading = false
         if (s3_stream_dir && (!params.NO_UPLOAD || params.KOLA_RUN_SLEEP)) {
             uploading = true
-        } else {
-            uploading = false
         }
 
         // Wrap a bunch of commands now inside the context of a remote

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -96,6 +96,9 @@ assert params.VERSION != ""
 def newBuildID = params.VERSION
 def basearch = params.ARCH
 
+// matches between build/build-arch job
+def timeout_mins = 240
+
 // release lock: we want to block the release job until we're done.
 // ideally we'd lock this from the main pipeline and have lock ownership
 // transferred to us when we're triggered. in practice, it's very unlikely the
@@ -104,7 +107,7 @@ lock(resource: "release-${params.VERSION}-${basearch}") {
 // build lock: we don't want multiple concurrent builds for the same stream and
 // arch (though this should work fine in theory)
 lock(resource: "build-${params.STREAM}-${basearch}") {
-    timeout(time: 240, unit: 'MINUTES') {
+    timeout(time: timeout_mins, unit: 'MINUTES') {
     cosaPod(cpu: "${ncpus}",
             memory: "${cosa_memory_request_mb}Mi",
             image: cosa_controller_img,

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -1,8 +1,8 @@
 import org.yaml.snakeyaml.Yaml;
 
-def pipeutils, pipecfg, libcloud
 node {
     checkout scm
+    // these are script global vars
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
     libcloud = load("libcloud.groovy")

--- a/jobs/build-cosa.Jenkinsfile
+++ b/jobs/build-cosa.Jenkinsfile
@@ -1,8 +1,8 @@
-def pipeutils
 def gitref, commit, shortcommit
 def containername = 'coreos-assembler'
 node {
     checkout scm
+    // these are script global vars
     pipeutils = load("utils.groovy")
 }
 

--- a/jobs/build-development.Jenkinsfile
+++ b/jobs/build-development.Jenkinsfile
@@ -1,6 +1,6 @@
-def pipecfg, pipeutils
 node {
     checkout scm
+    // these are script global vars
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
 }

--- a/jobs/build-fcos-buildroot.Jenkinsfile
+++ b/jobs/build-fcos-buildroot.Jenkinsfile
@@ -1,8 +1,8 @@
-def pipeutils
 def gitref, commit, shortcommit
 def containername = 'fcos-buildroot'
 node {
     checkout scm
+    // these are script global vars
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
 }

--- a/jobs/build-mechanical.Jenkinsfile
+++ b/jobs/build-mechanical.Jenkinsfile
@@ -1,6 +1,6 @@
-def pipecfg, pipeutils
 node {
     checkout scm
+    // these are script global vars
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
 }

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -49,6 +49,9 @@ properties([
       booleanParam(name: 'NO_UPLOAD',
                    defaultValue: false,
                    description: 'Do not upload results to S3; for debugging purposes.'),
+      booleanParam(name: 'WAIT_FOR_RELEASE_JOB',
+                   defaultValue: false,
+                   description: 'Wait for the release job and propagate errors.'),
     ] + pipeutils.add_hotfix_parameters_if_supported()),
     buildDiscarder(logRotator(
         numToKeepStr: '100',
@@ -491,7 +494,7 @@ def run_release_job(buildID) {
         // Since we are only running this stage for non-production (i.e.
         // mechanical and development) builds we'll default to allowing failures
         // for additional architectures.
-        build job: 'release', wait: wait, parameters: [
+        build job: 'release', wait: params.WAIT_FOR_RELEASE_JOB, parameters: [
             string(name: 'STREAM', value: params.STREAM),
             string(name: 'ADDITIONAL_ARCHES', value: params.ADDITIONAL_ARCHES),
             string(name: 'VERSION', value: buildID),

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -109,8 +109,20 @@ currentBuild.description = "${build_description} Waiting"
 // declare these early so we can use them in `finally` block
 def newBuildID, basearch
 
+// matches between build/build-arch job
+def timeout_mins = 240
+
+if (params.WAIT_FOR_RELEASE_JOB) {
+    // Waiting for the release job effectively means waiting for all the build-
+    // arch jobs we trigger to finish. While we do overlap in execution (by
+    // a lot when EARLY_ARCH_JOBS is set), let's just simplify and add its
+    // timeout value to ours to account for this. Add 30 minutes more for the
+    // release job itself.
+    timeout_mins += timeout_mins + 30
+}
+
 lock(resource: "build-${params.STREAM}") {
-    timeout(time: 240, unit: 'MINUTES') {
+    timeout(time: timeout_mins, unit: 'MINUTES') {
     cosaPod(cpu: "${ncpus}",
             memory: "${cosa_memory_request_mb}Mi",
             image: cosa_img,

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -1,6 +1,6 @@
 import org.yaml.snakeyaml.Yaml;
 
-def pipeutils, pipecfg, uploading, libcloud
+def pipeutils, pipecfg, libcloud
 node {
     checkout scm
     pipeutils = load("utils.groovy")
@@ -126,10 +126,9 @@ lock(resource: "build-${params.STREAM}") {
 
         // Now, determine if we should do any uploads to remote s3 buckets or clouds
         // Don't upload if the user told us not to or we're debugging with KOLA_RUN_SLEEP
+        def uploading = false
         if (s3_stream_dir && (!params.NO_UPLOAD || params.KOLA_RUN_SLEEP)) {
             uploading = true
-        } else {
-            uploading = false
         }
 
         // add any additional root CA cert before we do anything that fetches

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -503,7 +503,7 @@ def archive_ostree(version, basearch, s3_stream_dir) {
 
 def run_multiarch_jobs(arches, src_commit, version, cosa_img) {
     stage('Fork Multi-Arch Builds') {
-        for (arch in arches) {
+        parallel arches.collectEntries{arch -> [arch, {
             // We pass in FORCE=true here since if we got this far we know
             // we want to do a build even if the code tells us that there
             // are no apparent changes since the previous commit.
@@ -518,7 +518,7 @@ def run_multiarch_jobs(arches, src_commit, version, cosa_img) {
                 string(name: 'PIPECFG_HOTFIX_REPO', value: params.PIPECFG_HOTFIX_REPO),
                 string(name: 'PIPECFG_HOTFIX_REF', value: params.PIPECFG_HOTFIX_REF)
             ]
-        }
+        }]}
     }
 }
 

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -1,8 +1,8 @@
 import org.yaml.snakeyaml.Yaml;
 
-def pipeutils, pipecfg, libcloud
 node {
     checkout scm
+    // these are script global vars
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
     libcloud = load("libcloud.groovy")

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -1,6 +1,6 @@
-def pipeutils, pipecfg
 node {
     checkout scm
+    // these are script global vars
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
 }

--- a/jobs/cloud-replicate.Jenkinsfile
+++ b/jobs/cloud-replicate.Jenkinsfile
@@ -1,6 +1,6 @@
-def pipeutils, pipecfg, libcloud
 node {
     checkout scm
+    // these are script global vars
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
     libcloud = load("libcloud.groovy")

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -1,6 +1,6 @@
-def pipeutils, pipecfg
 node {
     checkout scm
+    // these are script global vars
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
 }

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -1,6 +1,6 @@
-def pipeutils, pipecfg
 node {
     checkout scm
+    // these are script global vars
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
 }

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -1,6 +1,6 @@
-def pipeutils, pipecfg
 node {
     checkout scm
+    // these are script global vars
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
 }

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -1,6 +1,6 @@
-def pipeutils, pipecfg
 node {
     checkout scm
+    // these are script global vars
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
 }

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -1,6 +1,6 @@
-def pipeutils, pipecfg
 node {
     checkout scm
+    // these are script global vars
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
 }

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -1,6 +1,6 @@
-def pipeutils, pipecfg, libcloud
 node {
     checkout scm
+    // these are script global vars
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
     libcloud = load("libcloud.groovy")

--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -1,6 +1,6 @@
-def pipecfg, pipeutils
 node {
     checkout scm
+    // these are script global vars
     pipeutils = load("utils.groovy")
     pipecfg = pipeutils.load_pipecfg()
 }

--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -304,6 +304,9 @@ def upload_to_clouds(pipecfg, basearch, buildID, stream) {
     }
 
     // Run the resulting set of uploaders in parallel
-    parallel uploaders
+    // It shouldn't take more than 45 minutes.
+    timeout(time: 45, unit: 'MINUTES') {
+        parallel uploaders
+    }
 }
 return this


### PR DESCRIPTION
Currently, if the x86_64 build succeeds, but not e.g. the aarch64 build,
a rerun of the `build` job will no-op. Salvaging the build requires
rerunning just the `build-arch` job for aarch64, and then rerunning the
`release` job. This is relatively easy for a human, but isn't very
automation-friendly.

With this patch, if we no-op but the latest build is missing builds for
some of the architectures, we automatically rerun the `build-arch` job
for those missing arches and then rerun the `release` job. This allows
the interface for automation to solely be the `build` job, and allows
transparently salvaging up-to-date but incomplete builds rather than
paying for a much costlier full rebuild on all arches.