### PR TITLE
jenkins/config: update Slack team domain

### DIFF
--- a/jenkins/config/slack.yaml
+++ b/jenkins/config/slack.yaml
@@ -1,6 +1,6 @@
 unclassified:
   slackNotifier:
-    teamDomain: coreos
+    teamDomain: redhat-internal
     tokenCredentialId: slack-api-token
     # https://github.com/jenkinsci/slack-plugin/issues/857
     room: ""


### PR DESCRIPTION
The internal Slack workspace recently was upgraded and migrated to a new name. Adapt our configs.