### PR TITLE
jobs/build-arch: only fetch generated lockfile if autolocking

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -195,16 +195,19 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
                     --url s3://${s3_stream_dir}/builds \
                     --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG}
                 """)
-                // Also fetch the x86_64 lockfile for the build we're
-                // complementing, if any. Usually, this is the same build we
-                // just fetched above, but not necessarily.
-                pipeutils.shwrapWithAWSBuildUploadCredentials("""
-                cosa buildfetch --arch=x86_64 \
-                    --build ${newBuildID} \
-                    --file manifest-lock.generated.x86_64.json \
-                    --url s3://${s3_stream_dir}/builds \
-                    --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG}
-                """)
+                if (autolock_arg != "") {
+                    // Also fetch the x86_64 lockfile for the build we're
+                    // complementing so that we can use autolocking. Usually,
+                    // this is the same build we just fetched above, but not
+                    // necessarily.
+                    pipeutils.shwrapWithAWSBuildUploadCredentials("""
+                    cosa buildfetch --arch=x86_64 \
+                        --build ${newBuildID} \
+                        --file manifest-lock.generated.x86_64.json \
+                        --url s3://${s3_stream_dir}/builds \
+                        --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG}
+                    """)
+                }
                 if (parent_version != "") {
                     // also fetch the parent version; this is used by cosa to do the diff
                     pipeutils.shwrapWithAWSBuildUploadCredentials("""

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -179,6 +179,14 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             }
         }
 
+        // enable --autolock if not in strict mode and cosa supports it
+        def autolock_arg = ""
+        if (strict_build_param == "") {
+            if (shwrapRc("cosa fetch --help |& grep -q autolock") == 0) {
+                autolock_arg = "--autolock ${params.VERSION}"
+            }
+        }
+
         // buildfetch previous build info
         stage('BuildFetch') {
             if (s3_stream_dir) {
@@ -214,13 +222,6 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
 
         // fetch from repos for the current build
         stage('Fetch') {
-            // enable --autolock if not in strict mode and cosa supports it
-            def autolock_arg = ""
-            if (strict_build_param == "") {
-                if (shwrapRc("cosa fetch --help |& grep -q autolock") == 0) {
-                    autolock_arg = "--autolock ${params.VERSION}"
-                }
-            }
             shwrap("""
             cosa fetch ${strict_build_param} ${autolock_arg}
             """)


### PR DESCRIPTION
Otherwise there's no point in fetching it. This also fixes the fact that
the `cosa buildfetch --file` switch hasn't been backported to older cosa
branches, where we don't support autolocking anyway.