### PR TITLE
jobs/build-arch: only buildupload for given arch

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -324,7 +324,8 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
                 pipeutils.shwrapWithAWSBuildUploadCredentials("""
                 cosa buildupload --skip-builds-json s3 \
                     --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
-                    --acl=${acl} ${s3_stream_dir}/builds
+                    --acl=${acl} ${s3_stream_dir}/builds \
+                    --arch=${basearch}
                 """)
                 pipeutils.bump_builds_json(
                     params.STREAM,

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -411,7 +411,8 @@ lock(resource: "build-${params.STREAM}") {
                 pipeutils.shwrapWithAWSBuildUploadCredentials("""
                 cosa buildupload --skip-builds-json s3 \
                     --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
-                    --acl=${acl} ${s3_stream_dir}/builds
+                    --acl=${acl} ${s3_stream_dir}/builds \
+                    --arch=${basearch}
                 """)
             }
         }


### PR DESCRIPTION
Commit 6c2d5a0 ("jobs/build-arch: use new autolock feature") made this job start fetching some x86_64 build metadata. This metadata should only be used as part of the autolocking feature. When uploading our build metadata for this arch, we shouldn't re-upload the x86_64 stuff since it might be outdated.