### PR TITLE
jobs/build[-arch]: fix `cosa buildupload` argument ordering

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -326,10 +326,9 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             if (uploading) {
                 def acl = pipecfg.s3.acl ?: 'public-read'
                 pipeutils.shwrapWithAWSBuildUploadCredentials("""
-                cosa buildupload --skip-builds-json s3 \
+                cosa buildupload --skip-builds-json --arch=${basearch} s3 \
                     --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
-                    --acl=${acl} ${s3_stream_dir}/builds \
-                    --arch=${basearch}
+                    --acl=${acl} ${s3_stream_dir}/builds
                 """)
                 pipeutils.bump_builds_json(
                     params.STREAM,

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -409,10 +409,9 @@ lock(resource: "build-${params.STREAM}") {
             if (uploading) {
                 def acl = pipecfg.s3.acl ?: 'public-read'
                 pipeutils.shwrapWithAWSBuildUploadCredentials("""
-                cosa buildupload --skip-builds-json s3 \
+                cosa buildupload --skip-builds-json --arch=${basearch} s3 \
                     --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
-                    --acl=${acl} ${s3_stream_dir}/builds \
-                    --arch=${basearch}
+                    --acl=${acl} ${s3_stream_dir}/builds
                 """)
             }
         }


### PR DESCRIPTION
The `--arch` switch is a top-level switch, not an `s3` subcommand
switch.

Fixes e70fb4b ("jobs/build[-arch]: only buildupload for given arch").