### PR TITLE
jobs/bump-lockfile: add --aws-config-file to buildfetch

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -131,6 +131,7 @@ lock(resource: "bump-${params.STREAM}") {
                     if (arch == "x86_64") {
                         pipeutils.shwrapWithAWSBuildUploadCredentials("""
                         cosa buildfetch --arch=${arch} --find-build-for-arch \
+                            --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
                             --url=s3://${s3_stream_dir}/builds
                         cosa fetch --update-lockfile --dry-run
                         """)
@@ -139,6 +140,7 @@ lock(resource: "bump-${params.STREAM}") {
                             arch: arch, session: archinfo[arch]['session']) {
                             pipeutils.shwrapWithAWSBuildUploadCredentials("""
                             cosa buildfetch --arch=${arch} --find-build-for-arch \
+                                --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
                                 --url=s3://${s3_stream_dir}/builds
                             cosa fetch --update-lockfile --dry-run
                             cosa remote-session sync {:,}src/config/manifest-lock.${arch}.json


### PR DESCRIPTION
On the remote builders the credentials file is laid down on the filesystem so let's specify the path to it.