### PR TITLE
config: add `source_config.yumrepos_ref`

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -7,6 +7,8 @@ source_config:
   ref: release-${STREAM}
   # OPTIONAL: git repo URL for yumrepos
   yumrepos: https://gitlab.example.com/sooper/seekret
+  # OPTIONAL: git repo ref for yumrepos
+  yumrepos_ref: devel
 
 # OPTIONAL: default artifacts to build per architecture
 default_artifacts:

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -140,9 +140,10 @@ lock(resource: "build-${params.STREAM}") {
 
         stage('Init') {
             def yumrepos = pipecfg.source_config.yumrepos ? "--yumrepos ${pipecfg.source_config.yumrepos}" : ""
+            def yumrepos_ref = pipecfg.source_config.yumrepos_ref ? "--yumrepos-branch ${pipecfg.source_config.yumrepos_ref}" : ""
             def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
             shwrap("""
-            cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${variant} ${pipecfg.source_config.url}
+            cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${yumrepos_ref} ${variant} ${pipecfg.source_config.url}
             """)
 
             // for now, just use the PVC to keep cache.qcow2 in a stream-specific dir


### PR DESCRIPTION
This allows specifying a different ref than the default when cloning the yumrepos git repo. We're only planning to use this in the hotfix path for RHCOS.