### PR TITLE
jobs/bump-lockfile: lower number of artifacts to keep

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -29,7 +29,7 @@ properties([
     ]),
     buildDiscarder(logRotator(
         numToKeepStr: '100',
-        artifactNumToKeepStr: '100'
+        artifactNumToKeepStr: '30'
     )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])


### PR DESCRIPTION
This job was taking up 7G of storage on the PVC in the FCOS pipeline. Since it runs tests on all architectures it will naturally take up way more storage as it archives all of those kola logs. Let's lower the number of artifacts it stores to 30 to alleviate this storage usage.