### PR TITLE
jobs: include hotfix name in Slack notifications

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -393,7 +393,11 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
     throw e
 } finally {
     def color
-    def message = "[${params.STREAM}][${basearch}] <${env.BUILD_URL}|${env.BUILD_NUMBER}>"
+    def stream = params.STREAM
+    if (pipecfg.hotfix) {
+        stream += "-${pipecfg.hotfix.name}"
+    }
+    def message = "[${stream}][${basearch}] <${env.BUILD_URL}|${env.BUILD_NUMBER}>"
 
     if (currentBuild.result == 'SUCCESS') {
         if (!newBuildID) {

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -484,7 +484,11 @@ lock(resource: "build-${params.STREAM}") {
     throw e
 } finally {
     def color
-    def message = "[${params.STREAM}][${basearch}] <${env.BUILD_URL}|${env.BUILD_NUMBER}>"
+    def stream = params.STREAM
+    if (pipecfg.hotfix) {
+        stream += "-${pipecfg.hotfix.name}"
+    }
+    def message = "[${stream}][${basearch}] <${env.BUILD_URL}|${env.BUILD_NUMBER}>"
 
     if (currentBuild.result == 'SUCCESS') {
         if (!newBuildID) {

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -378,5 +378,9 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    pipeutils.trySlackSend(message: ":bullettrain_front: release <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${params.STREAM}][${basearches.join(' ')}] (${params.VERSION})")
+    def stream = params.STREAM
+    if (pipecfg.hotfix) {
+        stream += "-${pipecfg.hotfix.name}"
+    }
+    pipeutils.trySlackSend(message: ":bullettrain_front: release <${env.BUILD_URL}|#${env.BUILD_NUMBER}> [${stream}][${basearches.join(' ')}] (${params.VERSION})")
 }}} // try-catch-finally, cosaPod and lock finish here


### PR DESCRIPTION
Otherwise, the Slack notifications look just like the regular ones for the official streams the hotfix build is based on. We noticed this when testing the hotfix workflow recently.