### PR TITLE
RFC: config: add `streams[].skip_cloud_images`

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -64,6 +64,9 @@ streams:
       type: production
       # OPTIONAL: override cosa image to use for this stream
       cosa_image: "quay.io/jlebon/coreos-assembler:stable"
+      # OPTIONAL: Whether to skip cloud image generation and upload. This is
+      # equivalent to listing all cloud platforms in `skip_artifacts`.
+      skip_cloud_images: true
       # OPTIONAL: skip some of the default artifacts for this stream
       skip_artifacts:
         aarch64:

--- a/utils.groovy
+++ b/utils.groovy
@@ -355,6 +355,13 @@ def get_artifacts_to_build(pipecfg, stream, basearch) {
         artifacts -= pipecfg.streams[stream].skip_artifacts?.all ?: []
         artifacts -= pipecfg.streams[stream].skip_artifacts?."${basearch}" ?: []
     }
+    if (pipecfg.streams[stream].skip_cloud_images) {
+        // Only keep containers and live artifacts. Note that the ostree
+        // container and QEMU image are always built and not skippable
+        // artifacts.
+        artifacts = artifacts.intersect(["extensions-container", "legacy-oscontainer",
+                                         "live", "metal", "metal4k"])
+    }
     return artifacts.unique()
 }
 


### PR DESCRIPTION
In RHCOS, we're often in a state where we don't care about regenerating all the disk images and instead just want the containers. We could do this by manually adding all the images we don't care about as `skip_artifacts` entries, but that's cumbersome and error-prone.

Add a `skip_cloud_images` knob for this. We still generate the QEMU and live artifacts for kola tests to run and because they're useful to debug, but we drop everything else.