### PR TITLE
updates for Azure credential handling

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -187,31 +187,29 @@ NOTE: For the prod pipeline these secrets can be found in BitWarden
 
 ### [OPTIONAL] Creating Azure credentials configs
 
-If you want to run kola tests against Azure images you need to
-create a secret with an `azureProfile.json` and a file called an
-azure auth file. See the
+If you want to do image uploads or run kola tests against Azure
+images you need to create a file called `azureCreds.json`. See the
 [kola docs](https://github.com/coreos/coreos-assembler/blob/main/docs/mantle/credentials.md#azure)
 for more information on those files.
 
-Once you have the azureAuth.json and azureProfile.json for connecting to Azure,
-create the secrets in OpenShift:
+Once you have the azureCreds.json for connecting to Azure, create the secrets in OpenShift:
 
 ```
-oc create secret generic azure-kola-tests-config-profile \
-    --from-literal=filename=azureProfile.json \
-    --from-file=data=/path/to/azureProfile.json
-oc label secret/azure-kola-tests-config-profile \
+oc create secret generic azure-image-upload-config \
+    --from-literal=filename=azure_config_file \
+    --from-file=data=/path/to/upload-secret
+oc label secret/azure-image-upload-config \
     jenkins.io/credentials-type=secretFile
-oc annotate secret/azure-kola-tests-config-profile \
-    jenkins.io/credentials-description="Azure kola tests azureProfile.json"
+oc annotate secret/azure-image-upload-config \
+    jenkins.io/credentials-description="Azure image upload credentials config"
 
-oc create secret generic azure-kola-tests-config-auth \
-    --from-literal=filename=azureAuth.json \
-    --from-file=data=/path/to/azureAuth.json
-oc label secret/azure-kola-tests-config-auth \
+oc create secret generic azure-kola-tests-config \
+    --from-literal=filename=azure_config_file \
+    --from-file=data=/path/to/kola-secret
+oc label secret/azure-kola-tests-config \
     jenkins.io/credentials-type=secretFile
-oc annotate secret/azure-kola-tests-config-auth \
-    jenkins.io/credentials-description="Azure kola tests azureAuth.json"
+oc annotate secret/azure-kola-tests-config \
+    jenkins.io/credentials-description="Azure kola tests credentials config"
 ```
 
 NOTE: For the prod pipeline these secrets can be found in BitWarden

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -86,10 +86,8 @@ timeout(time: 75, unit: 'MINUTES') {
             azure_image_name = "kola-fedora-coreos-${params.STREAM}-${params.ARCH}.vhd"
         }
 
-        withCredentials([file(variable: 'AZURE_KOLA_TESTS_CONFIG_PROFILE',
-                              credentialsId: 'azure-kola-tests-config-profile'),
-                         file(variable: 'AZURE_KOLA_TESTS_CONFIG_AUTH',
-                              credentialsId: 'azure-kola-tests-config-auth')]) {
+        withCredentials([file(variable: 'AZURE_KOLA_TESTS_CONFIG',
+                              credentialsId: 'azure-kola-tests-config')]) {
 
             def azure_testing_resource_group = pipecfg.clouds?.azure?.test_resource_group
             def azure_testing_storage_account = pipecfg.clouds?.azure?.test_storage_account
@@ -100,14 +98,12 @@ timeout(time: 75, unit: 'MINUTES') {
                 shwrap("""
                 # First delete the blob/image since we re-use it.
                 ore azure delete-image --log-level=INFO                 \
-                    --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
-                    --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
+                    --azure-credentials \${AZURE_KOLA_TESTS_CONFIG}     \
                     --azure-location $region                            \
                     --resource-group ${azure_testing_resource_group}    \
                     --image-name ${azure_image_name}
                 ore azure delete-blob --log-level=INFO                  \
-                    --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
-                    --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
+                    --azure-credentials \${AZURE_KOLA_TESTS_CONFIG}     \
                     --azure-location $region                            \
                     --resource-group $azure_testing_resource_group      \
                     --storage-account $azure_testing_storage_account    \
@@ -115,8 +111,7 @@ timeout(time: 75, unit: 'MINUTES') {
                     --blob-name $azure_image_name
                 # Then create them fresh
                 ore azure upload-blob --log-level=INFO                  \
-                    --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
-                    --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
+                    --azure-credentials \${AZURE_KOLA_TESTS_CONFIG}     \
                     --azure-location $region                            \
                     --resource-group $azure_testing_resource_group      \
                     --storage-account $azure_testing_storage_account    \
@@ -124,8 +119,7 @@ timeout(time: 75, unit: 'MINUTES') {
                     --blob-name $azure_image_name                       \
                     --file ${azure_image_filepath}
                 ore azure create-image --log-level=INFO                 \
-                    --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
-                    --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
+                    --azure-credentials \${AZURE_KOLA_TESTS_CONFIG}     \
                     --resource-group $azure_testing_resource_group      \
                     --azure-location $region                            \
                     --image-name $azure_image_name                      \
@@ -136,14 +130,13 @@ timeout(time: 75, unit: 'MINUTES') {
             // Since we don't have permanent images uploaded to Azure we'll
             // skip the upgrade test.
             try {
-                def azure_subscription = shwrapCapture("jq -r .subscriptionId \${AZURE_KOLA_TESTS_CONFIG_AUTH}")
+                def azure_subscription = shwrapCapture("jq -r .subscription \${AZURE_KOLA_TESTS_CONFIG}")
                 kola(cosaDir: env.WORKSPACE, parallel: 10,
                      build: params.VERSION, arch: params.ARCH,
                      extraArgs: params.KOLA_TESTS,
                      skipUpgrade: true,
                      platformArgs: """-p=azure                               \
-                         --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
-                         --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
+                         --azure-credentials \${AZURE_KOLA_TESTS_CONFIG}     \
                          --azure-location $region                            \
                          --azure-disk-uri /subscriptions/${azure_subscription}/resourceGroups/${azure_testing_resource_group}/providers/Microsoft.Compute/images/${azure_image_name}""")
             } finally {
@@ -151,14 +144,12 @@ timeout(time: 75, unit: 'MINUTES') {
                     // Delete the image in Azure
                     shwrap("""
                     ore azure delete-image --log-level=INFO                 \
-                        --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
-                        --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
+                        --azure-credentials \${AZURE_KOLA_TESTS_CONFIG}     \
                         --azure-location $region                            \
                         --resource-group $azure_testing_resource_group      \
                         --image-name $azure_image_name
                     ore azure delete-blob --log-level=INFO                  \
-                        --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
-                        --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
+                        --azure-credentials \${AZURE_KOLA_TESTS_CONFIG}     \
                         --azure-location $region                            \
                         --resource-group $azure_testing_resource_group      \
                         --storage-account $azure_testing_storage_account    \
@@ -168,8 +159,7 @@ timeout(time: 75, unit: 'MINUTES') {
                 }, "Garbage Collection": {
                     shwrap("""
                     ore azure gc --log-level=INFO                           \
-                        --azure-auth \${AZURE_KOLA_TESTS_CONFIG_AUTH}       \
-                        --azure-profile \${AZURE_KOLA_TESTS_CONFIG_PROFILE} \
+                        --azure-credentials \${AZURE_KOLA_TESTS_CONFIG}     \
                         --azure-location $region
                     """)
                 }

--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -186,23 +186,19 @@ def upload_to_clouds(pipecfg, basearch, buildID, stream) {
         }
     }
 
-    credentials = [file(variable: 'AZURE_IMAGE_UPLOAD_CONFIG_AUTH',
-                        credentialsId: 'azure-image-upload-config-auth'),
-                   file(variable: 'AZURE_IMAGE_UPLOAD_CONFIG_PROFILE',
-                        credentialsId: 'azure-image-upload-config-profile')]
+    credentials = [file(variable: 'AZURE_IMAGE_UPLOAD_CONFIG',
+                        credentialsId: 'azure-image-upload-config')]
     if (pipecfg.clouds?.azure &&
         artifacts.contains("azure") &&
         utils.credentialsExist(credentials)) {
         def creds = credentials
         uploaders["☁️ ⬆️ :azure"] = {
             withCredentials(creds) {
-                utils.syncCredentialsIfInRemoteSession(["AZURE_IMAGE_UPLOAD_CONFIG_AUTH",
-                                                        "AZURE_IMAGE_UPLOAD_CONFIG_PROFILE"])
+                utils.syncCredentialsIfInRemoteSession(["AZURE_IMAGE_UPLOAD_CONFIG"])
                 def c = pipecfg.clouds.azure
                 shwrap("""cosa buildextend-azure \
                     --upload \
-                    --auth \${AZURE_IMAGE_UPLOAD_CONFIG_AUTH} \
-                    --profile \${AZURE_IMAGE_UPLOAD_CONFIG_PROFILE} \
+                    --credentials \${AZURE_IMAGE_UPLOAD_CONFIG} \
                     --build=${buildID} \
                     --resource-group ${c.resource_group} \
                     --storage-account ${c.storage_account} \


### PR DESCRIPTION
This PR updates our Azure credential docs and handling to match what was implemented in https://github.com/coreos/coreos-assembler/pull/3349

Mainly we now only need one `azureCreds.json` file for authentication (this means Azure is now more like the others that only need a single file for authentication) and we must update CLI calls to use --azure-credentials.