### PR TITLE
Add hyperv to default artifacts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -68,6 +68,7 @@ default_artifacts:
     - digitalocean
     - exoscale
     - gcp
+    - hyperv
     - ibmcloud
     - nutanix
     - virtualbox


### PR DESCRIPTION
Supports:

  * https://github.com/coreos/fedora-coreos-tracker/issues/1411
  * https://github.com/coreos/fedora-coreos-tracker/issues/1421