### PR TITLE
config: skip hashlist generation on rawhide/branched

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,8 +21,16 @@ streams:
       # type: development # do not touch; line managed by `next-devel/manage.py`
     rawhide:
       type: mechanical
+      skip_artifacts:
+        all:
+          # https://github.com/coreos/fedora-coreos-tracker/issues/1429
+          - hashlist-experimental
     branched:
       type: mechanical
+      skip_artifacts:
+        all:
+          # https://github.com/coreos/fedora-coreos-tracker/issues/1429
+          - hashlist-experimental
     # bodhi-updates:
     #   type: mechanical
     # bodhi-updates-testing:


### PR DESCRIPTION
A newer systemd has introduced a file that is causing the command to fail. Let's skip it on rawhide/branched while we investigate. See: https://github.com/coreos/fedora-coreos-tracker/issues/1429