### PR TITLE
jobs/kola-{azure,openstack}: bump memory again for decompress jobs

### DIFF
--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -48,8 +48,8 @@ def region = "eastus"
 
 def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
-// Go with 1.5Gi here because we download/decompress/upload the image
-def cosa_memory_request_mb = 1536
+// Go with a higher memory request here because we download/decompress/upload the image
+def cosa_memory_request_mb = 1792
 
 
 timeout(time: 75, unit: 'MINUTES') {
@@ -74,7 +74,7 @@ timeout(time: 75, unit: 'MINUTES') {
                 cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
                     --url=s3://${s3_stream_dir}/builds --artifact=azure
                 """)
-                pipeutils.withXzMemLimit(cosa_memory_request_mb - 256) {
+                pipeutils.withXzMemLimit(cosa_memory_request_mb - 512) {
                     shwrap("cosa decompress --build=${params.VERSION} --artifact=azure")
                 }
                 azure_image_filepath = shwrapCapture("""

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -49,8 +49,8 @@ def region = "ca-ymq-1"
 
 def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
-// Go with 1.5Gi here because we download/decompress/upload the image
-def cosa_memory_request_mb = 1536
+// Go with a higher memory request here because we download/decompress/upload the image
+def cosa_memory_request_mb = 1792
 
 // Locking so we only run max of 2 runs (1 x86_64 and 1 aarch64) at any given time.
 lock(resource: "kola-openstack-${params.ARCH}") {
@@ -76,7 +76,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
                 cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
                     --url=s3://${s3_stream_dir}/builds --artifact=openstack
                 """)
-                pipeutils.withXzMemLimit(cosa_memory_request_mb - 256) {
+                pipeutils.withXzMemLimit(cosa_memory_request_mb - 512) {
                     shwrap("cosa decompress --build=${params.VERSION} --artifact=openstack")
                 }
                 openstack_image_filepath = shwrapCapture("""


### PR DESCRIPTION
We still occasionally hit issues where these jobs get SIGKILLed from the pipeline. I ran a profile recently with `time -v` and this is what I saw:

```
+ /usr/bin/time -v cosa decompress --build=39.20230222.91.0 --artifact=azure
Targeting build: 39.20230222.91.0
Uncompressing: builds/39.20230222.91.0/x86_64
2023-02-22 15:09:11,423 INFO - Running command: ['xz', '-dc', '-T2', 'builds/39.20230222.91.0/x86_64/fedora-coreos-39.20230222.91.0-azure.x86_64.vhd.xz']
Uncompressed: fedora-coreos-39.20230222.91.0-azure.x86_64.vhd
Skipped uncompressing artifacts: ostree nutanix vmware virtualbox gcp digitalocean live-iso live-kernel live-initramfs live-rootfs
Updated: builds/39.20230222.91.0/x86_64/meta.json
Skipping missing arch: s390x
	Command being timed: "cosa decompress --build=39.20230222.91.0 --artifact=azure"
	User time (seconds): 52.19
	System time (seconds): 7.22
	Percent of CPU this job got: 163%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:36.25
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 1189584
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 1
	Minor (reclaiming a frame) page faults: 348869
	Voluntary context switches: 14910
	Involuntary context switches: 1876
	Swaps: 0
	File system inputs: 2035520
	File system outputs: 3451960
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

In that run the decompress only used 1161 MiB, which means the 1280 MiB we're alotting should be enough. I also think if we were going higher than the 1280 then xz would tell us:

```
$ xz --decompress -M 1MiB fedora-coreos-31.20200517.3.0-metal.x86_64.raw.xz
xz: fedora-coreos-31.20200517.3.0-metal.x86_64.raw.xz: Memory usage limit reached
xz: 1 MiB of memory is required. The limit is 1 MiB.
```

So it must mean that other processes are using more than 256 MiB of memory. Let's just give the other processes more and see what happens.