### PR TITLE
manifests/jenkins: bump jnlp memory to 512Mi

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -88,15 +88,19 @@ objects:
           # https://github.com/coreos/coreos-ci/issues/28
           # DELTA: Set the default JNLP image to our Jenkins agent imagestream.
           # https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/cloudbees-ci-on-modern-cloud-platforms/change-the-default-jnlp-image-for-kubernetes-agents-provisioning#_system_property_approach
+          # We hard set a memory limit so that we don't get the default for the
+          # limitrange in this project we happen to be in, which is likely to be
+          # too generous. The default upstream memory *request* is 256Mi, which
+          # is too little as a limit.
           - name: JENKINS_JAVA_OVERRIDES
             value: >-
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=900
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true
               -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage=jenkins-agent-base:latest
               -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultCpuRequest=1
-              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultMemoryRequest=256Mi
+              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultMemoryRequest=512Mi
               -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultCpuLimit=1
-              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultMemoryLimit=256Mi
+              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultMemoryLimit=512Mi
           # DELTA: Increase session timeout to 24h (for docs on each field, see:
           # https://support.cloudbees.com/hc/en-us/articles/4406750806427)
           - name: JENKINS_OPTS


### PR DESCRIPTION
By default, the jnlp container has a memory request of 256Mi and no
memory limit. In 9eed927 ("manifests/jenkins: set resource limits and
requests for jnlp container"), we added an explicit memory limit so that
we don't inherit the default 10G memory limit from the limitrange in
the RHCOS OpenShift project. We set it to 256Mi since that's what the
default memory *request* was, but it's too little as a hard limit. Most
of the time, the jnlp unexplicably dies, but at least once, I saw it
fail with:

```
java.lang.OutOfMemoryError: unable to create native thread: possibly out of memory or process/resource limits reached
```

Bump it to 512Mi. And also bump the request since in this project we try
to have requests match what the pod actually needs.

While we're here, add a comment about why we set these values.

Fixes https://github.com/coreos/coreos-assembler/issues/3372.

