### PR TITLE
jobs/build: verify kernel + kernel-rt versions match in rhcos

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -231,3 +231,5 @@ clouds:
 misc:
   # OPTIONAL: whether to generate a release index
   generate_release_index: true
+  # OPTIONAL: require kernel + kernel-rt versions to match
+  check_kernel_rt_mismatch_rhcos: true

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -347,6 +347,19 @@ lock(resource: "build-${params.STREAM}") {
         // Build the remaining artifacts
         stage("Build Artifacts") {
             pipeutils.build_artifacts(pipecfg, params.STREAM, basearch)
+
+            // Stop the build if the kernel + kernel-rt versions do not match.
+            // This check runs on x86_64 RHCOS builds only.
+            // NOTE: This approach only checks the legacy extensions and not the new extensions
+            // container. This check can be removed for 9.3+ builds when we drop the legacy
+            // oscontainer as the versions will be matched using `match-base-evr` in `extensions.yaml`.
+            if (pipecfg.misc?.check_kernel_rt_mismatch_rhcos) {
+                echo("Verifying kernel + kernel-rt versions match")
+                def build_meta = [readJSON(file: "builds/latest/${basearch}/commitmeta.json"), readJSON(file: "builds/latest/${basearch}/meta.json")]
+                def kernel_version = build_meta[0]['ostree.linux'].split('.el')[0]
+                def kernel_rt_version = build_meta[1]['extensions']['manifest']['kernel-rt-core'].split('.rt')[0]
+                assert kernel_version == kernel_rt_version : "kernel-rt version: ${kernel_rt_version} does not match kernel version: ${kernel_version}"
+            }
         }
 
         // Run Kola TestISO tests for metal artifacts


### PR DESCRIPTION
The old RHCOS pipeline had a mechanism for checking if the kernel and kernel-rt packages were built from the same version and failing if they were not. The check was never migrated over to the new RHCOS pipeline. Add the check to verify that the kernel and kernel-rt are of the same version and stop the pipeline if there is a version mismatch. Also add an optional field in the stream section of `config.yaml`  to enable, disable this check. 

By default, the check will not run unless the optional field `check_kernel_rt_mismatch` is set to true. This will ensure the check will not run against FCOS builds.

See: https://issues.redhat.com/browse/COS-2021