### PR TITLE
Revert "config: skip hashlist generation on rawhide/branched"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,16 +21,8 @@ streams:
       # type: development # do not touch; line managed by `next-devel/manage.py`
     rawhide:
       type: mechanical
-      skip_artifacts:
-        all:
-          # https://github.com/coreos/fedora-coreos-tracker/issues/1429
-          - hashlist-experimental
     branched:
       type: mechanical
-      skip_artifacts:
-        all:
-          # https://github.com/coreos/fedora-coreos-tracker/issues/1429
-          - hashlist-experimental
     # bodhi-updates:
     #   type: mechanical
     # bodhi-updates-testing:


### PR DESCRIPTION
This reverts commit 3a94202df28ca4604232254c4579e99c859c19c1.

The underlying problem should have been fixed by
https://github.com/coreos/coreos-assembler/pull/3386