### PR TITLE
config: re-enable next-devel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,8 +17,8 @@ streams:
     testing-devel:
       type: development
       default: true
-    # next-devel:         # do not touch; line managed by `next-devel/manage.py`
-      # type: development # do not touch; line managed by `next-devel/manage.py`
+    next-devel:         # do not touch; line managed by `next-devel/manage.py`
+      type: development # do not touch; line managed by `next-devel/manage.py`
     rawhide:
       type: mechanical
     branched:

--- a/next-devel/badge.json
+++ b/next-devel/badge.json
@@ -2,6 +2,6 @@
     "schemaVersion": 1,
     "style": "for-the-badge",
     "label": "next-devel",
-    "message": "closed",
-    "color": "lightgrey"
+    "message": "open",
+    "color": "green"
 }

--- a/next-devel/status.json
+++ b/next-devel/status.json
@@ -1,3 +1,3 @@
 {
-    "enabled": false
+    "enabled": true
 }


### PR DESCRIPTION
The Fedora Linux 38 beta release is next week so `next-devel` and `next` are moving over to Fedora 38 content. Re-enable `next-devel` to allow it to differ from `testing-devel`.