### PR TITLE
config: disable `branched` stream

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,8 +21,8 @@ streams:
       type: development # do not touch; line managed by `next-devel/manage.py`
     rawhide:
       type: mechanical
-    branched:
-      type: mechanical
+    # branched:
+    #   type: mechanical
     # bodhi-updates:
     #   type: mechanical
     # bodhi-updates-testing:


### PR DESCRIPTION
`next-devel` is now on Fedora 38 so there's no point in also tracking it in the `branched` stream.