### PR TITLE
jobs: do `cosa buildfetch` with `time -v` when fetching large objects

### DIFF
--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -62,7 +62,7 @@ timeout(time: 90, unit: 'MINUTES') {
                 def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                 shwrap("""
                 cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
-                cosa buildfetch --artifact=ostree --build=${params.VERSION} \
+                time -v cosa buildfetch --artifact=ostree --build=${params.VERSION} \
                     --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds
                 """)
             }

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -71,7 +71,7 @@ timeout(time: 75, unit: 'MINUTES') {
                 def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                 shwrap("""
                 cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
-                cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
+                time -v cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
                     --url=s3://${s3_stream_dir}/builds --artifact=azure
                 """)
                 pipeutils.withXzMemLimit(cosa_memory_request_mb - 512) {

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -62,7 +62,7 @@ timeout(time: 30, unit: 'MINUTES') {
                 def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                 shwrap("""
                 cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
-                cosa buildfetch --artifact=ostree --build=${params.VERSION} \
+                time -v cosa buildfetch --artifact=ostree --build=${params.VERSION} \
                     --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds
                 """)
             }

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -73,7 +73,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
                 def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                 shwrap("""
                 cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
-                cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
+                time -v cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
                     --url=s3://${s3_stream_dir}/builds --artifact=openstack
                 """)
                 pipeutils.withXzMemLimit(cosa_memory_request_mb - 512) {

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -142,7 +142,7 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
             fetch_args += fetch_artifacts.collect{"--artifact=${it}"}
 
             pipeutils.shwrapWithAWSBuildUploadCredentials("""
-            cosa buildfetch --build=${params.VERSION} \
+            time -v cosa buildfetch --build=${params.VERSION} \
                 --url=s3://${s3_stream_dir}/builds    \
                 --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
                 ${fetch_args.join(' ')}


### PR DESCRIPTION
On `cosa buildfetch` invocations that fetch large objects, add `time -v` so we get a picture of how much memory the operation took. We're occasionally hitting what looks like OOM issues, but before either increasing our memory requests or tweaking S3 download settings, let's sanity-check first that's what's happening.