### PR TITLE
jobs: nest timeout within `cosaPod`

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -107,11 +107,11 @@ lock(resource: "release-${params.VERSION}-${basearch}") {
 // build lock: we don't want multiple concurrent builds for the same stream and
 // arch (though this should work fine in theory)
 lock(resource: "build-${params.STREAM}-${basearch}") {
-    timeout(time: timeout_mins, unit: 'MINUTES') {
     cosaPod(cpu: "${ncpus}",
             memory: "${cosa_memory_request_mb}Mi",
             image: cosa_controller_img,
             serviceAccount: "jenkins") {
+    timeout(time: timeout_mins, unit: 'MINUTES') {
     try {
 
         currentBuild.description = "${build_description} Running"

--- a/jobs/build-cosa.Jenkinsfile
+++ b/jobs/build-cosa.Jenkinsfile
@@ -91,10 +91,10 @@ currentBuild.description = "[${gitref}@${shortcommit}] Waiting"
 def basearches = params.ARCHES.split() as Set
 
 lock(resource: "build-${containername}") {
-    timeout(time: 60, unit: 'MINUTES') {
     cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
             memory: "512Mi", kvm: false,
             serviceAccount: "jenkins") {
+    timeout(time: 60, unit: 'MINUTES') {
     try {
 
         currentBuild.description = "[${gitref}@${shortcommit}] Running"

--- a/jobs/build-fcos-buildroot.Jenkinsfile
+++ b/jobs/build-fcos-buildroot.Jenkinsfile
@@ -102,10 +102,10 @@ currentBuild.description = "[${gitref}@${shortcommit}] Waiting"
 def basearches = params.ARCHES.split() as Set
 
 lock(resource: "build-${containername}") {
-    timeout(time: 60, unit: 'MINUTES') {
     cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
             memory: "256Mi", kvm: false,
             serviceAccount: "jenkins") {
+    timeout(time: 60, unit: 'MINUTES') {
     try {
 
         currentBuild.description = "[${gitref}@${shortcommit}] Running"

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -122,11 +122,11 @@ if (params.WAIT_FOR_RELEASE_JOB) {
 }
 
 lock(resource: "build-${params.STREAM}") {
-    timeout(time: timeout_mins, unit: 'MINUTES') {
     cosaPod(cpu: "${ncpus}",
             memory: "${cosa_memory_request_mb}Mi",
             image: cosa_img,
             serviceAccount: "jenkins") {
+    timeout(time: timeout_mins, unit: 'MINUTES') {
     try {
 
         basearch = shwrapCapture("cosa basearch")

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -63,10 +63,10 @@ def cosa_memory_request_mb = 10.5 * 1024 as Integer
 def ncpus = ((cosa_memory_request_mb - 512) / 1536) as Integer
 
 lock(resource: "bump-${params.STREAM}") {
-    timeout(time: 120, unit: 'MINUTES') { 
     cosaPod(image: cosa_img,
             cpu: "${ncpus}", memory: "${cosa_memory_request_mb}Mi",
             serviceAccount: "jenkins") {
+    timeout(time: 120, unit: 'MINUTES') { 
     try {
 
         currentBuild.description = "[${params.STREAM}] Running"

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -45,10 +45,10 @@ def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
 def stream_info = pipecfg.streams[params.STREAM]
 
-timeout(time: 90, unit: 'MINUTES') {
-    cosaPod(memory: "512Mi", kvm: false,
-            image: params.COREOS_ASSEMBLER_IMAGE,
-            serviceAccount: "jenkins") {
+cosaPod(memory: "512Mi", kvm: false,
+        image: params.COREOS_ASSEMBLER_IMAGE,
+        serviceAccount: "jenkins") {
+    timeout(time: 90, unit: 'MINUTES') {
     try {
 
         stage('Fetch Metadata') {

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -52,10 +52,10 @@ def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 def cosa_memory_request_mb = 1792
 
 
-timeout(time: 75, unit: 'MINUTES') {
-    cosaPod(memory: "${cosa_memory_request_mb}Mi", kvm: false,
-            image: params.COREOS_ASSEMBLER_IMAGE,
-            serviceAccount: "jenkins") {
+cosaPod(memory: "${cosa_memory_request_mb}Mi", kvm: false,
+        image: params.COREOS_ASSEMBLER_IMAGE,
+        serviceAccount: "jenkins") {
+    timeout(time: 75, unit: 'MINUTES') {
     try {
 
         def azure_image_name, azure_image_filepath

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -45,10 +45,10 @@ def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
 def stream_info = pipecfg.streams[params.STREAM]
 
-timeout(time: 30, unit: 'MINUTES') {
-    cosaPod(memory: "512Mi", kvm: false,
-            image: params.COREOS_ASSEMBLER_IMAGE,
-            serviceAccount: "jenkins") {
+cosaPod(memory: "512Mi", kvm: false,
+        image: params.COREOS_ASSEMBLER_IMAGE,
+        serviceAccount: "jenkins") {
+    timeout(time: 30, unit: 'MINUTES') {
     try {
 
         stage('Fetch Metadata') {

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -41,10 +41,10 @@ def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
 def stream_info = pipecfg.streams[params.STREAM]
 
-timeout(time: 60, unit: 'MINUTES') {
-    cosaPod(memory: "512Mi", kvm: false,
-            image: params.COREOS_ASSEMBLER_IMAGE,
-            serviceAccount: "jenkins") {
+cosaPod(memory: "512Mi", kvm: false,
+        image: params.COREOS_ASSEMBLER_IMAGE,
+        serviceAccount: "jenkins") {
+    timeout(time: 60, unit: 'MINUTES') {
     try {
 
         stage('Fetch Metadata') {

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -54,10 +54,10 @@ def cosa_memory_request_mb = 1792
 
 // Locking so we only run max of 2 runs (1 x86_64 and 1 aarch64) at any given time.
 lock(resource: "kola-openstack-${params.ARCH}") {
-    timeout(time: 90, unit: 'MINUTES') {
     cosaPod(memory: "${cosa_memory_request_mb}Mi", kvm: false,
             image: params.COREOS_ASSEMBLER_IMAGE,
             serviceAccount: "jenkins") {
+    timeout(time: 90, unit: 'MINUTES') {
     try {
 
         def openstack_image_name, openstack_image_filepath


### PR DESCRIPTION
Getting the resources for the cosa pod might take time if there's lots of concurrent builds in progress filling our quota. That wait time shouldn't count towards the timeout. Flip the scoping order so that the timeout starts only when we actually have the pod.

This is most problematic in the `build` job where we allocate pods with lots of resources. But for consistency, do this in all our jobs.