### PR TITLE
config: support per-stream `skip_cloud_uploads` knob

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -93,6 +93,8 @@ streams:
       # configured. Can be dropped when RHCOS 4.9 (last release that doesn't
       # support GovCloud) is EOL.
       skip_govcloud_hack: true
+      # OPTIONAL/TEMPORARY: don't upload images to clouds
+      skip_cloud_uploads: true
 
 # REQUIRED: architectures to build for other than x86_64
 additional_arches: [aarch64, ppc64le, s390x]

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -316,7 +316,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
 
         // Upload to relevant clouds
         // XXX: we don't support cloud uploads yet for hotfixes
-        if (uploading && !pipecfg.hotfix) {
+        if (uploading && !pipecfg.hotfix && !stream_info.skip_cloud_uploads) {
             stage('Cloud Upload') {
                 libcloud.upload_to_clouds(pipecfg, basearch, newBuildID, params.STREAM)
             }

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -369,7 +369,7 @@ lock(resource: "build-${params.STREAM}") {
 
         // Upload to relevant clouds
         // XXX: we don't support cloud uploads yet for hotfixes
-        if (uploading && !pipecfg.hotfix) {
+        if (uploading && !pipecfg.hotfix && !stream_info.skip_cloud_uploads) {
             stage('Cloud Upload') {
                 libcloud.upload_to_clouds(pipecfg, basearch, newBuildID, params.STREAM)
             }


### PR DESCRIPTION
While working with unreleased content, we don't want any publicly accessible artifacts. This includes cloud images. Add a `skip_cloud_uploads` key for this.

This is temporary to unblock the RHEL 9.2 work. I think what would be nicer here instead is to still upload to clouds but keep the images private. However, we need to add a `--public` knob to some of the cloud commands we use first.

Another option worth investigating is support for overriding the base `cloud` key entirely like we have for some other keys.