### PR TITLE
jobs: pass fully qualified ref name to `git ls-remote`

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -151,7 +151,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         if (params.SRC_CONFIG_COMMIT) {
             src_config_commit = params.SRC_CONFIG_COMMIT
         } else {
-            src_config_commit = shwrapCapture("git ls-remote ${pipecfg.source_config.url} ${ref} | cut -d \$'\t' -f 1")
+            src_config_commit = shwrapCapture("git ls-remote ${pipecfg.source_config.url} refs/heads/${ref} | cut -d \$'\t' -f 1")
         }
 
         stage('Init') {

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -150,7 +150,7 @@ lock(resource: "build-${params.STREAM}") {
         pipeutils.addOptionalRootCA()
 
         def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
-        def src_config_commit = shwrapCapture("git ls-remote ${pipecfg.source_config.url} ${ref} | cut -d \$'\t' -f 1")
+        def src_config_commit = shwrapCapture("git ls-remote ${pipecfg.source_config.url} refs/heads/${ref} | cut -d \$'\t' -f 1")
 
         stage('Init') {
             def yumrepos = pipecfg.source_config.yumrepos ? "--yumrepos ${pipecfg.source_config.yumrepos}" : ""

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -83,7 +83,7 @@ lock(resource: "bump-${params.STREAM}") {
         def branch = params.STREAM
         def forceTimestamp = false
         def haveChanges = false
-        def src_config_commit = shwrapCapture("git ls-remote https://github.com/${repo} ${branch} | cut -d \$'\t' -f 1")
+        def src_config_commit = shwrapCapture("git ls-remote https://github.com/${repo} refs/heads/${branch} | cut -d \$'\t' -f 1")
         def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
         shwrap("cosa init --branch ${branch} ${variant} --commit=${src_config_commit} https://github.com/${repo}")
 


### PR DESCRIPTION
Otherwise we risk getting multiple refs matching the given pattern (i.e. the branch name showing up in more branches than just the canonical branch). We hit this today with a revert branch that was auto-created accidentally by GitHub through the web UI:

```
$ git ls-remote https://github.com/coreos/fedora-coreos-config next
b9f8903339c142b00105bd0fb97c3fcc21e1502a        refs/heads/next
9007e5804e41097afaa7e42d13455d8a8cd87375        refs/heads/revert-2307-bootloader/next
```

And then the `src_config_commit` variable had multiple lines which messed up parameter substitution lower down.