### PR TITLE
manifests/jenkins: bump memory request to 6Gi

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -241,7 +241,7 @@ parameters:
   displayName: Memory Limit
   name: MEMORY_LIMIT
   # DELTA: changed from 1Gi
-  value: 3Gi
+  value: 6Gi
 - description: Volume space available for data, e.g. 512Mi, 2Gi.
   displayName: Volume Capacity
   name: VOLUME_CAPACITY


### PR DESCRIPTION
We're hitting https://issues.jenkins.io/browse/JENKINS-55287 yet again. We had bumped it in ef4c318 ("manifests/jenkins: bump memory request to 3Gi") from 2Gi to 3Gi, but that doesn't seem enough:

```
$ oc describe pod jenkins-22-rvq4w
...
Last State:     Terminated
    Reason:       OOMKilled
    Exit Code:    1
    Started:      Sat, 18 Mar 2023 10:28:31 -0400
    Finished:     Tue, 28 Mar 2023 10:37:05 -0400
```

Let's bump it to 6Gi.