### PR TITLE
Revert "config: Start producing kubevirt artifact for x86_64"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -69,7 +69,6 @@ default_artifacts:
     - exoscale
     - gcp
     - ibmcloud
-    - kubevirt
     - nutanix
     - virtualbox
     - vmware


### PR DESCRIPTION
Reverts coreos/fedora-coreos-pipeline#841

Apparently `cosa buildextend-kubevirt` works fine when running locally
but runs into failures in the pipeline. Let's revert for now until
we get fixes into coreos-assembler so that it can run fine inside
of OpenShift.