### PR TITLE
jobs/kola-upgrade: fix deadend checks; disallow uefi-secure on aarch64

### DIFF
--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -202,10 +202,6 @@ EOF
                     k1.extraArgs += " --qemu-firmware=uefi"
                     k1.marker = "uefi"
                     parallelruns['Kola:UEFI'] = { kola(k1) }
-                    k2 = kolaparams.clone()
-                    k2.extraArgs += " --qemu-firmware=uefi-secure"
-                    k2.marker = "uefi-secure"
-                    parallelruns['Kola:UEFI-SECURE'] = { kola(k2) }
                     break;
                 case 's390x':
                     parallelruns['Kola'] = { kola(kolaparams) }

--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -87,7 +87,7 @@ lock(resource: "kola-upgrade-${params.ARCH}") {
         // version, the empty string (implies earliest available), or two digits
         // (implies earliest available based on the Fedora major).
         if (start_version.length() > 2) {
-            if (release in deadends) {
+            if (start_version in deadends) {
                 error("Specified start_version is a deadend release")
             }
         } else {
@@ -95,7 +95,7 @@ lock(resource: "kola-upgrade-${params.ARCH}") {
             def releases = readJSON file: "releases.json"
             for (release in releases["releases"]) {
                 def has_arch = release["commits"].find{ commit -> commit["architecture"] == params.ARCH }
-                if (release in deadends || has_arch == null) {
+                if (release["version"] in deadends || has_arch == null) {
                     continue // This release has been disqualified
                 }
                 if (start_version.length() == 2) {


### PR DESCRIPTION
```
commit a6b6946e5623a128512d307ef9abc4fa220e9182
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Mar 31 20:35:52 2023 -0400

    jobs/kola-upgrade: fix deadend checks
    
    In would case we should have used `start_version` and in the other case
    we should have used `release["version"]` and not `release`.

commit 3fede5fc8a9a2f5e5bf208ca103a49e5c603ce8c
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Mar 31 20:29:50 2023 -0400

    jobs/kola-upgrade: SecureBoot on aarch64 isn't supported
    
    Looks like this isn't supported in Fedora. When running the tests
    we ran into:
    
    ```
     2023-03-31T23:49:51Z kola: retryloop: failed to bring up machines:
     architecture aarch64 doesn't have support for secure boot in kola
    ```
    
    I think this migth be the blocker for Fedora right now:
    https://pagure.io/fedora-infrastructure/issue/7361
```
