### PR TITLE
config: enable aarch64 boot images for GCP

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -56,6 +56,7 @@ default_artifacts:
   aarch64:
     - aws
     - azure
+    - gcp
   ppc64le:
     - powervs
   s390x:


### PR DESCRIPTION
Google cloud now has support for aarch64 instances https://cloud.google.com/compute/docs/instances/arm-on-compute