### PR TITLE
Revert "jobs/kola-upgrade: add exception for next stream start_version"

### DIFF
--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -91,13 +91,6 @@ lock(resource: "kola-upgrade-${params.ARCH}") {
             """)
         }
         echo "Selected ${target_version} as the target version to test"
-        // EXCEPTION: If the prod stream we'll use for the upgrade test will be `next`
-        // then we need to start at 33 because the earliest 32 versions in `next`
-        // didn't support Ignition spec 3.1.0; we need Ignition version 2.3.0.
-        // See https://github.com/coreos/coreos-assembler/pull/3416
-        if (start_stream == 'next' && start_version == '32') {
-            start_version = '32.20200517.1.0'
-        }
         // Determine the start version based on the provided params.START_VERSION
         // and the releases.json for this stream. The user can provide a full
         // version, the empty string (implies earliest available), or two digits


### PR DESCRIPTION
This reverts commit 1dcb453f2a4660f25654be83f57b9cda7d46c1c6.

cosa now uses spec v3.0.0[[1]] so this `start_version` should be fine.

[1]: https://github.com/coreos/coreos-assembler/pull/3426