### PR TITLE
jobs/bump-lockfile: run testiso in a stage

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -224,7 +224,9 @@ lock(resource: "bump-${params.STREAM}") {
                             // compressed one
                             shwrap("cosa compress --artifact=metal")
                         }
-                        kolaTestIso(cosaDir: env.WORKSPACE, arch: arch, marker: arch)
+                        stage("${arch}:kola:testiso") {
+                            kolaTestIso(cosaDir: env.WORKSPACE, arch: arch, marker: arch)
+                        }
                     }
                     if (arch == "x86_64") {
                         buildAndTest()


### PR DESCRIPTION
Running it in a stage will cause it to show up properly in the Blue Ocean view.