### PR TITLE
Revert "jobs: add kola-secex test"

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -306,14 +306,6 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             pipeutils.build_artifacts(pipecfg, params.STREAM, basearch)
         }
 
-        // secex specific tests
-        if (shwrapCapture("cosa meta --get-value images.qemu-secex") != "None") {
-            stage("Kola:Secex") {
-                kola(cosaDir: env.WORKSPACE, arch: basearch, skipUpgrade: true,
-                     extraArgs: "--qemu-secex --tag secex --qemu-secex-hostkey /data.secex/hostkeys/HKD-*.crt")
-            }
-        }
-
         // Run Kola TestISO tests for metal artifacts
         if (shwrapCapture("cosa meta --get-value images.live-iso") != "None") {
             stage("Kola:TestISO") {


### PR DESCRIPTION
This reverts commit 7f2b7d256d74076d66cc0acce6b3e55286163c30.

It's failing in the RHCOS pipeline with:

    13:42:52  --- FAIL: ext.config.shared.secex.ensure (1.00s)
    13:42:52          harness.go:1607: Cluster failed starting machines: reading hostkey: open /data.secex/hostkeys/HKD-*.crt: no such file or directory