### PR TITLE
jobs/build-arch: temporarily disable secex tests

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -306,13 +306,14 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             pipeutils.build_artifacts(pipecfg, params.STREAM, basearch)
         }
 
-        // secex specific tests
-        if (shwrapCapture("cosa meta --get-value images.qemu-secex") != "None") {
-            stage("Kola:Secex") {
-                kola(cosaDir: env.WORKSPACE, arch: basearch, skipUpgrade: true,
-                     extraArgs: "--qemu-secex --tag secex --qemu-secex-hostkey /data.secex/hostkeys/secex-hostkey.crt")
-            }
-        }
+        // XXX: temporarily disabled until it works or we skip it on 4.12
+        // // secex specific tests
+        // if (shwrapCapture("cosa meta --get-value images.qemu-secex") != "None") {
+        //     stage("Kola:Secex") {
+        //         kola(cosaDir: env.WORKSPACE, arch: basearch, skipUpgrade: true,
+        //              extraArgs: "--qemu-secex --tag secex --qemu-secex-hostkey /data.secex/hostkeys/secex-hostkey.crt")
+        //     }
+        // }
 
         // Run Kola TestISO tests for metal artifacts
         if (shwrapCapture("cosa meta --get-value images.live-iso") != "None") {


### PR DESCRIPTION
The tests don't work on the 4.12 pipeline because cosa is missing some
patches. We need to backport at least https://github.com/coreos/coreos-
assembler/pull/3384 but it gets messy because we don't want to also
backport the Ignition config GPG key stuff. Possibly we'll just need a
temporary hack key there in the future.

Anyway, for now let's at least unblock 4.12.