### PR TITLE
jobs/kola-{upgrade,openstack}: update --allow-rerun-success options

### DIFF
--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -119,7 +119,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
                      extraArgs: params.KOLA_TESTS,
                      skipUpgrade: true,
                      platformArgs: """-p=openstack                               \
-                         --allow-rerun-success                                   \
+                         --allow-rerun-success tags=all                          \
                          --openstack-config-file=\${OPENSTACK_KOLA_TESTS_CONFIG} \
                          --openstack-flavor=v3-starter-4                         \
                          --openstack-network=private                             \

--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -183,7 +183,7 @@ EOF
                 arch: params.ARCH,
                 build: start_version,
                 cosaDir: env.WORKSPACE,
-                extraArgs: "--tag extended-upgrade --allow-rerun-success --append-butane tmp/target_stream.bu",
+                extraArgs: "--tag extended-upgrade --allow-rerun-success tags=all --append-butane tmp/target_stream.bu",
                 skipBasicScenarios: true,
                 skipUpgrade: true,
             ]


### PR DESCRIPTION
This option to `kola run` now takes a string as input. See https://github.com/coreos/coreos-assembler/pull/3430.