### PR TITLE
jobs/kola-{openstack,upgrade): adjust to coreos-ci-lib allowRerunSuccess changes

### DIFF
--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -117,9 +117,9 @@ lock(resource: "kola-openstack-${params.ARCH}") {
                 kola(cosaDir: env.WORKSPACE, parallel: 5,
                      build: params.VERSION, arch: params.ARCH,
                      extraArgs: params.KOLA_TESTS,
+                     rerunSuccessArgs: "tags=all",
                      skipUpgrade: true,
                      platformArgs: """-p=openstack                               \
-                         --allow-rerun-success tags=all                          \
                          --openstack-config-file=\${OPENSTACK_KOLA_TESTS_CONFIG} \
                          --openstack-flavor=v3-starter-4                         \
                          --openstack-network=private                             \

--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -183,7 +183,7 @@ EOF
                 arch: params.ARCH,
                 build: start_version,
                 cosaDir: env.WORKSPACE,
-                extraArgs: "--tag extended-upgrade --allow-rerun-success tags=all --append-butane tmp/target_stream.bu",
+                extraArgs: "--tag extended-upgrade --append-butane tmp/target_stream.bu",
                 skipBasicScenarios: true,
                 skipUpgrade: true,
             ]


### PR DESCRIPTION
In https://github.com/coreos/coreos-ci-lib/pull/148 we are modifying the defaults to now call kola run with `--allow-rerun-success tags=needs-internet`, which is part of https://github.com/coreos/fedora-coreos-pipeline/issues/842.

Here we drop the `--allow-rerun-success tags=all` call from the upgrade test. Since the test itself has the `needs-internet` tag then it will be covered by the new default.

For the openstack test we'll adjust to the new way to override the argument string passed to `--allow-rerun-success` inside of `kola()`.