### PR TITLE
kola-aws: Drop snooze for xen-tests

### DIFF
--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -86,29 +86,23 @@ cosaPod(memory: "512Mi", kvm: false,
                 if (tests == "") {
                     tests = "basic"
                 }
-                // Snooze the xen_tests for rawhide for this month while we wait
-                // for a fix for https://github.com/coreos/fedora-coreos-tracker/issues/1438
-                def now = Calendar.getInstance()
-                def month = now.get(Calendar.MONTH)
-                if (params.STREAM != "rawhide" || month != Calendar.APRIL) {
-                    parallelruns['Kola:Xen'] = {
-                        // https://github.com/coreos/fedora-coreos-tracker/issues/997
-                        // Run this test on i3.large so we can also run ext.config.platforms.aws.nvme
-                        // to verify access to instance storage nvme disks works
-                        // https://github.com/coreos/fedora-coreos-tracker/issues/1306
-                        // Also add in the ext.config.platforms.aws.assert-xen test just
-                        // to sanity check we are on a Xen instance.
-                        def xen_tests = tests
-                        if (xen_tests == "basic") {
-                            xen_tests = "basic ext.config.platforms.aws.nvme ext.config.platforms.aws.assert-xen"
-                        }
-                        kola(cosaDir: env.WORKSPACE,
-                            build: params.VERSION, arch: params.ARCH,
-                            extraArgs: xen_tests,
-                            skipUpgrade: true,
-                            marker: "xen",
-                            platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=i3.large')
+                parallelruns['Kola:Xen'] = {
+                    // https://github.com/coreos/fedora-coreos-tracker/issues/997
+                    // Run this test on i3.large so we can also run ext.config.platforms.aws.nvme
+                    // to verify access to instance storage nvme disks works
+                    // https://github.com/coreos/fedora-coreos-tracker/issues/1306
+                    // Also add in the ext.config.platforms.aws.assert-xen test just
+                    // to sanity check we are on a Xen instance.
+                    def xen_tests = tests
+                    if (xen_tests == "basic") {
+                        xen_tests = "basic ext.config.platforms.aws.nvme ext.config.platforms.aws.assert-xen"
                     }
+                    kola(cosaDir: env.WORKSPACE,
+                         build: params.VERSION, arch: params.ARCH,
+                         extraArgs: xen_tests,
+                         skipUpgrade: true,
+                         marker: "xen",
+                         platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=i3.large')
                 }
                 parallelruns['Kola:Intel-Ice-Lake'] = {
                     // https://github.com/coreos/fedora-coreos-tracker/issues/1004


### PR DESCRIPTION
The latest kernel version doesn't result in kernel-oops for the zen tests so dropping the snooze on the the test. Since this snooze expired last month, the test's been running successfully on latest rawhide builds.
Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1438