### PR TITLE
Enable ppc64le on testing/next

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,14 +6,8 @@ streams:
         - ppc64le
     testing:
       type: production
-      skip_additional_arches:
-        # https://github.com/coreos/fedora-coreos-tracker/issues/1247#issuecomment-1261286872
-        - ppc64le
     next:
       type: production
-      skip_additional_arches:
-        # https://github.com/coreos/fedora-coreos-tracker/issues/1247#issuecomment-1261286872
-        - ppc64le
     testing-devel:
       type: development
       default: true


### PR DESCRIPTION
Once https://github.com/coreos/fedora-coreos-config/pull/2435 merges we should be unblocked for releasing ppc64le. We'll do a soft rollout with just `testing`/`next` for now.