### PR TITLE
jobs/kola-upgrade: enable kola-upgrade test for ppc64le

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -517,7 +517,7 @@ def run_fcos_upgrade_tests(pipecfg, stream, version, basearch, commit) {
 
     def min_supported_start_versions = [
         aarch64: 34,
-        ppc64le: 40, // We haven't released on ppc64le yet
+        ppc64le: 38,
         s390x:   36,
         x86_64:  32,
     ]


### PR DESCRIPTION
Let's set the min_supported_start_versions for ppc64le to F38 now that we are doing builds/releases for F38.