### PR TITLE
utils: fix typo in kola-azure snooze condition

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -484,7 +484,7 @@ def run_cloud_tests(pipecfg, stream, version, cosa, basearch, commit) {
     // for: https://github.com/coreos/fedora-coreos-tracker/issues/1515
     def now = Calendar.instance
     def month = now.get(Calendar.MONTH)
-    if (params.STREAM != "rawhide" || (month != Calendar.JUNE && month != Calendar.JULY)) {
+    if (stream != "rawhide" || (month != Calendar.JUNE && month != Calendar.JULY)) {
         // Kick off the Kola Azure job if we have an artifact, credentials, and testing is enabled.
         if (shwrapCapture("cosa meta --build=${version} --get-value images.azure") != "None" &&
             cloud_testing_enabled_for_arch(pipecfg, 'azure', basearch) &&


### PR DESCRIPTION
I made a mistake when accessing the `params` variable in my previous PR: https://github.com/coreos/fedora-coreos-pipeline/pull/881.

Update the condition to snooze kola-azure by accessing the `stream` variable directly.