### PR TITLE
jobs/build{,-arch}.Jenkinsfile: fix run_fcos_upgrade_tests() params

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -393,8 +393,8 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             }
             if (pipecfg.misc?.run_extended_upgrade_test_fcos) {
                 stage('Upgrade Tests') {
-                    pipeutils.run_fcos_upgrade_tests(pipecfg, params.STREAM, cosa_img,
-                                                     newBuildID, basearch, src_config_commit)
+                    pipeutils.run_fcos_upgrade_tests(pipecfg, params.STREAM, newBuildID,
+                                                     cosa_img, basearch, src_config_commit)
                 }
             }
         }

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -476,8 +476,8 @@ lock(resource: "build-${params.STREAM}") {
             }
             if (pipecfg.misc?.run_extended_upgrade_test_fcos) {
                 stage('Upgrade Tests') {
-                    pipeutils.run_fcos_upgrade_tests(pipecfg, params.STREAM, cosa_img,
-                                                     newBuildID, basearch, src_config_commit)
+                    pipeutils.run_fcos_upgrade_tests(pipecfg, params.STREAM, newBuildID,
+                                                     cosa_img, basearch, src_config_commit)
                 }
             }
         }


### PR DESCRIPTION
The version comes before the cosa_img in the argument list.

Fixes b81f738.