### PR TITLE
jobs: check-aws-regions job for checking disabled aws regions

### DIFF
--- a/jobs/check-aws-regions.Jenkinsfile
+++ b/jobs/check-aws-regions.Jenkinsfile
@@ -1,0 +1,32 @@
+import org.yaml.snakeyaml.Yaml;
+
+node {
+    checkout scm
+    // these are script global vars
+    pipeutils = load("utils.groovy")
+}
+
+properties([
+    pipelineTriggers([
+        // check once a day
+        pollSCM('H H * * *')
+    ]),
+    buildDiscarder(logRotator(
+        numToKeepStr: '20',
+        artifactNumToKeepStr: '20'
+    )),
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+])
+
+cosaPod(serviceAccount: "jenkins"){
+    def disabled_regions = ""
+    withCredentials([file(variable: 'AWS_CONFIG_FILE',
+                           credentialsId: 'aws-build-upload-config')]) {
+        disabled_regions = shwrapCapture("ore aws list-regions --disabled")
+    }
+    if (disabled_regions != "None") {
+        warn("Disabled AWS regions detected: ${disabled_regions}")
+        pipeutils.trySlackSend(message: ":aws: aws-regions-disabled :jenkins:<${env.BUILD_URL}|${env.BUILD_NUMBER}> ${disabled_regions}")
+        return
+    }    
+}


### PR DESCRIPTION
It is a periodic jenkins job that runs `ore aws list-regions --disabled` and sends a slack notification if any disabled aws-regions are returned.

Ref: https://github.com/coreos/fedora-coreos-pipeline/issues/152
JIRA: https://issues.redhat.com/browse/COS-2270