### PR TITLE
jobs/release: safely check if `brew` exists in pipecfg

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -6,8 +6,8 @@ node {
     libcloud = load("libcloud.groovy")
 }
 
-def brew_principal = pipecfg.brew.principal
-def brew_profile = pipecfg.brew.profile
+def brew_principal = pipecfg.brew?.principal
+def brew_profile = pipecfg.brew?.profile
 
 properties([
     pipelineTriggers([]),


### PR DESCRIPTION
The release jobs in both FCOS and RHCOS are failing with `java.lang.NullPointerException: Cannot get property 'principal' on null object`. 

There is a possibility that the `brew` section of the pipecfg doesn't exist, e.g. in FCOS. Add a `?` to the variable assignment to check if `brew` is null before assigning values to these variables.

See: https://github.com/coreos/fedora-coreos-pipeline/pull/886