### PR TITLE
Make the emoji clickable in all pipleine jobs slack notification

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -417,7 +417,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
     if (pipecfg.hotfix) {
         stream += "-${pipecfg.hotfix.name}"
     }
-    def message = "[${stream}][${basearch}] :jenkins:<${env.BUILD_URL}|${env.BUILD_NUMBER}> :ocean:<${env.RUN_DISPLAY_URL}|${env.BUILD_NUMBER}>"
+    def message = "[${stream}][${basearch}] #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:>"
 
     if (currentBuild.result == 'SUCCESS') {
         if (!newBuildID) {

--- a/jobs/build-cosa.Jenkinsfile
+++ b/jobs/build-cosa.Jenkinsfile
@@ -175,7 +175,7 @@ lock(resource: "build-${containername}") {
             currentBuild.description = "[${gitref}@${shortcommit}] ❌"
         }
         if (currentBuild.result != 'SUCCESS') {
-            message = "build-cosa :jenkins:<${env.BUILD_URL}|${env.BUILD_NUMBER}> :ocean:<${env.RUN_DISPLAY_URL}|${env.BUILD_NUMBER}> [${gitref}@${shortcommit}]"
+            message = "build-cosa #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> [${gitref}@${shortcommit}]"
             pipeutils.trySlackSend(message: message)
         }
     }

--- a/jobs/build-fcos-buildroot.Jenkinsfile
+++ b/jobs/build-fcos-buildroot.Jenkinsfile
@@ -176,7 +176,7 @@ lock(resource: "build-${containername}") {
             currentBuild.description = "[${gitref}@${shortcommit}] ❌"
         }
         if (currentBuild.result != 'SUCCESS') {
-            message = "build-${containername} :jenkins:<${env.BUILD_URL}|${env.BUILD_NUMBER}> :ocean:<${env.RUN_DISPLAY_URL}|${env.BUILD_NUMBER}> [${gitref}@${shortcommit}]"
+            message = "build-${containername} #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> [${gitref}@${shortcommit}]"
             pipeutils.trySlackSend(color: 'danger', message: message)
         }
     }

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -499,7 +499,7 @@ lock(resource: "build-${params.STREAM}") {
     if (pipecfg.hotfix) {
         stream += "-${pipecfg.hotfix.name}"
     }
-    def message = "[${stream}][${basearch}] :jenkins:<${env.BUILD_URL}|${env.BUILD_NUMBER}> :ocean:<${env.RUN_DISPLAY_URL}|${env.BUILD_NUMBER}>"
+    def message = "[${stream}][${basearch}] #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:>"
 
     if (currentBuild.result == 'SUCCESS') {
         if (!newBuildID) {

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -297,7 +297,7 @@ lock(resource: "bump-${params.STREAM}") {
         throw e
     } finally {
         if (currentBuild.result != 'SUCCESS') {
-            pipeutils.trySlackSend(message: ":jenkins:<${env.BUILD_URL}|bump-lockfile ${env.BUILD_NUMBER} (${params.STREAM})> :ocean:<${env.RUN_DISPLAY_URL}|${env.BUILD_NUMBER}>")
+            pipeutils.trySlackSend(message: "bump-lockfile #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> (${params.STREAM})> <${env.RUN_DISPLAY_URL}|:ocean:>")
         }
     }
 }}} // cosaPod, timeout, and lock finish here

--- a/jobs/check-aws-regions.Jenkinsfile
+++ b/jobs/check-aws-regions.Jenkinsfile
@@ -26,7 +26,7 @@ cosaPod(serviceAccount: "jenkins"){
     }
     if (disabled_regions != "") {
         warn("Disabled AWS regions detected: ${disabled_regions}")
-        pipeutils.trySlackSend(message: ":aws: aws-regions-disabled :jenkins:<${env.BUILD_URL}|${env.BUILD_NUMBER}> ${disabled_regions}")
+        pipeutils.trySlackSend(message: ":aws: check-aws-regions #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> detected disabled regions: ${disabled_regions}")
         return
     }    
 }

--- a/jobs/check-aws-regions.Jenkinsfile
+++ b/jobs/check-aws-regions.Jenkinsfile
@@ -24,7 +24,7 @@ cosaPod(serviceAccount: "jenkins"){
                            credentialsId: 'aws-build-upload-config')]) {
         disabled_regions = shwrapCapture("ore aws list-regions --disabled")
     }
-    if (disabled_regions != "None") {
+    if (disabled_regions != "") {
         warn("Disabled AWS regions detected: ${disabled_regions}")
         pipeutils.trySlackSend(message: ":aws: aws-regions-disabled :jenkins:<${env.BUILD_URL}|${env.BUILD_NUMBER}> ${disabled_regions}")
         return

--- a/jobs/cloud-replicate.Jenkinsfile
+++ b/jobs/cloud-replicate.Jenkinsfile
@@ -146,5 +146,5 @@ lock(resource: "cloud-replicate-${params.VERSION}") {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    pipeutils.trySlackSend(message: ":cloud: :arrows_counterclockwise: cloud-replicate :jenkins:<${env.BUILD_URL}|${env.BUILD_NUMBER}> :ocean:<${env.RUN_DISPLAY_URL}|${env.BUILD_NUMBER}> [${params.STREAM}][${basearches.join(' ')}] (${params.VERSION})")
+    pipeutils.trySlackSend(message: ":cloud: :arrows_counterclockwise: cloud-replicate #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> [${params.STREAM}][${basearches.join(' ')}] (${params.VERSION})")
 }}} // try-catch-finally, cosaPod and lock finish here

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -140,7 +140,7 @@ cosaPod(memory: "512Mi", kvm: false,
         throw e
     } finally {
         if (currentBuild.result != 'SUCCESS') {
-            pipeutils.trySlackSend(message: ":aws: kola-aws :jenkins:<${env.BUILD_URL}|${env.BUILD_NUMBER}> :ocean:<${env.RUN_DISPLAY_URL}|${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
+            pipeutils.trySlackSend(message: ":aws: kola-aws #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
         }
     }
 }} // cosaPod and timeout finish here

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -174,7 +174,7 @@ cosaPod(memory: "${cosa_memory_request_mb}Mi", kvm: false,
         throw e
     } finally {
         if (currentBuild.result != 'SUCCESS') {
-            pipeutils.trySlackSend(message: ":azure: kola-azure :jenkins:<${env.BUILD_URL}|${env.BUILD_NUMBER}> :ocean:<${env.RUN_DISPLAY_URL}|${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
+            pipeutils.trySlackSend(message: ":azure: kola-azure #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")     
         }
     }
 }} // cosaPod and timeout finish here

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -124,7 +124,7 @@ cosaPod(memory: "512Mi", kvm: false,
         throw e
     } finally {
         if (currentBuild.result != 'SUCCESS') {
-            pipeutils.trySlackSend(message: ":gcp: kola-gcp :jenkins:<${env.BUILD_URL}|${env.BUILD_NUMBER}> :ocean:<${env.RUN_DISPLAY_URL}|${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
+            pipeutils.trySlackSend(message: ":gcp: kola-gcp #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
         }
     }
 }} // cosaPod and timeout finish here

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -82,7 +82,7 @@ cosaPod(memory: "512Mi", kvm: false,
         throw e
     } finally {
         if (currentBuild.result != 'SUCCESS') {
-            pipeutils.trySlackSend(message: ":k8s: kola-kubernetes :jenkins:<${env.BUILD_URL}|${env.BUILD_NUMBER}> :ocean:<${env.RUN_DISPLAY_URL}|${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
+            pipeutils.trySlackSend(message: ":k8s: kola-kubernetes #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
         }
     }
 }} // cosaPod and timeout finish here

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -145,7 +145,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
         throw e
     } finally {
         if (currentBuild.result != 'SUCCESS') {
-            pipeutils.trySlackSend(message: ":openstack: kola-openstack :jenkins:<${env.BUILD_URL}|${env.BUILD_NUMBER}> :ocean:<${env.RUN_DISPLAY_URL}|${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
+            pipeutils.trySlackSend(message: ":openstack: kola-openstack #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> [${params.STREAM}][${params.ARCH}] (${params.VERSION})")
         }
     }
 }}} // cosaPod, timeout, and lock finish here

--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -256,7 +256,7 @@ EOF
         throw e
     } finally {
         if (currentBuild.result != 'SUCCESS') {
-            pipeutils.trySlackSend(message: "kola-upgrade :jenkins:<${env.BUILD_URL}|${env.BUILD_NUMBER}> :ocean:<${env.RUN_DISPLAY_URL}|${env.BUILD_NUMBER}> [${params.STREAM}][${params.ARCH}] (${start_version}->${target_version})")
+            pipeutils.trySlackSend(message: "kola-upgrade ${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> [${params.STREAM}][${params.ARCH}] (${start_version}->${target_version})")
         }
     }
 }}} // lock, cosaPod and timeout finish here

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -439,5 +439,5 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
     if (pipecfg.hotfix) {
         stream += "-${pipecfg.hotfix.name}"
     }
-    pipeutils.trySlackSend(message: ":bullettrain_front: release :jenkins:<${env.BUILD_URL}|${env.BUILD_NUMBER}> :ocean:<${env.RUN_DISPLAY_URL}|${env.BUILD_NUMBER}> [${stream}][${basearches.join(' ')}] (${params.VERSION})")
+    pipeutils.trySlackSend(message: ":bullettrain_front: release #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> [${stream}][${basearches.join(' ')}] (${params.VERSION})")
 }}} // try-catch-finally, cosaPod and lock finish here


### PR DESCRIPTION
Changes in the pipeline job slack notifications where the emoji itself is clickable and the build number is printed only once.

