### PR TITLE
bump-lockfile: improve slack message

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -297,7 +297,7 @@ lock(resource: "bump-${params.STREAM}") {
         throw e
     } finally {
         if (currentBuild.result != 'SUCCESS') {
-            pipeutils.trySlackSend(message: "bump-lockfile #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> (${params.STREAM})> <${env.RUN_DISPLAY_URL}|:ocean:>")
+            pipeutils.trySlackSend(message: "bump-lockfile #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> [${params.STREAM}]")
         }
     }
 }}} // cosaPod, timeout, and lock finish here


### PR DESCRIPTION
Right now it puts the stream in between the two emojis. Let's put the stream at the end.