### PR TITLE
Add Apple Hypervisor (applehv) to default artifacts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -50,6 +50,7 @@ default_artifacts:
     - openstack
     - hashlist-experimental
   aarch64:
+    - applehv
     - aws
     - azure
     - gcp
@@ -60,6 +61,7 @@ default_artifacts:
     - ibmcloud
   x86_64:
     - aliyun
+    - applehv
     - aws
     - azure
     - azurestack


### PR DESCRIPTION
See coreos/fedora-coreos-tracker#1533 and coreos/fedora-coreos-tracker#1548