### PR TITLE
manifests/jenkins: set file.encoding=UTF-8

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -83,15 +83,16 @@ objects:
           # DELTA: point c-as-c plugin to config map files; see below
           - name: CASC_JENKINS_CONFIG
             value: /var/lib/jenkins/configuration-as-code
-          # DELTA: Increase heartbeat interval so durable-task-plugin waits a
-          # bit longer for scripts to start before failing the build.
-          # https://github.com/coreos/coreos-ci/issues/28
-          # DELTA: Set the default JNLP image to our Jenkins agent imagestream.
-          # https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/cloudbees-ci-on-modern-cloud-platforms/change-the-default-jnlp-image-for-kubernetes-agents-provisioning#_system_property_approach
-          # We hard set a memory limit so that we don't get the default for the
-          # limitrange in this project we happen to be in, which is likely to be
-          # too generous. The default upstream memory *request* is 256Mi, which
-          # is too little as a limit.
+          # DELTA:
+          #   - Increase heartbeat interval so durable-task-plugin waits a
+          #     bit longer for scripts to start before failing the build.
+          #     https://github.com/coreos/coreos-ci/issues/28
+          #   - Set the default JNLP image to our Jenkins agent imagestream.
+          #     https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/cloudbees-ci-on-modern-cloud-platforms/change-the-default-jnlp-image-for-kubernetes-agents-provisioning#_system_property_approach
+          #   - We hard set a memory limit so that we don't get the default for the
+          #     limitrange in this project we happen to be in, which is likely to be
+          #     too generous. The default upstream memory *request* is 256Mi, which
+          #     is too little as a limit.
           - name: JENKINS_JAVA_OVERRIDES
             value: >-
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=900

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -84,6 +84,8 @@ objects:
           - name: CASC_JENKINS_CONFIG
             value: /var/lib/jenkins/configuration-as-code
           # DELTA:
+          #   - Tell Jenkins to use UTF-8 so emojis in log outputs work
+          #     https://stackoverflow.com/questions/27960996/jenkins-console-output-characters
           #   - Increase heartbeat interval so durable-task-plugin waits a
           #     bit longer for scripts to start before failing the build.
           #     https://github.com/coreos/coreos-ci/issues/28
@@ -95,6 +97,7 @@ objects:
           #     is too little as a limit.
           - name: JENKINS_JAVA_OVERRIDES
             value: >-
+              -Dfile.encoding=UTF-8
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=900
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true
               -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage=jenkins-agent-base:latest


### PR DESCRIPTION
This will allow the emojis that are output by the denylist processing
from kola to show up in the jenkins output rather than being shown
as weird looking binary characters.
