### PR TITLE
jobs/bump-lockfile: bump timout by 30m

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -66,7 +66,7 @@ lock(resource: "bump-${params.STREAM}") {
     cosaPod(image: cosa_img,
             cpu: "${ncpus}", memory: "${cosa_memory_request_mb}Mi",
             serviceAccount: "jenkins") {
-    timeout(time: 120, unit: 'MINUTES') { 
+    timeout(time: 150, unit: 'MINUTES') {
     try {
 
         currentBuild.description = "[${params.STREAM}] Running"


### PR DESCRIPTION
Some recent changes like droping unsafety for the cache disk [1] and also adding a few more root reprovision tests that get run on the ppc64le platform [2] are causing us to bump up into the 2 hour time limit. Let's bump it.

[1] https://github.com/coreos/coreos-assembler/pull/3619
[2] https://github.com/coreos/fedora-coreos-config/pull/2597