### PR TITLE
manifests/jenkins-s2i: set `scheduled` on our imagestreams

### DIFF
--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -57,6 +57,8 @@ objects:
             namespace: openshift
           referencePolicy:
             type: Source
+          importPolicy:
+            scheduled: true
   - kind: BuildConfig
     apiVersion: v1
     metadata:
@@ -103,3 +105,5 @@ objects:
             namespace: openshift
           referencePolicy:
             type: Source
+          importPolicy:
+            scheduled: true


### PR DESCRIPTION
I'm not sure why we didn't do this before. Without this, the imagestreams are only updated manually. In the `jenkins-with-cert` flow, we already have an `ImageChange` trigger which ensures that `jenkins:latest` is kept fresh. So this change is putting the non- custom-cert path at parity.

Note that this is separate from starting and deploying the S2I build, which currently is still done manually.