### PR TITLE
jobs: limit xz memory usage on multi-arch too

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -335,7 +335,8 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         }
 
         stage('Archive') {
-            shwrap("cosa compress")
+            // Limit to 2G to be good neighbours and reduce chances of getting OOMkilled.
+            // shwrap("cosa shell -- env XZ_DEFAULTS=--memlimit=2G cosa compress")
 
             if (uploading) {
                 def acl = pipecfg.s3.acl ?: 'public-read'

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -220,9 +220,11 @@ lock(resource: "bump-${params.STREAM}") {
                         }
                         stage("${arch}:Build Live") {
                             shwrap("cosa buildextend-live --fast")
-                            // Test metal4k with an uncompressed image and metal with a
-                            // compressed one
-                            shwrap("cosa compress --artifact=metal")
+                            // Test metal4k with an uncompressed image and
+                            // metal with a compressed one. Limit to 2G to be
+                            // good neighbours and reduce chances of getting
+                            // OOMkilled.
+                            shwrap("cosa shell -- env XZ_DEFAULTS=--memlimit=2G cosa compress --artifact=metal")
                         }
                         stage("${arch}:kola:testiso") {
                             kolaTestIso(cosaDir: env.WORKSPACE, arch: arch, marker: arch)


### PR DESCRIPTION
We recently hit `xz` on the ppc64le builder getting OOMkilled. Let's match x86_64 and also limit memory in the multi-arch paths too. Except we're using a more conservative value (though still plenty) since there's no resource-based scheduling on these builders.

We should probably add support for e.g. `cosa compress --xz-memlimit` instead to make this less awkward.