### PR TITLE
jobs/bump-lockfile: limit to single run at a time

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -62,7 +62,7 @@ def getLockfileInfo(lockfile) {
 def cosa_memory_request_mb = 10.5 * 1024 as Integer
 def ncpus = ((cosa_memory_request_mb - 512) / 1536) as Integer
 
-lock(resource: "bump-${params.STREAM}") {
+lock(resource: "bump-lockfile") {
     cosaPod(image: cosa_img,
             cpu: "${ncpus}", memory: "${cosa_memory_request_mb}Mi",
             serviceAccount: "jenkins") {


### PR DESCRIPTION
Right now when the bump-lockfiles job runs it kicks off two runs of bump-lockfile (one for each stream) at the exact same time. This might be what is causing our timeouts to be getting hit lately (primarily because the ppc64le runs are taking longer) [1].

Let's limit the bump-lockfile job to a singular run at any given time.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1579