### PR TITLE
jobs: bump multi-arch xz limit to 4G

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -335,8 +335,8 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         }
 
         stage('Archive') {
-            // Limit to 2G to be good neighbours and reduce chances of getting OOMkilled.
-            // shwrap("cosa shell -- env XZ_DEFAULTS=--memlimit=2G cosa compress")
+            // Limit to 4G to be good neighbours and reduce chances of getting OOMkilled.
+            shwrap("cosa shell -- env XZ_DEFAULTS=--memlimit=4G cosa compress")
 
             if (uploading) {
                 def acl = pipecfg.s3.acl ?: 'public-read'

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -221,10 +221,10 @@ lock(resource: "bump-lockfile") {
                         stage("${arch}:Build Live") {
                             shwrap("cosa buildextend-live --fast")
                             // Test metal4k with an uncompressed image and
-                            // metal with a compressed one. Limit to 2G to be
+                            // metal with a compressed one. Limit to 4G to be
                             // good neighbours and reduce chances of getting
                             // OOMkilled.
-                            shwrap("cosa shell -- env XZ_DEFAULTS=--memlimit=2G cosa compress --artifact=metal")
+                            shwrap("cosa shell -- env XZ_DEFAULTS=--memlimit=4G cosa compress --artifact=metal")
                         }
                         stage("${arch}:kola:testiso") {
                             kolaTestIso(cosaDir: env.WORKSPACE, arch: arch, marker: arch)


### PR DESCRIPTION
At 2G, we increased compression time from 2m to 15m. Let's bump it a little more to see if we can strike a better balance between performance and memory.

Also fix the gaping typo of having the `cosa compress` invocation being commented out in 11f2ca6.

Fixes: 11f2ca6 ("jobs: limit xz memory usage on multi-arch too")