### PR TITLE
jobs/bump-lockfile: more time

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -66,7 +66,7 @@ lock(resource: "bump-lockfile") {
     cosaPod(image: cosa_img,
             cpu: "${ncpus}", memory: "${cosa_memory_request_mb}Mi",
             serviceAccount: "jenkins") {
-    timeout(time: 180, unit: 'MINUTES') {
+    timeout(time: 240, unit: 'MINUTES') {
     try {
 
         currentBuild.description = "[${params.STREAM}] Running"


### PR DESCRIPTION
We have a real problem on our ppc64le builder. Until we can figure it out we bump time yet again.