### PR TITLE
jobs/build-fcos-buildroot: build for all arches

### DIFF
--- a/jobs/build-fcos-buildroot.Jenkinsfile
+++ b/jobs/build-fcos-buildroot.Jenkinsfile
@@ -42,7 +42,7 @@ properties([
     parameters([
       string(name: 'ARCHES',
              description: 'Space-separated list of target architectures',
-             defaultValue: "x86_64",
+             defaultValue: "x86_64" + " " + pipeutils.get_supported_additional_arches().join(" "),
              trim: true),
       string(name: 'CONFIG_GIT_URL',
              description: 'Override the src/config git repo to use',


### PR DESCRIPTION
We initially started building it only for x86_64 because there was no need to build for other arches[[1]], but with the work underway to have multi-arch support in CoreOS CI, that's no longer the case.

[1]: https://github.com/coreos/fedora-coreos-config/issues/1950