### PR TITLE
jobs/kola-*: trim artifacts to 30

### DIFF
--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -34,7 +34,7 @@ properties([
     ]),
     buildDiscarder(logRotator(
         numToKeepStr: '100',
-        artifactNumToKeepStr: '100'
+        artifactNumToKeepStr: '30'
     )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -34,7 +34,7 @@ properties([
     ]),
     buildDiscarder(logRotator(
         numToKeepStr: '100',
-        artifactNumToKeepStr: '100'
+        artifactNumToKeepStr: '30'
     )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -34,7 +34,7 @@ properties([
     ]),
     buildDiscarder(logRotator(
         numToKeepStr: '100',
-        artifactNumToKeepStr: '100'
+        artifactNumToKeepStr: '30'
     )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -34,7 +34,7 @@ properties([
     ]),
     buildDiscarder(logRotator(
         numToKeepStr: '100',
-        artifactNumToKeepStr: '100'
+        artifactNumToKeepStr: '30'
     )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])


### PR DESCRIPTION
Keeping around the test console logs of the last 100 builds seems excessive. Let's trim it back to 30 to match bump-lockfile. This should help reduce our storage requirements (each kola job right now takes about 1.2G- 1.4G).