### PR TITLE
Add support for using OSBuild

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -97,6 +97,8 @@ streams:
       skip_govcloud_hack: true
       # OPTIONAL/TEMPORARY: don't upload images to clouds
       skip_cloud_uploads: true
+      # Use newly added support for building images using OSBuild
+      use_osbuild: true
 
 # REQUIRED: architectures to build for other than x86_64
 additional_arches: [aarch64, ppc64le, s390x]

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -76,6 +76,9 @@ def stream_info = pipecfg.streams[params.STREAM]
 
 def cosa_controller_img = stream_info.cosa_controller_img_hack ?: cosa_img
 
+// Determine if we should use osbuild for image building
+def use_osbuild = pipeutils.get_use_osbuild_for_stream(pipecfg, params.STREAM)
+
 // If we are a mechanical stream then we can pin packages but we
 // don't maintain complete lockfiles so we can't build in strict mode.
 def strict_build_param = stream_info.type == "mechanical" ? "" : "--strict"
@@ -282,7 +285,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
 
         // Build QEMU image
         stage("Build QEMU") {
-            shwrap("cosa buildextend-qemu")
+            shwrap("cosa shell -- env COSA_USE_OSBUILD=${use_osbuild} cosa buildextend-qemu")
         }
 
         // This is a temporary hack to help debug https://github.com/coreos/fedora-coreos-tracker/issues/1108.

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -83,6 +83,9 @@ if (params.ADDITIONAL_ARCHES != "none") {
 
 def stream_info = pipecfg.streams[params.STREAM]
 
+// Determine if we should use osbuild for image building
+def use_osbuild = pipeutils.get_use_osbuild_for_stream(pipecfg, params.STREAM)
+
 // If we are a mechanical stream then we can pin packages but we
 // don't maintain complete lockfiles so we can't build in strict mode.
 def strict_build_param = stream_info.type == "mechanical" ? "" : "--strict"
@@ -344,7 +347,7 @@ lock(resource: "build-${params.STREAM}") {
 
         // Build QEMU image
         stage("Build QEMU") {
-            shwrap("cosa buildextend-qemu")
+            shwrap("cosa shell -- env COSA_USE_OSBUILD=${use_osbuild} cosa buildextend-qemu")
         }
 
         // This is a temporary hack to help debug https://github.com/coreos/fedora-coreos-tracker/issues/1108.

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -45,6 +45,9 @@ def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 
 def stream_info = pipecfg.streams[params.STREAM]
 
+// Determine if we should use osbuild for image building
+def use_osbuild = pipeutils.get_use_osbuild_for_stream(pipecfg, params.STREAM)
+
 def getLockfileInfo(lockfile) {
     def pkgChecksum, pkgTimestamp
     if (utils.pathExists(lockfile)) {
@@ -209,7 +212,7 @@ lock(resource: "bump-lockfile") {
                             shwrap("cosa fetch --strict")
                         }
                         stage("${arch}:Build") {
-                            shwrap("cosa build --force --strict")
+                            shwrap("cosa shell -- env COSA_USE_OSBUILD=${use_osbuild} cosa build --force --strict")
                         }
                         def n = ncpus - 1 // remove 1 for upgrade test
                         kola(cosaDir: env.WORKSPACE, parallel: n, arch: arch,

--- a/utils.groovy
+++ b/utils.groovy
@@ -123,6 +123,9 @@ def get_source_config_ref_for_stream(pipecfg, stream) {
     }
 }
 
+def get_use_osbuild_for_stream(pipecfg, stream) {
+    return pipecfg.streams[stream].use_osbuild ? '1' : ''
+}
 
 // Parse and handle the result of Kola
 boolean checkKolaSuccess(file) {


### PR DESCRIPTION
This is an opt-in for using OSBuild to build the qemu qcow2 for now. It sets the COSA_USE_OSBUILD environment variable to instruct COSA what to do.