### PR TITLE
config: start building hyperv image for aarch64

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -53,6 +53,7 @@ default_artifacts:
     - aws
     - azure
     - gcp
+    - hyperv
   ppc64le:
     - powervs
   s390x:


### PR DESCRIPTION
Follow-up to coreos/fedora-coreos-tracker#1411

I am not familiar with your process, so let me know what I should be following. If you think there should be a new issue for this, for example.  So far after this I am planning to follow up with additional PRs for the web content. 

I tested and verified this works locally on Windows ARM using cost build and cosa buildextend-hyperv.

Thanks!
