### PR TITLE
config: add per-stream `skip_brew_upload` knob

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -97,6 +97,8 @@ streams:
       skip_govcloud_hack: true
       # OPTIONAL/TEMPORARY: don't upload images to clouds
       skip_cloud_uploads: true
+      # OPTIONAL: dont perform Brew uploads
+      skip_brew_upload: true
       # Use newly added support for building images using OSBuild
       use_osbuild: true
 

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -293,7 +293,7 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
             }
         }
 
-        if (brew_profile) {
+        if (brew_profile && !stream_info.skip_brew_upload) {
             stage('Brew Upload') {
                 def tag = pipecfg.streams[params.STREAM].brew_tag
                 for (arch in basearches) {


### PR DESCRIPTION
Add a per-stream knob that enables the ability to skip brew uploads. This will allow us to skip these uploads for streams that don't need to be uploaded to brew, like development RHCOS builds that are based on CentOS Stream.

Fixes: https://github.com/coreos/fedora-coreos-pipeline/issues/922