### PR TITLE
jobs/release: update logic that makes AMIs public

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -369,7 +369,7 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
                 def bucket_prefix = "${pipecfg.s3.bucket}/${pipecfg.s3.builds_key}"
 
                 // make AMIs public if not already the case
-                if (!pipecfg.clouds?.aws?.public) {
+                if (pipecfg.clouds?.aws?.public) {
                     def rc = shwrapRc("""
                     cosa shell -- plume make-amis-public \
                         --version ${params.VERSION} \


### PR DESCRIPTION
Remove the not symbol here to ensure it creates the correct behavior where this code doesn't run when `public: false` is set like in the rhcos devel pipeline.