### PR TITLE
config: make `check_kernel_rt_mismatch_rhcos` a per-stream knob

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -99,6 +99,8 @@ streams:
       skip_cloud_uploads: true
       # Use newly added support for building images using OSBuild
       use_osbuild: true
+      # OPTIONAL: require kernel + kernel-rt versions to match
+      check_kernel_rt_mismatch_rhcos: true
 
 # REQUIRED: architectures to build for other than x86_64
 additional_arches: [aarch64, ppc64le, s390x]
@@ -262,7 +264,5 @@ clouds:
 misc:
   # OPTIONAL: whether to generate a release index
   generate_release_index: true
-  # OPTIONAL: require kernel + kernel-rt versions to match
-  check_kernel_rt_mismatch_rhcos: true
   # OPTIONAL: whether to run extended upgrade test kola job
   run_extended_upgrade_test_fcos: true

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -381,7 +381,7 @@ lock(resource: "build-${params.STREAM}") {
             // NOTE: This approach only checks the legacy extensions and not the new extensions
             // container. This check can be removed for 9.3+ builds when we drop the legacy
             // oscontainer as the versions will be matched using `match-base-evr` in `extensions.yaml`.
-            if (pipecfg.misc?.check_kernel_rt_mismatch_rhcos) {
+            if (stream_info.check_kernel_rt_mismatch_rhcos) {
                 echo("Verifying kernel + kernel-rt versions match")
                 def build_meta = [readJSON(file: "builds/latest/${basearch}/commitmeta.json"), readJSON(file: "builds/latest/${basearch}/meta.json")]
                 def kernel_version = build_meta[0]['ostree.linux'].split('.el')[0]


### PR DESCRIPTION
Alter the `check_kernel_rt_mismatch_rhcos` knob to be configurable per-stream instead of globally. This will allow us to skip running this mismatch check on certain streams, like development RHCOS builds based on CentOS Streams.

This PR will require a change to the rhcos-art and rhcos-devel pipeline configs.