### PR TITLE
jobs/kola-*: remove `skipBasicScenarios`

### DIFF
--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -77,7 +77,6 @@ cosaPod(memory: "512Mi", kvm: false,
                 kola(cosaDir: env.WORKSPACE, parallel: 5,
                      build: params.VERSION, arch: params.ARCH,
                      extraArgs: params.KOLA_TESTS,
-                     skipBasicScenarios: true,
                      platformArgs: '-p=aws --aws-region=us-east-1')
             }
 

--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -184,7 +184,6 @@ EOF
                 build: start_version,
                 cosaDir: env.WORKSPACE,
                 extraArgs: "--tag extended-upgrade --append-butane tmp/target_stream.bu",
-                skipBasicScenarios: true,
                 skipUpgrade: true,
             ]
             def k1, k2, k3


### PR DESCRIPTION
The basic scenarios have been moved out of kola cmd; therefor, `skipBasicScenarios` is no longer needed.

https://github.com/coreos/coreos-assembler/pull/3652