### PR TITLE
ci: cancel previous build on PR update

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,5 +1,10 @@
 // Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
 
+properties([
+    // abort previous runs when a PR is updated to save resources
+    disableConcurrentBuilds(abortPrevious: true)
+])
+
 node {
     checkout scm
 


### PR DESCRIPTION
This is an easy way to save CI resources; when a PR is updated, abort any previous build for that PR to focus on testing the latest push.