### PR TITLE
Revert "config: skip applehv on stable for next set of releases"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,6 @@
 streams:
   stable:
     type: production
-    skip_artifacts:
-      all:
-        - applehv
   testing:
     type: production
   next:


### PR DESCRIPTION
This reverts commit 41121e394c82bc6af843eed3b72472ef8f1adb84. The new Ignition version is being promoted to stable now sow we can allow applehv to be built for stable.