### PR TITLE
manifests: drop "aliased" `jenkins` and `jenkins-agent-base` imagestream tags

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -548,6 +548,13 @@ using a development cluster, it normally isn't, and you can drop it. For
 the Fedora prod cluster, use `ocs-storagecluster-ceph-rbd` as shown
 above.
 
+If using an additional root CA certificate, then you will also need to
+specify the `AGENT_NAMESPACE` parameter to yours, e.g.:
+
+```
+  --param=AGENT_NAMESPACE=fedora-coreos-pipeline \
+```
+
 Now, create the Jenkins configmap:
 
 ```

--- a/deploy
+++ b/deploy
@@ -57,9 +57,8 @@ def process_template(args):
         params.update(params_from_git_refspec(args.pipecfg, 'PIPECFG'))
     if has_additional_root_ca(args):
         templates += ['jenkins-with-cert.yaml']
-        # we want :latest to be owned by our BuildConfig, so call the base
-        # image :base instead of :latest
-        params['JENKINS_BASE_TAG'] = "base"
+        params['JENKINS_S2I_SRC_IMAGESTREAM_NAME'] = "jenkins:latest"
+        params['JENKINS_S2I_SRC_IMAGESTREAM_NAMESPACE'] = get_current_namespace(args)
 
     print("Parameters:")
     for k, v in params.items():
@@ -90,6 +89,11 @@ def has_additional_root_ca(args):
     secrets = subprocess.check_output([args.oc_cmd, 'get', 'secrets', '-o=name'],
                                       encoding='utf-8').splitlines()
     return 'secret/additional-root-ca-cert' in secrets
+
+
+def get_current_namespace(args):
+    return subprocess.check_output([args.oc_cmd, 'project', '--short=true'],
+                                   encoding='utf-8').strip()
 
 
 def update_resources(args, resources):

--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -12,21 +12,24 @@ parameters:
   - description: Git branch/tag reference for Jenkins S2I
     name: JENKINS_S2I_REF
     value: main
-  - name: JENKINS_BASE_TAG
-    description: Tag name of base OpenShift Jenkins agent image
-    value: latest
+  - description: Source imagestream
+    name: JENKINS_S2I_SRC_IMAGESTREAM_NAME
+    value: jenkins:2
+  - description: Namespace of source imagestream
+    name: JENKINS_S2I_SRC_IMAGESTREAM_NAMESPACE
+    value: openshift
 
 # Here's what the flow looks like when no cert is required:
 #
-# ┌─────────────────────┐   ┌────────────────┐   ┌─────────────┐   ┌─────────────┐
-# │ imagestream         │   │ imagestream    │   │ buildconfig │   │ imagestream │
-# │ openshift/jenkins:2 ├──►│ jenkins:latest ├──►│ jenkins-s2i ├──►│ jenkins:2   │
-# └─────────────────────┘   └────────────────┘   └─────────────┘   └─────────────┘
+# ┌─────────────────────┐   ┌─────────────┐   ┌─────────────┐
+# │ imagestream         │   │ buildconfig │   │ imagestream │
+# │ openshift/jenkins:2 ├──►│ jenkins-s2i ├──►│ jenkins:2   │
+# └─────────────────────┘   └─────────────┘   └─────────────┘
 #
-# ┌─────────────────────────────────────┐   ┌───────────────────────────┐
-# │ imagestream                         │   │ imagestream               │
-# │ openshift/jenkins-agent-base:latest ├──►│ jenkins-agent-base:latest │
-# └─────────────────────────────────────┘   └───────────────────────────┘
+# ┌─────────────────────────────────────┐
+# │ imagestream                         │
+# │ openshift/jenkins-agent-base:latest │
+# └─────────────────────────────────────┘
 #
 # And with cert required (see `jenkins-with-cert.yaml`):
 #
@@ -48,17 +51,6 @@ objects:
     kind: ImageStream
     metadata:
       name: jenkins
-    spec:
-      tags:
-        - name: ${JENKINS_BASE_TAG}
-          from:
-            kind: ImageStreamTag
-            name: jenkins:2
-            namespace: openshift
-          referencePolicy:
-            type: Source
-          importPolicy:
-            scheduled: true
   - kind: BuildConfig
     apiVersion: v1
     metadata:
@@ -78,7 +70,8 @@ objects:
         sourceStrategy:
           from:
             kind: ImageStreamTag
-            name: jenkins:latest
+            name: ${JENKINS_S2I_SRC_IMAGESTREAM_NAME}
+            namespace: ${JENKINS_S2I_SRC_IMAGESTREAM_NAMESPACE}
           forcePull: true
       output:
         to:
@@ -93,17 +86,3 @@ objects:
     kind: ImageStream
     metadata:
       name: jenkins-agent-base
-    spec:
-      lookupPolicy:
-        # this allows e.g. the pipeline to directly reference the imagestream
-        local: true
-      tags:
-        - name: ${JENKINS_BASE_TAG}
-          from:
-            kind: ImageStreamTag
-            name: jenkins-agent-base:latest
-            namespace: openshift
-          referencePolicy:
-            type: Source
-          importPolicy:
-            scheduled: true

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -100,7 +100,7 @@ objects:
               -Dfile.encoding=UTF-8
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=900
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true
-              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage=jenkins-agent-base:latest
+              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage=image-registry.openshift-image-registry.svc:5000/${AGENT_NAMESPACE}/jenkins-agent-base:latest
               -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultCpuRequest=1
               -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultMemoryRequest=512Mi
               -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultCpuLimit=1
@@ -255,6 +255,11 @@ parameters:
 - description: The OpenShift Namespace where the Jenkins ImageStream resides.
   displayName: Jenkins ImageStream Namespace
   name: NAMESPACE
+  value: openshift
+# DELTA: add separate agent namespace parameter
+- description: The OpenShift Namespace where the Jenkins Agent ImageStream resides.
+  displayName: Jenkins Agent ImageStream Namespace
+  name: AGENT_NAMESPACE
   value: openshift
 - description: Whether to perform memory intensive, possibly slow, synchronization
     with the Jenkins Update Center on start.  If true, the Jenkins core update monitor


### PR DESCRIPTION
In the case where we don't need custom certs, we had the
`openshift/jenkins:2` imagestream feed into the `jenkins:latest`
imagestream, which then was the input to the S2I build.

And similarly, we had `openshift/jenkins-agent-base:latest` feed  into
`jenkins-agent-base:latest`.

In eb70bf7 ("manifests/jenkins-s2i: set `scheduled` on our
imagestreams"), we added `scheduled: true` for those tags thinking they would
keep those imagestreams up to date with the `openshift/` ones. But in
fact, `scheduled: true` only works when an imagestream tracks an image
in an external registry.

There is no way as far as I can tell to have an imagestream tag track
another imagestream tag. The closest is aliases, but those only work
for tags within the same imagestream, not different imagestreams. This is
by design (see https://github.com/openshift/origin/pull/13595).

So we'd have to add more code to periodically `oc tag` them to keep them
up to date, and that doesn't seem worth it.

Instead, cut it out entirely.

So now, in the non-cert case, we really just have our buildconfig output
to an imagestream and that's it.

The cert flow remains unchanged.

To deal with the agent image being *either* the
`openshift/jenkins-agent-base` one or our custom one with a cert, we
have to parameterize the `defaultImage` property of the Kubernetes
plugin in `jenkins.yaml`.

