### PR TITLE
config: add temporary `hacks.ppc64le_kola_minimal` knob

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -36,6 +36,8 @@ hacks:
   skip_upgrade_tests: true
   # OPTIONAL: skip UEFI on older RHCOS
   skip_uefi_tests_on_older_rhcos: true
+  # OPTIONAL/TEMPORARY: run less tests on ppc64le
+  ppc64le_kola_minimal: true
 
 # OPTIONAL/TEMPORARY: whether to use `versionary` to derive version numbers
 versionary_hack: true

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -298,10 +298,17 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         // Run Kola Tests
         stage("Kola") {
             def n = 4 // VMs are 2G each and arch builders have approx 32G
-            kola(cosaDir: env.WORKSPACE, parallel: n, arch: basearch,
-                 skipUpgrade: pipecfg.hacks?.skip_upgrade_tests,
-                 allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
-                 skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack)
+            // XXX: only run the basic test if this hack is enabled; temporary
+            // measure for ppc64le move in RHCOS pipeline
+            if (pipecfg.hacks?.ppc64le_kola_minimal) {
+                kola(cosaDir: env.WORKSPACE, arch: basearch,
+                     skipUpgrade: true, extraArgs: 'basic')
+            } else {
+                kola(cosaDir: env.WORKSPACE, parallel: n, arch: basearch,
+                     skipUpgrade: pipecfg.hacks?.skip_upgrade_tests,
+                     allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
+                     skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack)
+            }
         }
 
         // Build the remaining artifacts
@@ -323,9 +330,18 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
 
         // Run Kola TestISO tests for metal artifacts
         if (shwrapCapture("cosa meta --get-value images.live-iso") != "None") {
-            stage("Kola:TestISO") {
-                kolaTestIso(cosaDir: env.WORKSPACE, arch: basearch,
-                            skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack)
+            // XXX: only run the basic test if this hack is enabled; temporary
+            // measure for ppc64le move in RHCOS pipeline
+            if (pipecfg.hacks?.ppc64le_kola_minimal) {
+                stage("Kola:TestISO") {
+                    kolaTestIso(cosaDir: env.WORKSPACE, arch: basearch,
+                                extraArgs: "iso-live-login.ppcfw")
+                }
+            } else {
+                stage("Kola:TestISO") {
+                    kolaTestIso(cosaDir: env.WORKSPACE, arch: basearch,
+                                skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack)
+                }
             }
         }
 


### PR DESCRIPTION
This knob will be used in the RHCOS pipeline to avoid running heavy tests without KVM support on ppc64le.

Related: https://issues.redhat.com/browse/COS-2554