### PR TITLE
jobs/build-arch: only run one ppc64le build at a time with ppc64le_kola_minimal

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -110,6 +110,10 @@ lock(resource: "release-${params.VERSION}-${basearch}") {
 // build lock: we don't want multiple concurrent builds for the same stream and
 // arch (though this should work fine in theory)
 lock(resource: "build-${params.STREAM}-${basearch}") {
+// XXX: only run one ppc64le build at a time; temporary measure for ppc64le move
+// in RHCOS pipeline
+pipeutils.conditionalLock(pipecfg.hacks?.ppc64le_kola_minimal &&
+                          basearch == "ppc64le", [resource: "build-${basearch}"]) {
     cosaPod(cpu: "${ncpus}",
             memory: "${cosa_memory_request_mb}Mi",
             image: cosa_controller_img,
@@ -460,4 +464,4 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             --state FINISHED --result ${currentBuild.result}
         """)
     }
-}}}}} // finally, cosaPod, timeout, and locks finish here
+}}}}}} // finally, cosaPod, timeout, and locks finish here

--- a/utils.groovy
+++ b/utils.groovy
@@ -277,6 +277,17 @@ def tryWithOrWithoutCredentials(creds, Closure body) {
     }
 }
 
+// Runs closure within lock if cond is true.
+def conditionalLock(cond, locks, Closure body) {
+    if (cond) {
+        lock(locks) {
+            body()
+        }
+    } else {
+        body()
+    }
+}
+
 // Runs closure if the fedmsg credentials exist, otherwise gracefully return.
 def tryWithMessagingCredentials(Closure body) {
     // Here we need to use `dockerCert`, which was renamed to


### PR DESCRIPTION
Our builder only has 32G of RAM. Combined with the fact that ppc64le VMs require a minimum of 4G of RAM, that doesn't leave much capacity for parallelism. We don't run tests, but multiple artifacts launch VMs.

Let's bring it down to 1 build at a time to make it more reliable. If the throughput is too slow, we'll bump to a beefier instance and increase parallelism here.