### PR TITLE
jobs/build: increase timeout with ppc64le_kola_minimal

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -114,6 +114,11 @@ def newBuildID, basearch
 
 // matches between build/build-arch job
 def timeout_mins = 240
+if (pipecfg.hacks?.ppc64le_kola_minimal) {
+    // XXX: extend the timeout for ppc64le; temporary measure for ppc64le move
+    // in RHCOS pipeline
+    timeout_mins = 300
+}
 
 if (params.WAIT_FOR_RELEASE_JOB) {
     // Waiting for the release job effectively means waiting for all the build-


### PR DESCRIPTION
The build-arch timeout was increased to 5h with the ppc64le_kola_minimal hack. Increase the build job's timeout to 5h as well so it doesnt timeout when waiting for the multi-arch job to complete.

See: https://github.com/coreos/fedora-coreos-pipeline/pull/944