### PR TITLE
utils: fix azure launching login in run_cloud_tests()

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -486,10 +486,8 @@ def run_cloud_tests(pipecfg, stream, version, cosa, basearch, commit) {
     // Kick off the Kola Azure job if we have an artifact, credentials, and testing is enabled.
     if (shwrapCapture("cosa meta --build=${version} --get-value images.azure") != "None" &&
         cloud_testing_enabled_for_arch(pipecfg, 'azure', basearch) &&
-        utils.credentialsExist([file(variable: 'AZURE_KOLA_TESTS_CONFIG_AUTH',
-                                     credentialsId: 'azure-kola-tests-config-auth'),
-                                file(variable: 'AZURE_KOLA_TESTS_CONFIG_PROFILE',
-                                     credentialsId: 'azure-kola-tests-config-profile')])) {
+        utils.credentialsExist([file(variable: 'AZURE_KOLA_TESTS_CONFIG',
+                                     credentialsId: 'azure-kola-tests-config')])) {
         testruns['Kola:Azure'] = { build job: 'kola-azure', wait: false, parameters: params }
     }
 


### PR DESCRIPTION
In 582bfae we changed the azure creds used for testing to a single file/secret. What we didn't do was update the run_cloud_tests() logic to check for the new secret name, it was still using the old secret names.

I assume this continued to work because the old secrets still existed in the pipeline until I recently deleted them because our new secret expired and I noticed the old named ones existed and deleted them.

Fixes 582bfae