### PR TITLE
jobs/check-aws-region: run daily

### DIFF
--- a/jobs/check-aws-regions.Jenkinsfile
+++ b/jobs/check-aws-regions.Jenkinsfile
@@ -8,8 +8,8 @@ node {
 
 properties([
     pipelineTriggers([
-        // check once a day
-        pollSCM('H H * * *')
+        // trigger once a day
+        cron('H H * * *')
     ]),
     buildDiscarder(logRotator(
         numToKeepStr: '20',


### PR DESCRIPTION
Instead of checking for changes in the SCM, lets trigger this job daily like the bump-lockfiles job.