### PR TITLE
jobs/release: emit a single `stream.release` fedmsg

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -397,12 +397,11 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
             }
 
             pipeutils.tryWithMessagingCredentials() {
-                for (basearch in basearches) {
-                    shwrap("""
-                    /usr/lib/coreos-assembler/fedmsg-broadcast --fedmsg-conf=\${FEDORA_MESSAGING_CONF} \
-                        stream.release --build ${params.VERSION} --basearch ${basearch} --stream ${params.STREAM}
-                    """)
-                }
+                def basearch_args = basearches.collect{"--basearch ${it}"}.join(" ")
+                shwrap("""
+                /usr/lib/coreos-assembler/fedmsg-broadcast --fedmsg-conf=\${FEDORA_MESSAGING_CONF} \
+                    stream.release --build ${params.VERSION} ${basearch_args} --stream ${params.STREAM}
+                """)
             }
         }
 


### PR DESCRIPTION
That message supports specifying multiple arches now. So let's do that since it's just cleaner that way.