### PR TITLE
multi-arch-builders: Disable Zincati

### DIFF
--- a/multi-arch-builders/coreos-ppc64le-builder.bu
+++ b/multi-arch-builders/coreos-ppc64le-builder.bu
@@ -23,3 +23,7 @@ storage:
       overwrite: true
       contents:
         inline: coreos-ppc64le-builder
+systemd:
+  units:
+    - name: zincati.service
+      enabled: false

--- a/multi-arch-builders/coreos-ppc64le-rhcos-builder.bu
+++ b/multi-arch-builders/coreos-ppc64le-rhcos-builder.bu
@@ -10,3 +10,7 @@ ignition:
     merge:
       - local: coreos-ppc64le-builder.ign
       - local: builder-splunk.ign
+systemd:
+  units:
+    - name: zincati.service
+      enabled: false


### PR DESCRIPTION
 - PPC64LE has issues in Petitboot with auto updates, due it disable it.
 See: https://github.com/coreos/fedora-coreos-tracker/issues/1633