### PR TITLE
plugins: add `matrix-communications`

### DIFF
--- a/jenkins/controller/plugins.txt
+++ b/jenkins/controller/plugins.txt
@@ -32,6 +32,7 @@ splunk-devops-extend:1.10.1
 splunk-devops:1.10.1
 antisamy-markup-formatter:162.v0e6ec0fcfcf6
 jms-messaging:1.1.27
+matrix-communication:13.vdcfb_b_44ce852
 
 # The below list are plugins that are also in base-plugins.txt but for
 # some reason or other we need to temporarily freeze or fast-track.


### PR DESCRIPTION
I'd like to have `bodhi-trigger` in CoreOS CI send messages to Matrix when failures occur. If that works well, we could also in the future move pipeline notifications to Matrix as well.