### PR TITLE
jobs/bump-lockfile: drop use_osbuild use

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -216,7 +216,7 @@ lock(resource: "bump-lockfile") {
                             shwrap("cosa fetch --strict")
                         }
                         stage("${arch}:Build") {
-                            shwrap("cosa shell -- env COSA_USE_OSBUILD=${use_osbuild} cosa build --force --strict")
+                            shwrap("cosa build --force --strict")
                         }
                         def n = ncpus - 1 // remove 1 for upgrade test
                         kola(cosaDir: env.WORKSPACE, parallel: n, arch: arch,


### PR DESCRIPTION
This is no longer necessary since c041f3d and should have been cleaned up in that commit.