### PR TITLE
config: promote `versionary` key, rework it

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -44,8 +44,6 @@ registry_repos:
     repo: quay.io/fedora/fedora-coreos-kubevirt
     tags: ["${STREAM}"]
 
-versionary_hack: true
-
 default_artifacts:
   all:
     - metal
@@ -108,5 +106,6 @@ clouds:
     test_architectures: [x86_64, aarch64]
 
 misc:
+  versionary: true
   generate_release_index: true
   run_extended_upgrade_test_fcos: true

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -37,9 +37,6 @@ hacks:
   # OPTIONAL: skip UEFI on older RHCOS
   skip_uefi_tests_on_older_rhcos: true
 
-# OPTIONAL/TEMPORARY: whether to use `versionary` to derive version numbers
-versionary_hack: true
-
 # OPTIONAL: coreos-assembler image to build with. Supports ${STREAM} variable.
 # If unset, defaults to `quay.io/coreos-assembler/coreos-assembler:main`.
 cosa_img: quay.io/jlebon/coreos-assembler:pr3139-${STREAM}
@@ -60,6 +57,8 @@ streams:
       source_config_ref: main
       # OPTIONAL: override OS variant to use for this stream
       variant: rhcos-9.0
+      # OPTIONAL: override whether to use a versionary for this stream
+      versionary: false
     stable:
       type: production
       # OPTIONAL: override cosa image to use for this stream
@@ -270,6 +269,8 @@ clouds:
 
 # OPTIONAL: miscellaneous options
 misc:
+  # OPTIONAL: whether to use a versionary to derive version numbers
+  versionary: true
   # OPTIONAL: whether to generate a release index
   generate_release_index: true
   # OPTIONAL: whether to run extended upgrade test kola job


### PR DESCRIPTION
The versionary FCOS script was one of the few things that differed between FCOS and RHCOS and was awkwardly attached as a hack knob to work.

Now, we promote it to a proper key under the `misc` section, with support for stream-level overrides. This is prep for also using a versionary in other streams.

The versionary is now part of the source config and cosa knows how to execute it if the `--versionary` argument is passed.