### PR TITLE
config: enable branched stream

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,8 +20,8 @@ streams:
     # for image building rawhide images. https://github.com/coreos/fedora-coreos-tracker/issues/1653
     env:
       COSA_USE_OSBUILD: true
-  # branched:
-  #   type: mechanical
+   branched:
+     type: mechanical
   # bodhi-updates:
   #   type: mechanical
   # bodhi-updates-testing:


### PR DESCRIPTION
Fedora 40 has branched from rawhide. Enable the branched stream to track F40.

xref: https://github.com/coreos/fedora-coreos-config/pull/2862