### PR TITLE
Revert "config.yaml: build `vmware` on aarch64 on rawhide"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,10 +12,6 @@ streams:
     # type: development # do not touch; line managed by `next-devel/manage.py`
   rawhide:
     type: mechanical
-    # for testing https://github.com/coreos/fedora-coreos-tracker/issues/1594
-    additional_artifacts:
-      aarch64:
-        - vmware
     # Set the COSA_USE_OSBUILD environment variable to force use of OSBuild
     # for image building rawhide images. https://github.com/coreos/fedora-coreos-tracker/issues/1653
     env:


### PR DESCRIPTION
This reverts commit 5c6f8a73b9483f84081fb321ebf32f8020b3bde5.

Testing shows this needs more work.
https://github.com/coreos/fedora-coreos-tracker/issues/1594#issuecomment-1955096867