### PR TITLE
config: fixed branched stream indentation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,8 +16,8 @@ streams:
     # for image building rawhide images. https://github.com/coreos/fedora-coreos-tracker/issues/1653
     env:
       COSA_USE_OSBUILD: true
-   branched:
-     type: mechanical
+  branched:
+    type: mechanical
   # bodhi-updates:
   #   type: mechanical
   # bodhi-updates-testing:


### PR DESCRIPTION
This is causing errors in the pipeline parsing the YAML.