### PR TITLE
config: use OSBuild for the branched stream too

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,10 @@ streams:
       COSA_USE_OSBUILD: true
   branched:
     type: mechanical
+    # Set the COSA_USE_OSBUILD environment variable to force use of OSBuild
+    # for image building rawhide images. https://github.com/coreos/fedora-coreos-tracker/issues/1653
+    env:
+      COSA_USE_OSBUILD: true
   # bodhi-updates:
   #   type: mechanical
   # bodhi-updates-testing:


### PR DESCRIPTION
We're phasing this in and it will be enabled for `next` soon enough so let's enable it for `branched` now.