### PR TITLE
`next-devel` is now on Fedora 40 so disable `branched` stream

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,10 +18,10 @@ streams:
     type: mechanical
     env:
       COSA_USE_OSBUILD: true
-  branched:
-    type: mechanical
-    env:
-      COSA_USE_OSBUILD: true
+  #branched:
+  #  type: mechanical
+  #  env:
+  #    COSA_USE_OSBUILD: true
   # bodhi-updates:
   #   type: mechanical
   # bodhi-updates-testing:


### PR DESCRIPTION
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1674