### PR TITLE
drop skip_govcloud_hack

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -94,10 +94,6 @@ streams:
       # OPTIONAL: additional architectures to skip building for
       skip_additional_arches:
         - s390x
-      # OPTIONAL/TEMPORARY: don't upload to govcloud even if cloud is
-      # configured. Can be dropped when RHCOS 4.9 (last release that doesn't
-      # support GovCloud) is EOL.
-      skip_govcloud_hack: true
       # OPTIONAL/TEMPORARY: don't upload images to clouds
       skip_cloud_uploads: true
       # OPTIONAL: dont perform Brew uploads

--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -57,7 +57,6 @@ def replicate_to_clouds(pipecfg, basearch, buildID, stream) {
         }
         credentials = [file(variable: "UNUSED", credentialsId: "aws-govcloud-image-upload-config")]
         if (pipecfg.clouds?.aws?.govcloud &&
-            (pipecfg.streams[stream]?.skip_govcloud_hack != true) &&
             utils.credentialsExist(credentials)) {
             replicators["☁️ 🔄:aws:govcloud"] = {
                 awsReplicateClosure.call(pipecfg.clouds.aws.govcloud,
@@ -177,7 +176,6 @@ def upload_to_clouds(pipecfg, basearch, buildID, stream) {
         }
         credentials = [file(variable: "UNUSED", credentialsId: "aws-govcloud-image-upload-config")]
         if (pipecfg.clouds?.aws?.govcloud &&
-            (pipecfg.streams[stream]?.skip_govcloud_hack != true) &&
             utils.credentialsExist(credentials)) {
             uploaders["☁️ ⬆️ :aws:govcloud"] = {
                 awsUploadClosure.call(pipecfg.clouds.aws.govcloud,


### PR DESCRIPTION
We are no longer building any release that requires this hack. Let's drop it.