### PR TITLE
jobs/build-development: make development streams build daily

### DIFF
--- a/jobs/build-development.Jenkinsfile
+++ b/jobs/build-development.Jenkinsfile
@@ -6,7 +6,10 @@ node {
 }
 
 properties([
-    pipelineTriggers(pipeutils.get_push_trigger()),
+    pipelineTriggers([
+        // run every 24h only for now
+        cron("H H * * *")
+    ]),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 


### PR DESCRIPTION
Over time I'm thinking the build on every push to the git repo is a bit heavy. Often times the changes will be insignificant to warrant building, testing, and pushing all that we do. On the other hand, if there is a change we want we can easily click a button and start a build if we don't want to wait.