### PR TITLE
config: Add `FedoraUser=coreos` tag to AMIs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -89,8 +89,13 @@ clouds:
     # we make our images public in the release job via plume
     public: false
     # Accounts to share newly created AMIs with
+    # Added the FCOS community account so kola can use for testing
     grant_users:
       - "013116697141"
+    # Add FedoraGroup=coreos as per Fedora Policy
+    # Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1605
+    tags:
+      - "FedoraGroup=coreos"
   azure:
     test_resource_group: fedora-coreos-testing
     test_storage_account: fedoracoreostesting

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -151,6 +151,9 @@ clouds:
     # OPTIONAL: accounts to share newly created AMIs with
     grant_users:
       - "1234567890"
+    # OPTIONAL: AWS tags to add on the AMIs
+    tags:
+      - "FedoraGroup=coreos"    
     # REQUIRED (if AWS build upload credentials provided): the region to do
     # initial image creation in.
     primary_region: us-east-1

--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -150,6 +150,9 @@ def upload_to_clouds(pipecfg, basearch, buildID, stream) {
                 extraArgs += c.grant_users.collect{"--grant-user=${it}"}
                 extraArgs += c.grant_users.collect{"--grant-user-snapshot=${it}"}
             }
+            if (c.tags) {
+                extraArgs += c.tags.collect { "--tags=${it}" }
+            }
             if (c.public) {
                 extraArgs += "--public"
             }


### PR DESCRIPTION
We need to add `FedoraGroup=coreos` tag adhering to the Fedora policy for the AWS account.
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1605