### PR TITLE
jobs/build-kola-containers: build weekly

### DIFF
--- a/jobs/build-kola-containers.Jenkinsfile
+++ b/jobs/build-kola-containers.Jenkinsfile
@@ -7,6 +7,8 @@ node {
 
 properties([
     pipelineTriggers([
+        // run weekly to ensure regular updates
+        cron("@weekly"),
         [$class: 'GenericTrigger',
          genericVariables: [
           [


### PR DESCRIPTION
Currently the last time this job ran was over a month ago. Let's build periodically to keep the content fresh and to also know sooner if breaking changes occur.