### PR TITLE
config: enable OSBuild for testing/testing-devel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,8 @@ streams:
     type: production
   testing:
     type: production
+    env:
+      COSA_USE_OSBUILD: true
   next:
     type: production
     env:
@@ -10,6 +12,8 @@ streams:
   testing-devel:
     type: development
     default: true
+    env:
+      COSA_USE_OSBUILD: true
   next-devel:         # do not touch; line managed by `next-devel/manage.py`
     type: development # do not touch; line managed by `next-devel/manage.py`
     env:


### PR DESCRIPTION
They are now on F40 and we can roll this out!

xref: https://github.com/coreos/fedora-coreos-tracker/issues/1653