### PR TITLE
config.yaml: disable next-devel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,8 +14,8 @@ streams:
     default: true
     env:
       COSA_USE_OSBUILD: true
-  next-devel:         # do not touch; line managed by `next-devel/manage.py`
-    type: development # do not touch; line managed by `next-devel/manage.py`
+  # next-devel:         # do not touch; line managed by `next-devel/manage.py`
+    # type: development # do not touch; line managed by `next-devel/manage.py`
     env:
       COSA_USE_OSBUILD: true
   rawhide:

--- a/next-devel/badge.json
+++ b/next-devel/badge.json
@@ -2,6 +2,6 @@
     "schemaVersion": 1,
     "style": "for-the-badge",
     "label": "next-devel",
-    "message": "open",
-    "color": "green"
+    "message": "closed",
+    "color": "lightgrey"
 }

--- a/next-devel/status.json
+++ b/next-devel/status.json
@@ -1,3 +1,3 @@
 {
-    "enabled": true
+    "enabled": false
 }


### PR DESCRIPTION
`testing-devel` is moved back over to F40 and we don't have any differences in `testing-devel` and `next-devel`, so we'll disable it.

Ref : https://github.com/coreos/fedora-coreos-tracker/issues/1674