### PR TITLE
multi-arch-builders: extend AWS tofu bits to work for x86_64 or aarch64

### DIFF
--- a/multi-arch-builders/coreos-aarch64-builder.bu
+++ b/multi-arch-builders/coreos-aarch64-builder.bu
@@ -1,6 +1,5 @@
 # This butane config will do the following:
 #
-# - Merge in the builder-common.ign Ignition file
 # - Allow the builder user to log in with the associated ssh key
 # - Set a hostname
 #

--- a/multi-arch-builders/coreos-x86_64-builder.bu
+++ b/multi-arch-builders/coreos-x86_64-builder.bu
@@ -1,15 +1,10 @@
 # This butane config will do the following:
 #
-# - Merge in the builder-common.ign Ignition file
 # - Allow the builder user to log in with the associated ssh key
 # - Set a hostname
 #
 variant: fcos
 version: 1.4.0
-ignition:
-  config:
-    merge:
-      - local: builder-common.ign
 passwd:
   users:
     - name: builder

--- a/multi-arch-builders/provisioning/aarch64/README.md
+++ b/multi-arch-builders/provisioning/aarch64/README.md
@@ -13,7 +13,7 @@
 
 ```bash
 # Add your credentials to the environment.
-# Be aware for aarch64 the region is us-east-2
+# Be aware for rhcos the region is us-east-2
 HISTCONTROL='ignoreboth'
  export AWS_DEFAULT_REGION=us-east-2
  export AWS_ACCESS_KEY_ID=XXXX
@@ -61,7 +61,7 @@ export TF_VAR_itpaas_splunk_repo=...
    # If you plan to make changes to the code as modules/plugins, go ahead and run it:
    tofu init -upgrade
    # To destroy it run:
-   tofu destroy -target aws_instance.coreos-aarch64-builder
+   tofu destroy -target aws_instance.coreos-builder
 ```
 ## Generating additional resources with unique names
 
@@ -74,18 +74,18 @@ To achieve this, you'll need to manually edit the resource name
 in the Tofu configuration.
 
 ```
-resource "aws_instance" "coreos-aarch64-builder"
+resource "aws_instance" "coreos-builder"
 ```
 Make sure the resource name is unique, in this case
-if I already have a resource named `coreos-aarch64-builder`,
-I need to change it to `coreos-aarch64-devel-builder` for example.
+if I already have a resource named `coreos-builder`,
+I need to change it to `coreos-devel-builder` for example.
 
 I may also want to update the project var:
 
 ```
 variable "project" {
  type    = string
- default = "coreos-aarch64-devel-builder"
+ default = "coreos-devel-builder"
 }
 ```
 

--- a/multi-arch-builders/provisioning/aarch64/architecture.tf
+++ b/multi-arch-builders/provisioning/aarch64/architecture.tf
@@ -1,0 +1,6 @@
+# We are deploying for? aarch64 here
+variable "arch" {
+ type    = string
+ default = "aarch64"
+}
+

--- a/multi-arch-builders/provisioning/aarch64/networks.tf
+++ b/multi-arch-builders/provisioning/aarch64/networks.tf
@@ -2,7 +2,7 @@ resource "aws_vpc" "vpc" {
   count = var.distro == "fcos" ? 1 : 0
   cidr_block           = "172.31.0.0/16"
   tags = {
-    Name = "${var.project}-vpc"
+    Name = "${local.project}-vpc"
   }
 }
 
@@ -27,7 +27,7 @@ resource "aws_subnet" "private_subnets" {
  cidr_block = element(var.private_subnet_cidrs, count.index)
  availability_zone = element(data.aws_availability_zones.azs.names, count.index)
  tags = {
-   Name = "${var.project}-private-subnet-${count.index + 1}"
+   Name = "${local.project}-private-subnet-${count.index + 1}"
  }
 }
 
@@ -40,7 +40,7 @@ resource "aws_route_table" "internet_route" {
     gateway_id = aws_internet_gateway.gw[0].id
   }
   tags = {
-    Name = "${var.project}-ig"
+    Name = "${local.project}-ig"
   }
 }
 

--- a/multi-arch-builders/provisioning/aarch64/security-groups.tf
+++ b/multi-arch-builders/provisioning/aarch64/security-groups.tf
@@ -1,5 +1,19 @@
+locals {
+  rhcos_cidr_blocks = ["0.0.0.0/0"]
+  fcos_cidr_blocks = [
+        # FCOS Production Jenkins
+        "38.145.60.3/32",
+        # FCOS Staging Jenkins
+        "38.145.60.4/32",
+        # Fedora Bastion Hosts
+        # bastion01.fedoraproject.org 
+        "38.145.60.11/32",
+        # bastion02.fedoraproject.org 
+        "38.145.60.12/32",
+    ]
+}
 resource "aws_security_group" "sg" {
-  name        = "${var.project}-security-group"
+  name        = "${local.project}-security-group"
   description = "Allow SSH inbound traffic only"
   vpc_id      = local.aws_vpc_id
 
@@ -8,7 +22,7 @@ resource "aws_security_group" "sg" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.distro == "fcos" ? local.fcos_cidr_blocks : local.rhcos_cidr_blocks
   }
 
   egress {
@@ -19,6 +33,6 @@ resource "aws_security_group" "sg" {
   }
 
   tags = {
-    Name = "${var.project}-security-group"
+    Name = "${local.project}-security-group"
   }
 }

--- a/multi-arch-builders/provisioning/x86_64/README.md
+++ b/multi-arch-builders/provisioning/x86_64/README.md
@@ -1,0 +1,1 @@
+../aarch64/README.md

--- a/multi-arch-builders/provisioning/x86_64/architecture.tf
+++ b/multi-arch-builders/provisioning/x86_64/architecture.tf
@@ -1,0 +1,6 @@
+# We are deploying for? x86_64 here
+variable "arch" {
+ type    = string
+ default = "x86_64"
+}
+

--- a/multi-arch-builders/provisioning/x86_64/main.tf
+++ b/multi-arch-builders/provisioning/x86_64/main.tf
@@ -1,0 +1,1 @@
+../aarch64/main.tf

--- a/multi-arch-builders/provisioning/x86_64/networks.tf
+++ b/multi-arch-builders/provisioning/x86_64/networks.tf
@@ -1,0 +1,1 @@
+../aarch64/networks.tf

--- a/multi-arch-builders/provisioning/x86_64/security-groups.tf
+++ b/multi-arch-builders/provisioning/x86_64/security-groups.tf
@@ -1,0 +1,1 @@
+../aarch64/security-groups.tf


### PR DESCRIPTION
- Now depending on which directory you are in it will do the right thing.
- Handles RHCOS versus FCOS gracefully
- Deletes old provisioning instructions from the README