### PR TITLE
jobs/bump-jenkins-job: update slack notification

### DIFF
--- a/jobs/bump-jenkins-plugins.Jenkinsfile
+++ b/jobs/bump-jenkins-plugins.Jenkinsfile
@@ -143,7 +143,7 @@ node {
         }
         if (currentBuild.result != 'SUCCESS') {
             message = ":fire: ${message}"
-            pipeutils.trySlackSend(message: message)
         }
+        pipeutils.trySlackSend(message: message)
     }
 }


### PR DESCRIPTION
Slack notification intended to be sent at both instances of build success and failure.