### PR TITLE
jobs/bump-jenkins-job: Change in emoji of slack notification

### DIFF
--- a/jobs/bump-jenkins-plugins.Jenkinsfile
+++ b/jobs/bump-jenkins-plugins.Jenkinsfile
@@ -137,7 +137,7 @@ node {
         def message = "bump-jenkins-plugins #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:>"
         if (currentBuild.result == 'SUCCESS') {
             currentBuild.description = "bump-jenkins-plugins ⚡"
-            message = ":sparkles: ${message}"
+            message = ":pr: ${message}"
         } else {
             currentBuild.description = "bump-jenkins-plugins ❌"
         }


### PR DESCRIPTION
A PR would be created after the build run of bump-jenkins-job. To notify about the open PR, it would be better if the emoji is set to ':pr'.