### PR TITLE
jobs/release: tag containers images with version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,7 +37,7 @@ s3:
 registry_repos:
   oscontainer:
     repo: quay.io/fedora/fedora-coreos
-    tags: ["${STREAM}"]
+    tags: ["${STREAM}", "${VERSION}"]
   kubevirt:
     repo: quay.io/fedora/fedora-coreos-kubevirt
     tags: ["${STREAM}"]


### PR DESCRIPTION
This tag the manifest with the full version number. First step for https://github.com/coreos/fedora-coreos-tracker/issues/1367


Is it that simple ? 
Obviously I need to add the GC code as well