### PR TITLE
jobs/build-podman-os: set `deploy-via-container: true`

### DIFF
--- a/jobs/build-podman-os.Jenkinsfile
+++ b/jobs/build-podman-os.Jenkinsfile
@@ -40,7 +40,8 @@ def generate_diskvar_json(shortcommit, arch, artifacts, staging_repo, repo) {
             "image-type": "${artifact["platform"]}",
             "container-imgref": "ostree-remote-registry:fedora:${repo}:5.1",
             "metal-image-size": "3072",
-            "cloud-image-size": "10240"
+            "cloud-image-size": "10240",
+            "deploy-via-container": "true"
         }
         """
         def file_path="./diskvars-${arch}-${artifact["suffix"]}.json"


### PR DESCRIPTION
We implicitly before relied on the osbuild manifest templates to fall into the `ostree container image deploy` path for our use case just by having the `container_repo` key set. But a recent cosa change tweaked this so that now we *must* also explicitly specify `deploy-via-container`.

See also https://github.com/coreos/coreos-assembler/commit/48f11cc8cd928dbd2b2b06927c372b0a10dd1543.