### PR TITLE
utils.groovy: escape MATRIX_WEBHOOK_URL and TOKEN

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -715,7 +715,7 @@ def matrixSend(message) {
 
     shwrap("""
            curl -X POST -H "Content-Type: application/json" \
-           -u $TOKEN $MATRIX_WEBHOOK_URL \
+           -u \$TOKEN \$MATRIX_WEBHOOK_URL \
            --silent \
            -d '
            {


### PR DESCRIPTION
These are environment variables, so we need to escape it to let bash interpret it instead of Groovy.