### PR TITLE
jobs/fix-builds: minor fixes

### DIFF
--- a/jobs/fix-build.Jenkinsfile
+++ b/jobs/fix-build.Jenkinsfile
@@ -56,6 +56,8 @@ if (params.VERSION == "") {
     throw new Exception("Missing VERSION parameter!")
 }
 
+build_description = "${build_description}[$params.VERSION]"
+
 // runtime parameter always wins
 def cosa_img = params.COREOS_ASSEMBLER_IMAGE
 cosa_img = cosa_img ?: pipeutils.get_cosa_img(pipecfg, params.STREAM)
@@ -94,7 +96,7 @@ lock(resource: "sign-${params.VERSION}") {
             pipeutils.shwrapWithAWSBuildUploadCredentials("""
             cosa init --branch ${ref} ${variant} ${pipecfg.source_config.url}
             cosa buildfetch --build=${params.VERSION} \
-                ${arch_args} --artifact=all --url=s3://${s3_stream_dir}/builds \
+                ${arch_args.join(' ')} --artifact=all --url=s3://${s3_stream_dir}/builds \
                 --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG}
             """)
         }
@@ -161,5 +163,5 @@ lock(resource: "sign-${params.VERSION}") {
     currentBuild.result = 'FAILURE'
     throw e
 } finally {
-    pipeutils.trySlackSend(message: ":key: fix-build #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> [${params.STREAM}][${basearches.join(' ')}] (${params.VERSION})")
+    pipeutils.trySlackSend(message: ":hammer: fix-build #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> [${params.STREAM}][${basearches.join(' ')}] (${params.VERSION})")
 }}} // try-catch-finally, cosaPod and lock finish here

--- a/utils.groovy
+++ b/utils.groovy
@@ -507,7 +507,7 @@ def run_cloud_tests(pipecfg, stream, version, cosa, basearch, commit) {
                   string(name: 'SRC_CONFIG_COMMIT', value: commit)]
 
     // Kick off the Kola AWS job if we have an uploaded image, credentials, and testing is enabled.
-    if (shwrapCapture("cosa meta --build=${version} --get-value amis") != "None" &&
+    if (shwrapCapture("cosa meta --build=${version} --arch=${basearch} --get-value amis") != "None" &&
         cloud_testing_enabled_for_arch(pipecfg, 'aws', basearch) &&
         utils.credentialsExist([file(variable: 'AWS_KOLA_TESTS_CONFIG',
                                      credentialsId: 'aws-kola-tests-config')])) {
@@ -518,7 +518,7 @@ def run_cloud_tests(pipecfg, stream, version, cosa, basearch, commit) {
     }
 
     // Kick off the Kola Azure job if we have an artifact, credentials, and testing is enabled.
-    if (shwrapCapture("cosa meta --build=${version} --get-value images.azure") != "None" &&
+    if (shwrapCapture("cosa meta --build=${version} --arch=${basearch} --get-value images.azure") != "None" &&
         cloud_testing_enabled_for_arch(pipecfg, 'azure', basearch) &&
         utils.credentialsExist([file(variable: 'AZURE_KOLA_TESTS_CONFIG',
                                      credentialsId: 'azure-kola-tests-config')])) {
@@ -526,7 +526,7 @@ def run_cloud_tests(pipecfg, stream, version, cosa, basearch, commit) {
     }
 
     // Kick off the Kola GCP job if we have an uploaded image, credentials, and testing is enabled.
-    if (shwrapCapture("cosa meta --build=${version} --get-value gcp") != "None" &&
+    if (shwrapCapture("cosa meta --build=${version} --arch=${basearch} --get-value gcp") != "None" &&
         cloud_testing_enabled_for_arch(pipecfg, 'gcp', basearch) &&
         utils.credentialsExist([file(variable: 'GCP_KOLA_TESTS_CONFIG',
                                      credentialsId: 'gcp-kola-tests-config')])) {
@@ -534,7 +534,7 @@ def run_cloud_tests(pipecfg, stream, version, cosa, basearch, commit) {
     }
 
     // Kick off the Kola OpenStack job if we have an artifact, credentials, and testing is enabled.
-    if (shwrapCapture("cosa meta --build=${version} --get-value images.openstack") != "None" &&
+    if (shwrapCapture("cosa meta --build=${version} --arch=${basearch} --get-value images.openstack") != "None" &&
         cloud_testing_enabled_for_arch(pipecfg, 'openstack', basearch) &&
         utils.credentialsExist([file(variable: 'OPENSTACK_KOLA_TESTS_CONFIG',
                                      credentialsId: 'openstack-kola-tests-config')])) {


### PR DESCRIPTION
- include version in job description
- fix passing `--arch` args to `cosa buildfetch`
- use `:hammer:` emoji instead of `:key:` for Slack message