### PR TITLE
jobs/build: add support for stream level `skip_kola_tags` knob

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -96,6 +96,8 @@ streams:
         COSA_USE_OSBUILD: true
       # OPTIONAL: require kernel + kernel-rt versions to match
       check_kernel_rt_mismatch_rhcos: true
+      # OPTIONAL: list of kola tags to skip for this stream
+      skip_kola_tags: [openshift, needs-internet, luks]
 
 # REQUIRED: architectures to build for other than x86_64
 additional_arches: [aarch64, ppc64le, s390x]

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -305,7 +305,8 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             kola(cosaDir: env.WORKSPACE, parallel: n, arch: basearch,
                  skipUpgrade: pipecfg.hacks?.skip_upgrade_tests,
                  allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
-                 skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack)
+                 skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack,
+                 skipKolaTags: stream_info.skip_kola_tags)
         }
 
         // Build the remaining artifacts

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -374,7 +374,8 @@ lock(resource: "build-${params.STREAM}") {
             kola(cosaDir: env.WORKSPACE, parallel: n, arch: basearch,
                  skipUpgrade: pipecfg.hacks?.skip_upgrade_tests,
                  allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
-                 skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack)
+                 skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack,
+                 skipKolaTags: stream_info.skip_kola_tags)
         }
 
         // If desired let's go ahead and archive+fork the multi-arch jobs

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -220,7 +220,8 @@ lock(resource: "bump-lockfile") {
                         }
                         def n = ncpus - 1 // remove 1 for upgrade test
                         kola(cosaDir: env.WORKSPACE, parallel: n, arch: arch,
-                             marker: arch, allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE)
+                             marker: arch, allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
+                             skipKolaTags: stream_info.skip_kola_tags)
                         stage("${arch}:Build Metal") {
                             shwrap("cosa buildextend-metal")
                             shwrap("cosa buildextend-metal4k")

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -78,7 +78,8 @@ cosaPod(memory: "512Mi", kvm: false,
                      build: params.VERSION, arch: params.ARCH,
                      extraArgs: params.KOLA_TESTS,
                      skipBasicScenarios: true,
-                     platformArgs: '-p=aws --aws-region=us-east-1')
+                     platformArgs: '-p=aws --aws-region=us-east-1',
+                     skipKolaTags: stream_info.skip_kola_tags)
             }
 
             if (params.ARCH == "x86_64") {
@@ -102,7 +103,8 @@ cosaPod(memory: "512Mi", kvm: false,
                          extraArgs: xen_tests,
                          skipUpgrade: true,
                          marker: "xen",
-                         platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=i3.large')
+                         platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=i3.large',
+                         skipKolaTags: stream_info.skip_kola_tags)
                 }
                 parallelruns['Kola:Intel-Ice-Lake'] = {
                     // https://github.com/coreos/fedora-coreos-tracker/issues/1004
@@ -111,7 +113,8 @@ cosaPod(memory: "512Mi", kvm: false,
                          extraArgs: tests,
                          skipUpgrade: true,
                          marker: "intel-ice-lake",
-                         platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=m6i.large')
+                         platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=m6i.large',
+                         skipKolaTags: stream_info.skip_kola_tags)
                 }
             } else if (params.ARCH == "aarch64") {
                 def tests = params.KOLA_TESTS
@@ -125,7 +128,8 @@ cosaPod(memory: "512Mi", kvm: false,
                          extraArgs: tests,
                          skipUpgrade: true,
                          marker: "graviton3",
-                         platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=c7g.xlarge')
+                         platformArgs: '-p=aws --aws-region=us-east-1 --aws-type=c7g.xlarge',
+                         skipKolaTags: stream_info.skip_kola_tags)
                 }
             }
 

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -135,6 +135,7 @@ cosaPod(memory: "${cosa_memory_request_mb}Mi", kvm: false,
                      build: params.VERSION, arch: params.ARCH,
                      extraArgs: params.KOLA_TESTS,
                      skipUpgrade: true,
+                     skipKolaTags: stream_info.skip_kola_tags,
                      platformArgs: """-p=azure                               \
                          --azure-credentials \${AZURE_KOLA_TESTS_CONFIG}     \
                          --azure-location $region                            \

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -78,6 +78,7 @@ cosaPod(memory: "512Mi", kvm: false,
                 kola(cosaDir: env.WORKSPACE, parallel: 5,
                     build: params.VERSION, arch: params.ARCH,
                     extraArgs: params.KOLA_TESTS,
+                    skipKolaTags: stream_info.skip_kola_tags,
                     platformArgs: """-p=gcp \
                         --gcp-json-key=\${GCP_KOLA_TESTS_CONFIG} \
                         --gcp-project=${gcp_project}""")
@@ -97,6 +98,7 @@ cosaPod(memory: "512Mi", kvm: false,
                         build: params.VERSION, arch: params.ARCH,
                         extraArgs: confidential_tests,
                         skipUpgrade: true,
+                        skipKolaTags: stream_info.skip_kola_tags,
                         marker: "confidential",
                         platformArgs: """-p=gcp \
                             --gcp-json-key=\${GCP_KOLA_TESTS_CONFIG} \

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -72,6 +72,7 @@ cosaPod(memory: "512Mi", kvm: false,
                  build: params.VERSION, arch: params.ARCH,
                  extraArgs: "--tag k8s",
                  skipUpgrade: true,
+                 skipKolaTags: stream_info.skip_kola_tags,
                  platformArgs: '-p=aws --aws-region=us-east-1')
         }
 

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -119,6 +119,7 @@ lock(resource: "kola-openstack-${params.ARCH}") {
                      extraArgs: params.KOLA_TESTS,
                      rerunSuccessArgs: "tags=all",
                      skipUpgrade: true,
+                     skipKolaTags: stream_info.skip_kola_tags,
                      platformArgs: """-p=openstack                               \
                          --openstack-config-file=\${OPENSTACK_KOLA_TESTS_CONFIG} \
                          --openstack-flavor=v3-starter-4                         \

--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -186,6 +186,7 @@ EOF
                 extraArgs: "--tag extended-upgrade --append-butane tmp/target_stream.bu",
                 skipBasicScenarios: true,
                 skipUpgrade: true,
+                skipKolaTags: pipecfg.streams[params.STREAM].skip_kola_tags,
             ]
             def k1, k2, k3
 


### PR DESCRIPTION
Kola can now support skipping kola tags per stream \[1]. Add support for that here by modifying each Jenkins job to pass the list of kola tags to skip to the kola function.

\[1]: https://github.com/coreos/coreos-ci-lib/pull/159

See: https://github.com/coreos/fedora-coreos-pipeline/issues/1002