### PR TITLE
ITUP Cluster updates for the RHCOS Pipeline migration

### DIFF
--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -72,6 +72,9 @@ objects:
             kind: ImageStreamTag
             name: ${JENKINS_S2I_SRC_IMAGESTREAM_NAME}
             namespace: ${JENKINS_S2I_SRC_IMAGESTREAM_NAMESPACE}
+          env:
+            - name: JENKINS_UC_DOWNLOAD
+              value: 'https://archives.jenkins.io'
           forcePull: true
       output:
         to:

--- a/utils.groovy
+++ b/utils.groovy
@@ -10,6 +10,8 @@ PROTECTED_JENKINSES = [
         ['fcos-builds', 'prod/streams/${STREAM}', false],
     'https://jenkins-rhcos-devel.apps.ocp-virt.prod.psi.redhat.com/':
         ['rhcos-ci', 'prod/streams/${STREAM}', true],
+    'https://jenkins-rhcos--runtime-int.apps.int.preprod-stable-spoke1-dc-iad2.itup.redhat.com/':
+        ['rhcos-ci', 'prod/streams/${STREAM}', true],
     'https://jenkins-rhcos.apps.ocp-virt.prod.psi.redhat.com/':
         ['art-rhcos-ci', 'prod/streams/${STREAM}', true]
 ]


### PR DESCRIPTION
The following changes are needed to migrate the RHCOS devel pipeline to the new ITUP cluster:

- Add the devel jenkins URL to the list of protected jenkins instances
- Specify the exact mirror to use when downloading Jenkins plugins

```
commit 8fb1f1870648e68211ef2a036cb789d150871363
Author: Michael Armijo <marmijo@redhat.com>
Date:   Mon Jul 1 17:37:08 2024 -0600

    manifests/jenkins-s2i: specify mirror for Jenkins plugins download
    
    The new ITUP cluster for the RHCOS pipeline requires all connections
    to be specified in a FirewallEgress file. Let's use the environment
    variable `JENKINS_UC_DOWNLOAD`[1] to ensure the Jenkins plugins
    are always downloaded from 'https://archives.jenkins.io'
    
    [1]: https://github.com/openshift/jenkins/blob/ffc5df9d865e0c60947477a1ff7d354d1d618daf/2/contrib/jenkins/install-plugins.sh#L248
    
    Co-authored-by: Aashish Radhakrishnan <aaradhak@redhat.com>

commit 3747b142dfea0c993b7e4dbc2afa5c81ea3ac63b
Author: Michael Armijo <marmijo@redhat.com>
Date:   Mon Jun 10 23:19:19 2024 -0600

    utils: add new ITUP devel Jenkins instance to protected Jenkins list
    
    We are migrating the RHCOS prod and devel pipelines to a new ITUP
    cluster. Add the devel Jenkins instance to the list of protected
    Jenkins instances so we can use the s3 bucket in this new cluster.
    
    Co-authored-by: Aashish Radhakrishnan <aaradhak@redhat.com>
```