### PR TITLE
jobs/build-podman-os: set `rootfs-size: 0`

### DIFF
--- a/jobs/build-podman-os.Jenkinsfile
+++ b/jobs/build-podman-os.Jenkinsfile
@@ -41,7 +41,8 @@ def generate_diskvar_json(shortcommit, arch, artifacts, staging_repo, repo) {
             "container-imgref": "ostree-remote-registry:fedora:${repo}:5.1",
             "metal-image-size": "3072",
             "cloud-image-size": "10240",
-            "deploy-via-container": "true"
+            "deploy-via-container": "true",
+            "rootfs-size": "0"
         }
         """
         def file_path="./diskvars-${arch}-${artifact["suffix"]}.json"


### PR DESCRIPTION
Recent cosa change enabled osbuild based `secex` build, where image contains more partitions (for dm-verity) and `root` labeled filesystem is not the last one, so now we should also set `rootfs-size`.

See also https://github.com/coreos/coreos-assembler/commit/443b9da52d5556b70492a3229801619881dabc4d