### PR TITLE
jobs/sync-stream-metadata: use jenkins service account to start pod

### DIFF
--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -18,7 +18,7 @@ properties([
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 
-cosaPod() {
+cosaPod(serviceAccount: "jenkins") {
     try {
         git(url: 'https://github.com/coreos/fedora-coreos-streams',
             branch: 'main', credentialsId: 'github-coreosbot-token-username-password')


### PR DESCRIPTION
Fetching the Slace API Token seems to be failing in this job because the default fedora-coreos-pipeline service account can't access the openshift secrets directly. This is fallout from https://github.com/coreos/fedora-coreos-pipeline/pull/1012 where sending a Slack message on failure was added to this job.