### PR TITLE
jobs/sync-stream-metadata: report successful build result

### DIFF
--- a/jobs/sync-stream-metadata.Jenkinsfile
+++ b/jobs/sync-stream-metadata.Jenkinsfile
@@ -63,6 +63,9 @@ cosaPod(serviceAccount: "jenkins") {
                 """)
             }
         }
+
+        currentBuild.result = 'SUCCESS'
+        
     } catch (e) {
         currentBuild.result = 'FAILURE'
         throw e


### PR DESCRIPTION
The logic for sending the slack message on build failure relies on `currentBuild.result`. Set this variable to `SUCCESS` when completing the job successfully.