### PR TITLE
release: Run garbage collection from release job

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -333,6 +333,12 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
                 }
             }
         }
+        stage('Fork Garbage Collection') {
+            build job: 'garbage-collection', wait: false, parameters: [
+                string(name: 'STREAM', value: params.STREAM),
+                booleanParam(name: 'DRY_RUN', value: false)
+            ]
+        }
         stage('Publish') {
             pipeutils.withAWSBuildUploadCredentials() {
                 // Since some of the earlier operations (like AWS replication) only modify


### PR DESCRIPTION
Trigger the garbage collection job during the `release` job for the respective `stream` which will run the pruning job as specified in `gc-policy.yaml`