### PR TITLE
config: enable branched stream

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,8 +12,8 @@ streams:
     # type: development # do not touch; line managed by `next-devel/manage.py`
   rawhide:
     type: mechanical
-  #branched:
-  #  type: mechanical
+  branched:
+    type: mechanical
   #  env:
   #    COSA_USE_OSBUILD: true
   # bodhi-updates:


### PR DESCRIPTION
Fedora 41 has now branched from rawhide. Enable the branched stream tracking F41.

Needs: https://github.com/coreos/fedora-coreos-config/pull/3092