### PR TITLE
gc-policy.yaml: Update duration for pruning for mechanical streams

### DIFF
--- a/gc-policy.yaml
+++ b/gc-policy.yaml
@@ -1,4 +1,6 @@
 branched:
-    cloud-uploads: 3y
+    cloud-uploads: 1y
 rawhide:
-    cloud-uploads: 3y
+    cloud-uploads: 1y
+bodhi-updates:
+    cloud-uploads: 1y


### PR DESCRIPTION
Update the duration of pruning for the mechanical streams from three years to one year since we didn't start uploading AMIs till `38.20220826.91.0` and can hence use an aggressive approach for these streams. Also add `bodhi-updates` stream for the pruning