### PR TITLE
multi-arch-builders: Set the permission of vfio device

### DIFF
--- a/multi-arch-builders/coreos-s390x-rhcos-builder.bu
+++ b/multi-arch-builders/coreos-s390x-rhcos-builder.bu
@@ -4,6 +4,7 @@
 # - Merge in the builder-splunk.ign Ignition file
 # - Enable the Secure Execution Host
 # - Create and initialize the secex-data volume
+# - Enable the Cex hardware based luks encryption
 #
 variant: fcos
 version: 1.4.0

--- a/multi-arch-builders/create-cex-device.sh
+++ b/multi-arch-builders/create-cex-device.sh
@@ -56,3 +56,10 @@ if [[ "${card_no}.${domain_no}" != ${validate_dom} ]]; then
     echo -e "Mismatched card number. \n"
     exit 1
 fi
+
+echo "Setting the permission on vfio device node."
+if [ ! -c '/dev/vfio/0' ]; then
+    echo -e "Failed setting the permission on '/dev/vfio/0'. \n"
+    exit 1
+fi
+chmod 0666 /dev/vfio/0


### PR DESCRIPTION
To run the cex based luks encryption test, the builder user requires access to `/dev/vfio/0` device. This enable the builder user to use the cex device for luks encryption test. 