### PR TITLE
jobs/kola-upgrade: account for overhead in x86_64 case

### DIFF
--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -72,7 +72,8 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${start_version
 def cosa_memory_request_mb = 1024
 if (params.ARCH == 'x86_64') {
     // local (qemu+x86_64) testing will require more memory
-    cosa_memory_request_mb = 3584
+    // bios=1024, uefi=1024, uefi-secure=1536, overhead=512
+    cosa_memory_request_mb = 1024 + 1024 + 1536 + 512
 }
 
 lock(resource: "kola-upgrade-${params.ARCH}") {


### PR DESCRIPTION
When requesting memory for a COSA pod for x86_64 in the past (274a97a) we basically requested a pod with exactly the amount of memory we needed for the 3 virtual machines (bios,uefi,uefi-secure). This lead to a VM getting killed occasionally at first and then more consistently over time [1]. Most often this would be the uefi-secure VM most likely because that process was using more memory than the other two.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1756