### PR TITLE
jobs/checkaws: Change the URL to use coreos pipeline

### DIFF
--- a/jobs/check-aws-regions.Jenkinsfile
+++ b/jobs/check-aws-regions.Jenkinsfile
@@ -28,7 +28,7 @@ cosaPod(serviceAccount: "jenkins"){
     }
     if (disabled_regions != "") {
         warn("Disabled AWS regions detected: ${disabled_regions}")
-        pipeutils.trySlackSend(message: ":aws: check-aws-regions #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> detected disabled regions: ${disabled_regions}\n :pencil: To enable region -> <https://github.com/aaradhak/fedora-coreos-pipeline/blob/checkaws/docs/aws-region-enable.md|AWS Region Enablement>")
+        pipeutils.trySlackSend(message: ":aws: check-aws-regions #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> detected disabled regions: ${disabled_regions}\n :pencil: To enable region -> <https://github.com/coreos/fedora-coreos-pipeline/blob/main/docs/aws-region-enable.md|AWS Region Enablement>")
         return
     }    
 }


### PR DESCRIPTION
The url in the slack message is pointing to "aaradhak" fcos-pipeline. This needs to be changed to "coreos" fcos-pipeline