### PR TITLE
manifests/jenkins: bump capacity to 25Gi

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -251,7 +251,7 @@ parameters:
   name: VOLUME_CAPACITY
   required: true
   # DELTA: changed from 1Gi
-  value: 20Gi
+  value: 25Gi
 - description: The OpenShift Namespace where the Jenkins ImageStream resides.
   displayName: Jenkins ImageStream Namespace
   name: NAMESPACE


### PR DESCRIPTION
This was done live in cluster, so let's make sure to update our definition so it remains the source of truth.