### PR TITLE
builder-common: Run additional prune job to free up space

### DIFF
--- a/multi-arch-builders/builder-common.bu
+++ b/multi-arch-builders/builder-common.bu
@@ -103,7 +103,8 @@ storage:
       contents:
         inline: |
             [Timer]
-            OnCalendar=*-*-* 05:00:00 UTC
+            OnCalendar=*-*-* 10:00:00 UTC
+            OnCalendar=*-*-* 22:00:00 UTC
             AccuracySec=30m
             Persistent=true
             [Install]


### PR DESCRIPTION
The Aarch64 builder consistently complains about a lack of space, particularly around 10am UTC / 12pm BST (London).
This additional prune job aims to mitigate the space issues.

See: https://github.com/openshift/os/issues/1554