### PR TITLE
manifests: use `scheduled-upgrade` as source ImageStream tag

### DIFF
--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -14,34 +14,34 @@ parameters:
     value: main
   - description: Source imagestream
     name: JENKINS_S2I_SRC_IMAGESTREAM_NAME
-    value: jenkins:2
+    value: jenkins:scheduled-upgrade-redeploy
   - description: Namespace of source imagestream
     name: JENKINS_S2I_SRC_IMAGESTREAM_NAMESPACE
     value: openshift
 
 # Here's what the flow looks like when no cert is required:
 #
-# ┌─────────────────────┐   ┌─────────────┐   ┌─────────────┐
-# │ imagestream         │   │ buildconfig │   │ imagestream │
-# │ openshift/jenkins:2 ├──►│ jenkins-s2i ├──►│ jenkins:2   │
-# └─────────────────────┘   └─────────────┘   └─────────────┘
+# ┌──────────────────────────────────────────────┐   ┌─────────────┐   ┌─────────────┐
+# │ imagestream                                  │   │ buildconfig │   │ imagestream │
+# │ openshift/jenkins:scheduled-upgrade-redeploy ├──►│ jenkins-s2i ├──►│ jenkins:2   │
+# └──────────────────────────────────────────────┘   └─────────────┘   └─────────────┘
 #
-# ┌─────────────────────────────────────┐
-# │ imagestream                         │
-# │ openshift/jenkins-agent-base:latest │
-# └─────────────────────────────────────┘
+# ┌────────────────────────────────────────────────┐
+# │ imagestream                                    │
+# │ openshift/jenkins-agent-base:scheduled-upgrade │
+# └────────────────────────────────────────────────┘
 #
 # And with cert required (see `jenkins-with-cert.yaml`):
 #
-# ┌─────────────────────┐   ┌───────────────────┐   ┌────────────────┐   ┌─────────────┐   ┌─────────────┐
-# │ imagestream         │   │ buildconfig       │   │ imagestream    │   │ buildconfig │   │ imagestream │
-# │ openshift/jenkins:2 ├──►│ jenkins-with-cert ├──►│ jenkins:latest ├──►│ jenkins-s2i ├──►│ jenkins:2   │
-# └─────────────────────┘   └───────────────────┘   └────────────────┘   └─────────────┘   └─────────────┘
+# ┌──────────────────────────────────────────────┐   ┌───────────────────┐   ┌────────────────┐   ┌─────────────┐   ┌─────────────┐
+# │ imagestream                                  │   │ buildconfig       │   │ imagestream    │   │ buildconfig │   │ imagestream │
+# │ openshift/jenkins:scheduled-upgrade-redeploy ├──►│ jenkins-with-cert ├──►│ jenkins:latest ├──►│ jenkins-s2i ├──►│ jenkins:2   │
+# └──────────────────────────────────────────────┘   └───────────────────┘   └────────────────┘   └─────────────┘   └─────────────┘
 #
-# ┌─────────────────────────────────────┐   ┌──────────────────────────────┐   ┌───────────────────────────┐
-# │ imagestream                         │   │ buildconfig                  │   │ imagestream               │
-# │ openshift/jenkins-agent-base:latest ├──►│ jenkins-agent-base-with-cert ├──►│ jenkins-agent-base:latest │
-# └─────────────────────────────────────┘   └──────────────────────────────┘   └───────────────────────────┘
+# ┌────────────────────────────────────────────────┐   ┌──────────────────────────────┐   ┌───────────────────────────┐
+# │ imagestream                                    │   │ buildconfig                  │   │ imagestream               │
+# │ openshift/jenkins-agent-base:scheduled-upgrade ├──►│ jenkins-agent-base-with-cert ├──►│ jenkins-agent-base:latest │
+# └────────────────────────────────────────────────┘   └──────────────────────────────┘   └───────────────────────────┘
 
 objects:
 

--- a/manifests/jenkins-with-cert.yaml
+++ b/manifests/jenkins-with-cert.yaml
@@ -32,7 +32,7 @@ objects:
         dockerStrategy:
           from:
             kind: ImageStreamTag
-            name: jenkins:2
+            name: jenkins:scheduled-upgrade-redeploy
             namespace: openshift
           forcePull: true
       output:
@@ -63,7 +63,7 @@ objects:
         dockerStrategy:
           from:
             kind: ImageStreamTag
-            name: jenkins-agent-base:latest
+            name: jenkins-agent-base:scheduled-upgrade
             namespace: openshift
           forcePull: true
       output:


### PR DESCRIPTION
The `jenkins:2` tag hasn't been rebuilt in almost a year and the Jenkins version and plugin versions are getting out of date. The `scheduled-upgrade` and `scheduled-upgrade-redeploy` tags are rebuilt when there are changes in openshift/jenkins. By using these tags instead, we can keep our Jenkins insance more up-to-date. The `scheduled-upgrade-redeploy` tag will even automatically redeploy Jenkins when new changes are detected. This has been working in the production RHCOS pipeline for a while now.

https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/jenkins/important-changes-to-openshift-jenkins-images#customizing-the-jenkins-image-stream-tag_important-changes-to-openshift-jenkins-images