### PR TITLE
config: enable next-devel 2024-09

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,8 +8,8 @@ streams:
   testing-devel:
     type: development
     default: true
-  # next-devel:         # do not touch; line managed by `next-devel/manage.py`
-    # type: development # do not touch; line managed by `next-devel/manage.py`
+  next-devel:         # do not touch; line managed by `next-devel/manage.py`
+    type: development # do not touch; line managed by `next-devel/manage.py`
   rawhide:
     type: mechanical
   branched:

--- a/next-devel/badge.json
+++ b/next-devel/badge.json
@@ -2,6 +2,6 @@
     "schemaVersion": 1,
     "style": "for-the-badge",
     "label": "next-devel",
-    "message": "closed",
-    "color": "lightgrey"
+    "message": "open",
+    "color": "green"
 }

--- a/next-devel/status.json
+++ b/next-devel/status.json
@@ -1,3 +1,3 @@
 {
-    "enabled": false
+    "enabled": true
 }


### PR DESCRIPTION
Enabling next-devel for the Fedora 41 release process.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1695