### PR TITLE
config: disable branched stream

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,8 +12,8 @@ streams:
     # type: development # do not touch; line managed by `next-devel/manage.py`
   rawhide:
     type: mechanical
-  branched:
-    type: mechanical
+  # branched:
+  #  type: mechanical
   #  env:
   #    COSA_USE_OSBUILD: true
   # bodhi-updates:


### PR DESCRIPTION
Now that `next-devel` has been enabled, we can disable the branched stream.

Wait for https://github.com/coreos/fedora-coreos-pipeline/pull/1035 before merging this.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1695