### PR TITLE
multi-arch-builders: fix the syntax error in cex script

### DIFF
--- a/multi-arch-builders/create-cex-device.sh
+++ b/multi-arch-builders/create-cex-device.sh
@@ -30,7 +30,7 @@ for card in $cards; do
 done
 
 # Validating the card and domain
-if [ -z "${card}" ] || [ -z "${card_domain}"]; then
+if [ -z "${card}" ] || [ -z "${card_domain}" ]; then
     echo "couldn't find card with CCA controller"
     exit 1
 fi


### PR DESCRIPTION

There was a syntax error at line33 `multi-arch-builders/create-cex-device.sh`. 

```
core@coreos-s390x-builder:~$ sudo systemctl status cex-config
● cex-config.service - Create IBM CEX mediate device
     Loaded: loaded (/etc/systemd/system/cex-config.service; enabled; preset: enabled)
    Drop-In: /usr/lib/systemd/system/service.d
             └─10-timeout-abort.conf
     Active: active (exited) since Tue 2024-09-17 08:52:36 UTC; 23h ago
    Process: 2326 ExecStart=/usr/local/bin/create-cex-device.sh (code=exited, status=0/SUCCESS)
   Main PID: 2326 (code=exited, status=0/SUCCESS)
        CPU: 115ms

Sep 17 08:52:36 coreos-s390x-builder systemd[1]: Starting cex-config.service - Create IBM CEX mediate device...
Sep 17 08:52:36 coreos-s390x-builder create-cex-device.sh[2326]: /usr/local/bin/create-cex-device.sh: line 33: [: missing `]'
Sep 17 08:52:36 coreos-s390x-builder create-cex-device.sh[2326]: Freeing adapter and domain.
Sep 17 08:52:36 coreos-s390x-builder create-cex-device.sh[2326]: Configuring the adapter and domain.
Sep 17 08:52:36 coreos-s390x-builder create-cex-device.sh[2326]: Validating the domains.
Sep 17 08:52:36 coreos-s390x-builder create-cex-device.sh[2326]: Setting the permission on vfio device node.
Sep 17 08:52:36 coreos-s390x-builder systemd[1]: Finished cex-config.service - Create IBM CEX mediate device.
```

This has been fixed and tested.

```
Last login: Thu Sep 19 15:57:09 2024 from 172.23.0.1
[root@m13lp71 ~]# cd fedora-coreos-pipeline/

[root@m13lp71 fedora-coreos-pipeline]# cd multi-arch-builders/

[root@m13lp71 multi-arch-builders]# ls
builder-common.bu  coreos-aarch64-builder.bu  coreos-ppc64le-rhcos-builder.bu  coreos-s390x-rhcos-builder.bu  create-cex-device.sh  README.md
builder-splunk.bu  coreos-ppc64le-builder.bu  coreos-s390x-builder.bu          coreos-x86_64-builder.bu       provisioning

[root@m13lp71 multi-arch-builders]# sh create-cex-device.sh 
Freeing adapter and domain.
Configuring the adapter and domain.
Validating the domains.
Setting the permission on vfio device node.

[root@m13lp71 multi-arch-builders]# sh create-cex-device.sh 
68cd2d83-3eef-4e45-b22c-534f90b16cb9
```
 

