### PR TITLE
gc-policy.yaml: Add images and builds pruning

### DIFF
--- a/gc-policy.yaml
+++ b/gc-policy.yaml
@@ -4,3 +4,6 @@ rawhide:
     cloud-uploads: 1y
 bodhi-updates:
     cloud-uploads: 1y
+    images: 58m
+    images-keep: [qemu, live-iso]
+    build: 62m

--- a/jobs/garbage-collection.Jenkinsfile
+++ b/jobs/garbage-collection.Jenkinsfile
@@ -14,7 +14,7 @@ properties([
     pipelineTriggers([]),
     parameters([
         choice(name: 'STREAM',
-               choices: pipeutils.get_streams_choices(pipecfg),
+               choices: pipeutils.get_streams_choices(pipecfg) + ['branched', 'bodhi-updates'],
                description: 'CoreOS stream to run GC'),
         booleanParam(name: 'DRY_RUN',
                      defaultValue: true,


### PR DESCRIPTION
Update the `gc-policy.yaml` to prune the images and the whole builds itself. There's also a field for `images-kept` which we won't pruning when pruning the artifacts in meta.json's `images` key for each build.