### PR TITLE
config: set COSA_TESTISO_DEBUG on non-prod streams for now

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,10 +8,16 @@ streams:
   testing-devel:
     type: development
     default: true
+    env:
+      COSA_TESTISO_DEBUG: true
   next-devel:         # do not touch; line managed by `next-devel/manage.py`
     type: development # do not touch; line managed by `next-devel/manage.py`
+    env:
+      COSA_TESTISO_DEBUG: true
   rawhide:
     type: mechanical
+    env:
+      COSA_TESTISO_DEBUG: true
   # branched:
   #  type: mechanical
   #  env:


### PR DESCRIPTION
We're trying to get more information on the root cause for https://github.com/coreos/fedora-coreos-tracker/issues/1796 and maybe this will help us find a clue.