### PR TITLE
garbage-collection: keep `container_env` as empty map

### DIFF
--- a/jobs/garbage-collection.Jenkinsfile
+++ b/jobs/garbage-collection.Jenkinsfile
@@ -24,7 +24,9 @@ properties([
 
 def build_description = "[${params.STREAM}]"
 def cosa_img = 'quay.io/coreos-assembler/coreos-assembler:main'
-def container_env = pipeutils.get_env_vars_for_stream(pipecfg, params.STREAM)
+// def container_env = pipeutils.get_env_vars_for_stream(pipecfg, params.STREAM)
+// Let's keep container_env as empty map temporarily to prune on disabled streams 
+def container_env = [:]
 def s3_stream_dir = pipeutils.get_s3_streams_dir(pipecfg, params.STREAM)
 def dry_run = params.DRY_RUN ? "--dry-run" : ""
 


### PR DESCRIPTION
Update `container_env` as empty map to make sure we can run the garbage-collection on streams that we are disabled at the moment like `branched` and `bodhi-updates`