### PR TITLE
muliti-arch-builders/splunk: only build the splunk sidecar container

### DIFF
--- a/multi-arch-builders/builder-splunk.bu
+++ b/multi-arch-builders/builder-splunk.bu
@@ -102,14 +102,13 @@ storage:
           Type=oneshot
           RemainAfterExit=yes
           ExecStartPre=nm-online --timeout=30
-          # use `--arch=x86_64` because the RPM doesnt exist for aarch64.
-          # ppc64le and s390x RPMs are not compatible with journald input as mentioned
-          # in the splunk journald documentation for version 8.2.6
-          # https://docs.splunk.com/Documentation/Splunk/8.2.6/Data/CollecteventsfromJournalD
+          # use `--arch=x86_64` because non x86_64 RPMs
+          # are not compatible with journald input as mentioned
+          # in the splunk journald documentation for version 9.3.1 (latest)
+          # https://docs.splunk.com/Documentation/Splunk/9.3.1/Data/CollecteventsfromJournalD
           # The --arch=x86_64 works here because we have `qemu-user-static-x86`
           # installed on non-x86_64 FCOS streams.
-          ExecStart=-podman build --pull-always --cache-ttl=480h --arch=x86_64 -t localhost/splunkforwarder:latest ${ITPAAS_SPLUNK_REPO}
-          ExecStart=-podman build --build-arg project=rhcos-multiarch-builders --cache-ttl=480h --from localhost/splunkforwarder:latest -t localhost/splunkforwarder-rhcos ${SPLUNK_SIDECAR_REPO}
+          ExecStart=-podman build --build-arg project=rhcos-multiarch-builders --cache-ttl=480h --arch=x86_64 -t localhost/splunkforwarder-rhcos ${SPLUNK_SIDECAR_REPO}
           ExecStartPost=-podman image prune --force --filter until=720h
           [Install]
           WantedBy=default.target


### PR DESCRIPTION
The repo we are using to build the ITPAAS splunkforwarder container on the RHCOS multi-arch builders is out of date and references a splunkforwarder rpm that no longer exists in the internal repos. By omitting the build step for this container, we can pull in the already built image from ITPAAS that includes a more recent RPM. 
We'll still use `--arch=x86_64` for the sidecar container to ensure proper logging on non x86_64 builders.

See: https://github.com/coreos/fedora-coreos-pipeline/issues/1044