### PR TITLE
multi-arch-builders: prune external containers/images too

### DIFF
--- a/multi-arch-builders/builder-common.bu
+++ b/multi-arch-builders/builder-common.bu
@@ -91,7 +91,7 @@ storage:
           [Service]
           Type=oneshot
           ExecStart=podman image prune --force
-          ExecStart=podman image prune --all --force --filter until=48h
+          ExecStart=podman image prune --all --external --force --filter until=48h
           ExecStart=podman container prune --force
           ExecStart=podman volume prune --force --filter="label!=persistent"
     - path: /home/builder/.config/systemd/user/prune-container-resources.timer


### PR DESCRIPTION
Sometimes when image builds fail they leave behind containers and images in container storage. We weren't accounting for this in our pruning logic so over time these would grow and cause problems.

An snippet of an example of this is on our ppc64le builder where we had some of these old remnants from nearly two years ago and many since then too:

```
$ podman ps --external
CONTAINER ID  IMAGE                                                                                          COMMAND     CREATED         STATUS         PORTS       NAMES
d7cfa165ae4f  registry.fedoraproject.org/fedora:36                                                           buildah     23 months ago   Storage                    fedora-working-container
e04835810e64  docker.io/library/61f604fbe05fd673fac867f2da16700939930df4421c6b1669461a4da545060f-tmp:latest  buildah     23 months ago   Storage                    9a733ceff5dd-working-container
1dfcfc9b4730  docker.io/library/ac17e3d13d2d66c650f02e180ee4e728645d18d7e52bdc530c1d5462589760bf-tmp:latest  buildah     23 months ago   Storage                    806d78dd9ac9-working-container
...
```