### PR TITLE
jobs: run `cosa push-container-manifest` privileged

### DIFF
--- a/jobs/build-fcos-buildroot.Jenkinsfile
+++ b/jobs/build-fcos-buildroot.Jenkinsfile
@@ -146,12 +146,16 @@ lock(resource: "build-${containername}") {
                     def arch = architecture
                     images += " --image=docker://${params.CONTAINER_REGISTRY_STAGING_REPO}:${arch}-${shortcommit}"
                 }
-                shwrap("""
-                export STORAGE_DRIVER=vfs # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668507
-                cosa push-container-manifest \
-                    --auth=\$REGISTRY_SECRET --tag ${gitref} \
-                    --repo ${params.CONTAINER_REGISTRY_REPO} ${images}
-                """)
+                // arbitrarily selecting the x86_64 builder; we don't run this
+                // locally because podman wants user namespacing (yes, even just
+                // to push a manifest...)
+                pipeutils.withPodmanRemoteArchBuilder(arch: "x86_64") {
+                    shwrap("""
+                        cosa push-container-manifest \
+                            --auth=\$REGISTRY_SECRET --tag ${gitref} \
+                            --repo ${params.CONTAINER_REGISTRY_REPO} ${images}
+                    """)
+                }
             }
 
             stage('Delete Intermediate Tags') {

--- a/jobs/build-kola-containers.Jenkinsfile
+++ b/jobs/build-kola-containers.Jenkinsfile
@@ -186,12 +186,16 @@ lock(resource: "build-kola-containers") {
                         images += " --image=docker://${params.CONTAINER_REGISTRY_STAGING_REPO}:${imageName}-${arch}-${shortcommit}"
                     }
 
-                    shwrap("""
-                        export STORAGE_DRIVER=vfs # https://github.com/coreos/fedora-coreos-pipeline/issues/723#issuecomment-1297668507
-                        cosa push-container-manifest --v2s2 \
-                            --auth=\$REGISTRY_SECRET --tag latest \
-                            --repo ${params.CONTAINER_REGISTRY_ORG}/${imageName} ${images}
-                    """)
+                    // arbitrarily selecting the x86_64 builder; we don't run this
+                    // locally because podman wants user namespacing (yes, even just
+                    // to push a manifest...)
+                    pipeutils.withPodmanRemoteArchBuilder(arch: "x86_64") {
+                        shwrap("""
+                            cosa push-container-manifest --v2s2 \
+                                --auth=\$REGISTRY_SECRET --tag latest \
+                                --repo ${params.CONTAINER_REGISTRY_ORG}/${imageName} ${images}
+                        """)
+                    }
                 }
             }
 


### PR DESCRIPTION
In a recent 4.16 z-stream release, a cri-o backport changed the default seccomp policy to by default block `clone(CLONE_NEW*)` syscalls:

https://github.com/cri-o/cri-o/pull/8514

This affects us in the FCOS pipeline which runs in a cluster that was recently updated. The `podman manifest` commands all AIUI also flow through the default path where it wants to enter a namespace if running rootless even though we don't strictly need root; we're not running containers, just creating manifest lists. Ideally podman would be less eager there.

Anyway, work around this as necessary by running
`cosa push-container-manifest` privileged.

There are two general places where this command is used: in container image build jobs (e.g. `build-cosa`), and in the release job.

Use the multi-arch builders to do this. In the container image build jobs, this feels natural since we're already using the multi-arch builders there. In the release job, it requires cargo culting all the goop associated with remote sessions.

I initially used `cosa supermin-run` which seems like a nice fit here, but it's not in older cosa and it doesn't feel worth backporting and testing vs something we know works.

While we're here, fix the release job to respect container envs and make the Brew injection bit more DRY.