### PR TITLE
build-cosa: Add scheduled trigger to run weekly on Mondays/Wednesdays

### DIFF
--- a/jobs/build-cosa.Jenkinsfile
+++ b/jobs/build-cosa.Jenkinsfile
@@ -26,7 +26,8 @@ properties([
          silentResponse: false,
          regexpFilterText: '$COREOS_ASSEMBLER_GIT_REF',
          regexpFilterExpression: 'main|rhcos-.*'
-        ]
+        ], 
+        cron('H H * * 1,3')
     ]),
     parameters([
       string(name: 'ARCHES',


### PR DESCRIPTION
 - Add a trigger for the Cosa build to execute at least twice a week (Mondays and Wednesdays);
 - This ensures regular builds even if no PRs, maintaining build continuity during periods of inactivity.