### PR TITLE
config: drop hashlist-experimental

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -54,7 +54,6 @@ default_artifacts:
     - metal4k
     - live
     - openstack
-    - hashlist-experimental
   aarch64:
     - applehv
     - aws


### PR DESCRIPTION
If I understand correctly this was never used and we can stop generating it.