### PR TITLE
build-kola-containers: delete local manifests if FORCE

### DIFF
--- a/jobs/build-kola-containers.Jenkinsfile
+++ b/jobs/build-kola-containers.Jenkinsfile
@@ -190,6 +190,13 @@ lock(resource: "build-kola-containers") {
                     // locally because podman wants user namespacing (yes, even just
                     // to push a manifest...)
                     pipeutils.withPodmanRemoteArchBuilder(arch: "x86_64") {
+
+                        // delete previously existing manifests
+                        if ( params.FORCE ) {
+                          shwrap("""
+                            podman manifest rm ${params.CONTAINER_REGISTRY_ORG}/${imageName}
+                          """)
+                        }
                         shwrap("""
                             cosa push-container-manifest --v2s2 \
                                 --auth=\$REGISTRY_SECRET --tag latest \


### PR DESCRIPTION
If a previous run failed while pushing the manifest, subsequent runs will fail because a manifest referencing the same image already exist in the local storage.
This will clear any existing manifests if FORCE is true, allowing re-runs.

The error is:
```
[2024-11-03T17:27:57.249Z] + cosa push-container-manifest --v2s2 --auth=**** --tag latest --repo quay.io/coreos-assembler/nfs --image=docker://quay.io/coreos-assembler/staging:nfs-aarch64-4e45505 --image=docker://quay.io/coreos-assembler/staging:nfs-x86_64-4e45505 --image=docker://quay.io/coreos-assembler/staging:nfs-s390x-4e45505 --image=docker://quay.io/coreos-assembler/staging:nfs-ppc64le-4e45505
[2024-11-03T17:27:57.249Z] 2024-11-03 17:27:57,220 INFO - Running command: ['podman', 'manifest', 'create', 'quay.io/coreos-assembler/nfs:latest']
[2024-11-03T17:27:57.503Z] Error: creating manifest: image name "quay.io/coreos-assembler/nfs:latest" is already associated with image "88541596f5bb4fb033eb24ac82d8325096d9490463019033ed42e5bbdcb86a2c": that name is already in use
```

This happens as a previous run tried to create the `nfs` image, following https://github.com/coreos/coreos-assembler/commit/4e455054513d7e61a19221171bb6eef3891ccff0, but failing to upload it. 
I guess this will go away with some cache refresh but having the force option override it can help 