### PR TITLE
support conditionally building artifacts in an OSBuild stage

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,6 +16,7 @@ streams:
     type: mechanical
     env:
       COSA_TESTISO_DEBUG: true
+    osbuild_experimental: true
   # branched:
   #  type: mechanical
   #  env:

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -98,6 +98,9 @@ streams:
       check_kernel_rt_mismatch_rhcos: true
       # OPTIONAL: list of kola tags to skip for this stream
       skip_kola_tags: [openshift, needs-internet, luks]
+      # OPTIONAL: allow building using OSBuild for artifacts where OSBuild is
+      # not yet the default in CoreOS Assembler.
+      osbuild_experimental: true
 
 # REQUIRED: architectures to build for other than x86_64
 additional_arches: [aarch64, ppc64le, s390x]

--- a/utils.groovy
+++ b/utils.groovy
@@ -427,6 +427,42 @@ def build_artifacts(pipecfg, stream, basearch) {
     // First get the list of artifacts to build from the config
     def artifacts = get_artifacts_to_build(pipecfg, stream, basearch)
 
+    // If `cosa osbuild` is supported then let's build what we can using OSBuild
+    if (shwrapRc("cosa shell -- test -e /usr/lib/coreos-assembler/cmd-osbuild") == 0) {
+        // Determine which platforms are OSBuild experimental versus
+        // stable (i.e. the default is to use OSBuild for them).
+        def experimental = shwrapCapture("cosa osbuild --supported-platforms").tokenize()
+        def stable = shwrapCapture('''
+            cosa shell -- bash -c '
+                for buildextend in /usr/lib/coreos-assembler/cmd-buildextend-*; do
+                    if [ "$(readlink -f ${buildextend})" == "/usr/lib/coreos-assembler/cmd-osbuild" ]; then
+                        # the 42 here chops off /usr/lib/coreos-assembler/cmd-buildextend-
+                        echo "${buildextend:42}"
+                    fi
+                done
+            '
+        ''').tokenize('\n')
+        // Based on the pipeline configuration we'll either use OSBuild for as
+        // much as we can (experimental) or just what it is the default for (stable)
+        def osbuild_supported_artifacts = stable
+        if (pipecfg.streams[stream].osbuild_experimental) {
+            osbuild_supported_artifacts = experimental
+        }
+        // Let's build separately the artifacts that can be built directly with OSBuild.
+        def osbuild_artifacts = []
+        for (artifact in artifacts) {
+            if (artifact in osbuild_supported_artifacts) {
+                osbuild_artifacts += artifact
+            }
+        }
+        if (!osbuild_artifacts.isEmpty()) {
+            artifacts.removeAll(osbuild_artifacts)
+            stage('💽:OSBuild') {
+                shwrap("cosa osbuild ${osbuild_artifacts.join(' ')}")
+            }
+        }
+    }
+
     // Next let's do some massaging of the inputs based on two problems we
     // need to consider:
     //


### PR DESCRIPTION
With https://github.com/coreos/coreos-assembler/pull/3930 we can now build multiple artifacts/platforms in a single OSBuild call. Let's add support here for detecting what artifacts are supported to be built by OSBuild and build them using OSBuild.

We segregate here "experimental" versus "stable" OSbuild built artifacts and add a pipecfg knob for opting into the "experimental" ones being built by OSBuild.