### PR TITLE
jobs: consistently discard old builds

### DIFF
--- a/jenkins/config/seed.yaml
+++ b/jenkins/config/seed.yaml
@@ -18,6 +18,10 @@ jobs:
                                defaultValue: false,
                                description: 'Whether to redefine existing jobs (make sure to rerun all jobs with triggers to re-activate them)'),
                 ]),
+                buildDiscarder(logRotator(
+                    numToKeepStr: '100',
+                    artifactNumToKeepStr: '100'
+                )),
                 durabilityHint('PERFORMANCE_OPTIMIZED')
               ])
 

--- a/jobs/build-development.Jenkinsfile
+++ b/jobs/build-development.Jenkinsfile
@@ -7,6 +7,10 @@ node {
 
 properties([
     pipelineTriggers(pipeutils.get_push_trigger()),
+    buildDiscarder(logRotator(
+        numToKeepStr: '100',
+        artifactNumToKeepStr: '100'
+    )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 

--- a/jobs/build-mechanical.Jenkinsfile
+++ b/jobs/build-mechanical.Jenkinsfile
@@ -10,6 +10,10 @@ properties([
         // run every 24h only for now
         cron("H H * * *")
     ]),
+    buildDiscarder(logRotator(
+        numToKeepStr: '100',
+        artifactNumToKeepStr: '100'
+    )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 

--- a/jobs/cloud-replicate.Jenkinsfile
+++ b/jobs/cloud-replicate.Jenkinsfile
@@ -30,6 +30,10 @@ properties([
              defaultValue: "",
              trim: true)
     ] + pipeutils.add_hotfix_parameters_if_supported()),
+    buildDiscarder(logRotator(
+        numToKeepStr: '100',
+        artifactNumToKeepStr: '100'
+    )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 

--- a/jobs/fix-build.Jenkinsfile
+++ b/jobs/fix-build.Jenkinsfile
@@ -35,6 +35,10 @@ properties([
              defaultValue: "",
              trim: true)
     ] + pipeutils.add_hotfix_parameters_if_supported()),
+    buildDiscarder(logRotator(
+        numToKeepStr: '100',
+        artifactNumToKeepStr: '100'
+    )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 

--- a/jobs/garbage-collection.Jenkinsfile
+++ b/jobs/garbage-collection.Jenkinsfile
@@ -19,7 +19,11 @@ properties([
         booleanParam(name: 'DRY_RUN',
                      defaultValue: true,
                      description: 'Only print what would be deleted')
-    ])
+    ]),
+    buildDiscarder(logRotator(
+        numToKeepStr: '200',
+        artifactNumToKeepStr: '200'
+    ))
 ])
 
 def cosa_img = 'quay.io/coreos-assembler/coreos-assembler:main'

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -40,6 +40,10 @@ properties([
              defaultValue: "",
              trim: true)
     ] + pipeutils.add_hotfix_parameters_if_supported()),
+    buildDiscarder(logRotator(
+        numToKeepStr: '200',
+        artifactNumToKeepStr: '200'
+    )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])
 


### PR DESCRIPTION
Most of our jobs enable build discard, but not all. Turn it on consistently across the board. Use the established setting of 100 for most of them, except for the garbage-collection and release jobs whose logs have more value.