### PR TITLE
jobs/gc: Change the credential for containers deletion

### DIFF
--- a/jobs/garbage-collection.Jenkinsfile
+++ b/jobs/garbage-collection.Jenkinsfile
@@ -62,7 +62,7 @@ lock(resource: "gc-${params.STREAM}") {
 
             withCredentials([
                 file(variable: 'GCP_KOLA_TESTS_CONFIG', credentialsId: 'gcp-image-upload-config'),
-                file(variable: 'REGISTRY_SECRET', credentialsId: 'oscontainer-push-registry-secret'),
+                file(variable: 'REGISTRY_SECRET', credentialsId: 'cosa-push-registry-secret'),
                 file(variable: 'AWS_BUILD_UPLOAD_CONFIG', credentialsId: 'aws-build-upload-config')
             ]) {
                 stage('Garbage Collection') {


### PR DESCRIPTION
We need `cosa-push-registry-secret` to delete quay containers. Updated it from `oscontainer-push-registry-secret`.