### PR TITLE
Revert "jobs/gc: Change the credential for deletion"

### DIFF
--- a/jobs/garbage-collection.Jenkinsfile
+++ b/jobs/garbage-collection.Jenkinsfile
@@ -62,7 +62,7 @@ lock(resource: "gc-${params.STREAM}") {
 
             withCredentials([
                 file(variable: 'GCP_KOLA_TESTS_CONFIG', credentialsId: 'gcp-image-upload-config'),
-                file(variable: 'REGISTRY_SECRET', credentialsId: 'cosa-push-registry-secret'),
+                file(variable: 'REGISTRY_SECRET', credentialsId: 'oscontainer-push-registry-secret'),
                 file(variable: 'AWS_BUILD_UPLOAD_CONFIG', credentialsId: 'aws-build-upload-config')
             ]) {
                 stage('Garbage Collection') {


### PR DESCRIPTION
This reverts commit a962a6c1e79b561111e173db9aec253637d48bfa.
Reason: https://github.com/coreos/fedora-coreos-pipeline/pull/1059#issuecomment-2491123014