### PR TITLE
Rework build-mechanical Jenkins job and add  `scheduled: true` config knob

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -101,6 +101,11 @@ streams:
       # OPTIONAL: allow building using OSBuild for artifacts where OSBuild is
       # not yet the default in CoreOS Assembler.
       osbuild_experimental: true
+      # OPTIONAL: stream will be set as "scheduled"
+      # By default, `build-mechanical` builds all mechanical streams.
+      # When mechanical streams have `scheduled` on, then
+      # `build-mechanical` will only build those streams
+      scheduled: true
 
 # REQUIRED: architectures to build for other than x86_64
 additional_arches: [aarch64, ppc64le, s390x]

--- a/jobs/build-mechanical.Jenkinsfile
+++ b/jobs/build-mechanical.Jenkinsfile
@@ -19,28 +19,16 @@ properties([
 
 node {
     def mechanical_streams = pipeutils.streams_of_type(pipecfg, 'mechanical')
+    def scheduled_streams = pipeutils.scheduled_streams(pipecfg, mechanical_streams)
+    if (scheduled_streams) {
+        mechanical_streams = scheduled_streams
+    }
 
-    change = checkout(
-        [$class: 'GitSCM',
-         userRemoteConfigs: [[url: pipecfg.source_config.url]],
-         branches: pipeutils.streams_as_branches(mechanical_streams)
+    mechanical_streams.each{
+        echo "Triggering build for mechanical stream: ${it}"
+        build job: 'build', wait: false, parameters: [
+          string(name: 'STREAM', value: it),
+          booleanParam(name: 'EARLY_ARCH_JOBS', value: false)
         ]
-    )
-
-    if (pipeutils.triggered_by_push()) {
-        stream = pipeutils.stream_from_branch(change.GIT_BRANCH)
-        if (stream in mechanical_streams) {
-            build job: 'build', wait: false, parameters: [
-              string(name: 'STREAM', value: stream)
-            ]
-        }
-    } else {
-        // cron or manual build: build all mechanical streams
-        mechanical_streams.each{
-            build job: 'build', wait: false, parameters: [
-              string(name: 'STREAM', value: it),
-              booleanParam(name: 'EARLY_ARCH_JOBS', value: false)
-            ]
-        }
     }
 }

--- a/utils.groovy
+++ b/utils.groovy
@@ -384,6 +384,12 @@ def streams_of_type(config, type) {
     return config.streams.findAll{k, v -> v.type == type}.collect{k, v -> k}
 }
 
+// Returns a list of stream names from `streams_subset` that have `scheduled: true` set
+def scheduled_streams(config, streams_subset) {
+    return streams_subset.findAll{stream ->
+        config.streams[stream].scheduled}.collect{k, v -> k}
+}
+
 def get_streams_choices(config) {
     def default_stream = config.streams.find{k, v -> v['default'] == true}?.key
     def other_streams = config.streams.keySet().minus(default_stream) as List


### PR DESCRIPTION
Changes include: 
- Rework build-mechanical Jenkins Job:
  - Change the logic of build-mechanical to continue to build all mechanical streams every 24 hours with the conditions set on the `scheduled: true` knob:
    - if any mechanical stream has the knob set, then only trigger those streams
    - if no mechanical stream has the knob set, then trigger all mechanical streams 
  - This will be used to build the rhel-9.6 and c9s streams in the RHCOS pipeline on a schedule. 
- `scheduled: true` knob:
  - used to flag streams that will be built on a schedule using the new `build-scheduled` Jenkins job. Specifically, this knob will be used to build two new RHCOS streams every two days.
- utils.groovy `scheduled_streams` method:
  - From a provided list, returns a subset of streams  with the `scheduled: true` knob set The method is used by the build-mechanical Jenkins job to build only streams with the knob set to true.

See: https://issues.redhat.com/browse/COS-3012