### PR TITLE
config: re-enable `kola-openstack`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -110,7 +110,7 @@ clouds:
       - "fedora-coreos-${STREAM}"
       - "https://compute.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
   openstack:
-    test_architectures: [none]
+    test_architectures: [x86_64, aarch64]
 
 misc:
   versionary: true


### PR DESCRIPTION
The `kola-openstack` job is passing again, so lets re-enable the job in the pipeline. There must have been some temporary issues with Vexxhost.

See: https://github.com/coreos/fedora-coreos-pipeline/issues/1061

This reverts commit e36f84eff14408070b2498d41b1161f191654f22.