### PR TITLE
jobs/build-mechanical: use `propagate: false` to wait for build

### DIFF
--- a/jobs/build-mechanical.Jenkinsfile
+++ b/jobs/build-mechanical.Jenkinsfile
@@ -25,14 +25,10 @@ node {
     }
 
     mechanical_streams.each{
-        try {
-            echo "Triggering build for mechanical stream: ${it}"
-            build job: 'build', wait: true, parameters: [
-              string(name: 'STREAM', value: it),
-              booleanParam(name: 'EARLY_ARCH_JOBS', value: false)
-            ]
-        } catch (e) {
-            echo "Build failed for mechanical stream: ${it}"
-        }   
+        echo "Triggering build for mechanical stream: ${it}"
+        build job: 'build', wait: true, propagate: false, parameters: [
+          string(name: 'STREAM', value: it),
+          booleanParam(name: 'EARLY_ARCH_JOBS', value: false)
+        ]
     }
 }


### PR DESCRIPTION
If a scheduled build fails, the build-mechanical job will fail. Instead of the try/catch block to solve this, use `propagate: false`  instead to build each scheduled stream regardless of the build result.

follow-on to: https://github.com/coreos/fedora-coreos-pipeline/pull/1076