### PR TITLE
config: add `streams[].skip_disk_images`

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -59,6 +59,10 @@ streams:
       variant: rhcos-9.0
       # OPTIONAL: override whether to use a versionary for this stream
       versionary: false
+      # OPTIONAL: Whether to skip disk image generation and upload. This
+      # is equivalent to listing all live artifacts and cloud platforms in
+      # `skip_artifacts`.
+      skip_disk_images: true
     stable:
       type: production
       # OPTIONAL: override cosa image to use for this stream

--- a/utils.groovy
+++ b/utils.groovy
@@ -425,6 +425,11 @@ def get_artifacts_to_build(pipecfg, stream, basearch) {
         artifacts -= pipecfg.streams[stream].skip_artifacts?.all ?: []
         artifacts -= pipecfg.streams[stream].skip_artifacts?."${basearch}" ?: []
     }
+    if (pipecfg.streams[stream].skip_disk_images) {
+        // Only keep the extensions container. Note that the ostree container
+        // and QEMU image are always built and not skippable artifacts.
+        artifacts = artifacts.intersect(["extensions-container"])
+    }
     return artifacts.unique()
 }
 


### PR DESCRIPTION
As part of https://github.com/openshift/enhancements/pull/1637, we've moved OCP 4.19 to use bootimages with RHEL content only. This means that the bootimages built with OCP content will never be used in practice.

Add a `skip_disk_images` knob to disable building them.

We still generate the QEMU image for kola tests to run and because they're useful to debug, but we drop everything else. (Actually, we could also not generate the QEMU image either and sanity-check the OCI image with `kola run --oscontainer`, but that requires more rewiring.)

We don't generate live media since I don't think the test coverage from that is meaningfully different enough from the RHEL-only variants given that the additional OCP packages are unrelated.