### PR TITLE
release: allow pushing container images to multipes repositories

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -40,11 +40,11 @@ s3:
 
 registry_repos:
   oscontainer:
-    repo: quay.io/fedora/fedora-coreos
-    tags: ["${STREAM}", "${VERSION}"]
+    - repo: quay.io/fedora/fedora-coreos
+      tags: ["${STREAM}", "${VERSION}"]
   kubevirt:
-    repo: quay.io/fedora/fedora-coreos-kubevirt
-    tags: ["${STREAM}"]
+    - repo: quay.io/fedora/fedora-coreos-kubevirt
+      tags: ["${STREAM}"]
 
 default_artifacts:
   all:

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -81,6 +81,12 @@ streams:
       # OPTIONAL: override additional architectures to build for
       additional_arches:
         - s390x
+      # OPTIONAL: add OCI registries to upload images to, specific to this stream.
+      # This will be merged with the `registry_repos` key.
+      additional_registry_repos:
+        oscontainer:
+          - repo: quay.io/someorg/someimage
+            tags: ["${STREAM}"] 
     rawhide:
       type: mechanical
       # OPTIONAL: additional architectures to skip building for
@@ -138,25 +144,29 @@ brew:
 registry_repos:
   # OPTIONAL: repo and tags to which to push oscontainer
   oscontainer:
-    # REQUIRED: repo name
-    repo: quay.io/fedora/fedora-coreos
-    # REQUIRED: list of tags to create/overwrite when pushing
-    #           STREAM and VERSION are supported for templating
-    tags: ["${STREAM}"]
-  # OPTIONAL: repo and tags to which to push legacy oscontainer
+      # REQUIRED: repo name
+    - repo: quay.io/fedora/fedora-coreos
+      # REQUIRED: list of tags to create/overwrite when pushing
+      #           STREAM and VERSION are supported for templating
+      tags: ["${STREAM}"]
+      # multiple push destinations can be specified
+    - repo: quay.io/some_other/registry
+      tags: ["{$STREAM}"]
+   # OPTIONAL: repo and tags to which to push legacy oscontainer
   legacy_oscontainer:
-    repo: quay.io/openshift-release-dev/rhel-coreos-dev
-    tags: ["${STREAM}-legacy", "${VERSION}-legacy"]
+    - repo: quay.io/openshift-release-dev/rhel-coreos-dev
+      tags: ["${STREAM}-legacy", "${VERSION}-legacy"]
   # OPTIONAL: repo and tags to which to push the extensions container
   extensions:
-    repo: quay.io/openshift-release-dev/rhel-coreos-extensions-dev
-    tags: ["${STREAM}-extensions", "${VERSION}-extensions"]
+    - repo: quay.io/openshift-release-dev/rhel-coreos-extensions-dev
+      tags: ["${STREAM}-extensions", "${VERSION}-extensions"]
   # OPTIONAL: repo and tags to which to push kubevirt containerdisk container
   kubevirt:
-    repo: quay.io/fedora/fedora-coreos-kubevirt
-    tags: ["${STREAM}"]
-  # OPTIONAL: whether to push in v2s2 format rather than OCI
-  v2s2: true
+    - repo: quay.io/fedora/fedora-coreos-kubevirt
+      tags: ["${STREAM}"]
+      # OPTIONAL: whether to push in v2s2 format rather than OCI
+      # Default to false if not specified
+      v2s2: true
 
 # OPTIONAL: cloud-related knobs
 clouds:

--- a/utils.groovy
+++ b/utils.groovy
@@ -516,26 +516,29 @@ def build_artifacts(pipecfg, stream, basearch) {
 
 def get_registry_repos(pipecfg, stream, version) {
     def registry_repos = pipecfg.registry_repos ?: [:]
-    // merge top-level registry_repos with stream-specific bits
-    registry_repos += pipecfg.streams[stream].additional_registry_repos ?: [:]
-    for (repo in (registry_repos.keySet() as List)) {
-        if (repo == 'v2s2') {
-            // this is a boolean option, not a registry repo
-            continue
-        }
-        if (registry_repos[repo].tags) {
-            def processed_tags = []
-            for (tag in registry_repos."${repo}".tags) {
-                tag = utils.substituteStr(tag, [STREAM: stream, VERSION: version])
-                if (pipecfg.hotfix) {
-                    // this is a hotfix build; include the hotfix name
-                    // in the tag suffix so we don't clobber official
-                    // tags
-                    tag += "-hotfix-${pipecfg.hotfix.name}"
+    // get stream-specific bits additional repos
+    def additional_repos = pipecfg.streams[stream].additional_registry_repos ?: [:]
+    for (repo_id in (additional_repos.keySet() as List)) {
+        // merge top-level registry_repos with additional repos
+        def merged_registry_repos = registry_repos[repo_id] ?: []
+        registry_repos[repo_id] = merged_registry_repos + (additional_repos[repo_id] ?: [])
+     }
+    for (repo_id in (registry_repos.keySet() as List)) {
+        for (repo in registry_repos[repo_id]) {
+            if (repo.tags) {
+                def processed_tags = []
+                for (tag in repo.tags) {
+                    tag = utils.substituteStr(tag, [STREAM: stream, VERSION: version])
+                    if (pipecfg.hotfix) {
+                        // this is a hotfix build; include the hotfix name
+                        // in the tag suffix so we don't clobber official
+                        // tags
+                        tag += "-hotfix-${pipecfg.hotfix.name}"
+                    }
+                    processed_tags += tag
                 }
-                processed_tags += tag
+                repo.tags = processed_tags
             }
-            registry_repos[repo]['tags'] = processed_tags
         }
     }
     return registry_repos


### PR DESCRIPTION
In RHCOS we need to publish the oscontainer image to the release repo and also the CI repo. Changing the registry_repo object to be an array instead of a map to allow multiple entries.

Patch best reviwed without whitespace changes