### PR TITLE
bump-lockfile: consolidate image building; use OSBuild

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -215,19 +215,17 @@ lock(resource: "bump-lockfile") {
                         stage("${arch}:Fetch") {
                             shwrap("cosa fetch --strict")
                         }
-                        stage("${arch}:Build") {
-                            shwrap("cosa build --force --strict")
+                        stage("${arch}:Build OSTree") {
+                            shwrap("cosa build ostree --force --strict")
+                        }
+                        stage("${arch}:OSBuild") {
+                            shwrap("cosa osbuild qemu metal metal4k live")
                         }
                         def n = ncpus - 1 // remove 1 for upgrade test
                         kola(cosaDir: env.WORKSPACE, parallel: n, arch: arch,
                              marker: arch, allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
                              skipKolaTags: stream_info.skip_kola_tags)
-                        stage("${arch}:Build Metal") {
-                            shwrap("cosa buildextend-metal")
-                            shwrap("cosa buildextend-metal4k")
-                        }
-                        stage("${arch}:Build Live") {
-                            shwrap("cosa buildextend-live --fast")
+                        stage("${arch}:Compress Metal") {
                             // Test metal4k with an uncompressed image and
                             // metal with a compressed one. Limit to 4G to be
                             // good neighbours and reduce chances of getting


### PR DESCRIPTION
We haven't yet switched over the production streams to use OSBuild for the Live ISO/PXE yet, but I think it's time for us to go ahead and switch this job over (since `next` will be on Fedora 42 beta soon, which will be using OSBuild for live*).

While we are here let's just go ahead and build all disks up front, which means less OSBuild invocations to achieve the same result with less effort because we aren't jumping in and out of supermin multiple times.