### PR TITLE
jobs/build: lock buildfetch to avoid simultaneous jobs race condition

### DIFF
--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -51,20 +51,22 @@ cosaPod(memory: "512Mi", kvm: false,
     timeout(time: 30, unit: 'MINUTES') {
     try {
 
-        stage('Fetch Metadata') {
-            def commitopt = ''
-            if (params.SRC_CONFIG_COMMIT != '') {
-                commitopt = "--commit=${params.SRC_CONFIG_COMMIT}"
-            }
-            withCredentials([file(variable: 'AWS_CONFIG_FILE',
-                                  credentialsId: 'aws-build-upload-config')]) {
-                def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
-                def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
-                shwrap("""
-                cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
-                time -v cosa buildfetch --artifact=ostree --build=${params.VERSION} \
-                    --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds
-                """)
+        lock(resource: "kola-cloud-buildfetch") {
+            stage('Fetch Metadata') {
+                def commitopt = ''
+                if (params.SRC_CONFIG_COMMIT != '') {
+                    commitopt = "--commit=${params.SRC_CONFIG_COMMIT}"
+                }
+                withCredentials([file(variable: 'AWS_CONFIG_FILE',
+                                    credentialsId: 'aws-build-upload-config')]) {
+                    def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+                    def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
+                    shwrap("""
+                    cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
+                    time -v cosa buildfetch --artifact=ostree --build=${params.VERSION} \
+                        --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds
+                    """)
+                }
             }
         }
 
@@ -125,7 +127,7 @@ cosaPod(memory: "512Mi", kvm: false,
                             --gcp-confidential-type tdx""")
                 }
             }
-            
+
             // process this batch
             parallel parallelruns
 


### PR DESCRIPTION
jobs/kola: lock kola cloud jobs to avoid race condition
 
There were an issue recently where kola-aws and kola-gcp were
killed in the fetch metadata step because they started
at the same time. This aims to block cloud jobs since
the buildfetch doesn't take long. It shouldn't be too disruptive
to do this across all jobs that buildfetch at the beginning.
 
See: https://github.com/coreos/fedora-coreos-pipeline/issues/1079
