### PR TITLE
config: drop COSA_TESTISO_DEBUG env var

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,15 +9,11 @@ streams:
   testing-devel:
     type: development
     default: true
-    env:
-      COSA_TESTISO_DEBUG: true
   next-devel:         # do not touch; line managed by `next-devel/manage.py`
     type: development # do not touch; line managed by `next-devel/manage.py`
     osbuild_experimental: true
   rawhide:
     type: mechanical
-    env:
-      COSA_TESTISO_DEBUG: true
     osbuild_experimental: true
  #branched:
  #  type: mechanical


### PR DESCRIPTION
I have a sneaking suspicion that this is actually causing some of our ppc64le testiso tests to be more flaky. Let's just drop it for now.