### PR TITLE
jobs/build-node-image: tweak current build description

### DIFF
--- a/jobs/build-node-image.Jenkinsfile
+++ b/jobs/build-node-image.Jenkinsfile
@@ -1,4 +1,4 @@
-def gitref, commit, shortcommit
+def commit, shortcommit
 
 node {
     checkout scm
@@ -134,9 +134,9 @@ lock(resource: "build-node-image") {
         throw e
     } finally {
         if (currentBuild.result == 'SUCCESS') {
-            currentBuild.description = "[${gitref}@${shortcommit}] ⚡"
+            currentBuild.description = "[${params.RELEASE}@${shortcommit}] ⚡"
         } else {
-            currentBuild.description = "[${gitref}@${shortcommit}] ❌"
+            currentBuild.description = "[${params.RELEASE}@${shortcommit}] ❌"
         }
         if (currentBuild.result != 'SUCCESS') {
             message = ":openshift: build-node-image #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> [${params.RELEASE}][${src_config_ref}@${shortcommit}]"


### PR DESCRIPTION
In the `finally` block, set the description to the same format as we do in the `try` block.

Drop unused `gitref` variable.