### PR TITLE
jobs/build-development: make development streams build daily

### DIFF
--- a/jobs/build-development.Jenkinsfile
+++ b/jobs/build-development.Jenkinsfile
@@ -6,7 +6,10 @@ node {
 }
 
 properties([
-    pipelineTriggers(pipeutils.get_push_trigger()),
+    pipelineTriggers([
+        // run every 24h at 5:00 UTC
+        cron("0 5 * * *")
+    ]),
     buildDiscarder(logRotator(
         numToKeepStr: '100',
         artifactNumToKeepStr: '100'
@@ -17,18 +20,17 @@ properties([
 node {
     def development_streams = pipeutils.streams_of_type(pipecfg, 'development')
 
-    change = checkout(
-        [$class: 'GitSCM',
-         userRemoteConfigs: [[url: pipecfg.source_config.url]],
-         branches: pipeutils.streams_as_branches(development_streams)
-        ]
-    )
-
-    stream = pipeutils.stream_from_branch(change.GIT_BRANCH)
-    if (stream in development_streams) {
-        build job: 'build', wait: false, parameters: [
-          string(name: 'STREAM', value: stream),
-          booleanParam(name: 'EARLY_ARCH_JOBS', value: false)
-        ]
-    }
+    parallel development_streams.collectEntries { stream -> [stream, {
+        // If there is a bump-lockfile job running for this stream
+        // let's wait until it is done before we kick off the daily
+        // development build so we get the latest content.
+        echo "Waiting for bump-${stream} lock"
+        lock(resource: "bump-${stream}") {
+            echo "Triggering build for development stream: ${stream}"
+            build job: 'build', wait: false, propagate: false, parameters: [
+              string(name: 'STREAM', value: stream),
+              booleanParam(name: 'EARLY_ARCH_JOBS', value: false)
+            ]
+        }
+    }] }
 }

--- a/jobs/build-mechanical.Jenkinsfile
+++ b/jobs/build-mechanical.Jenkinsfile
@@ -7,8 +7,8 @@ node {
 
 properties([
     pipelineTriggers([
-        // run every 24h at 2am UTC
-        cron("0 2 * * *")
+        // run every 24h at 10:00 UTC
+        cron("0 10 * * *")
     ]),
     buildDiscarder(logRotator(
         numToKeepStr: '100',

--- a/jobs/bump-lockfiles.Jenkinsfile
+++ b/jobs/bump-lockfiles.Jenkinsfile
@@ -1,7 +1,7 @@
 properties([
     pipelineTriggers([
-        // we don't need to bump lockfiles any more often than daily
-        cron("H H * * *")
+        // run every 24h at 04:00 UTC
+        cron("0 4 * * *")
     ]),
     buildDiscarder(logRotator(
         numToKeepStr: '100',


### PR DESCRIPTION
Over time I'm thinking the build on every push to the git repo is a bit heavy. Often times the changes will be insignificant to warrant building, testing, and pushing all that we do. On the other hand, if there is a change we want we can easily click a button and start a build if we don't want to wait.

This commit switches the development streams to build daily similarly to the mechanical ones (i.e. rawhide). It also changes the timing of the build-mechanical and bump-lockfiles jobs and adds a stage to the bump-lockfile job to trigger a build once it has pushed.

The timings are chosen based on:

- bump-lockfiles at 04:00 UTC
    - The bodhi/pungi updates composes seem to run around 0:00 UTC and finish within an hour or two. This gives some extra time so we hopefully trigger a bump-lockfile with the latest content.
- build-development at 05:00 UTC
    - Triggered soon after the bump-lockfiles job it will now wait if there are bump-lockfile jobs running before kicking off the development stream builds.
    - If the bump-lockfile runs failed (and thus didn't trigger a new build at the end of the run) this daily trigger will make sure we still get a build. If the bump-lockfile run finished and a new build was started then this build will wait and hopefully result in "No New Build".
- build-mechanical at 10:00 UTC
    - The rawhide composes seem to run around 5:00 UTC and finish around 7:00 UTC or 8:00 UTC. This runs a rawhide soon after with an hour or so of grace in case the pungi runs start taking more time.