### PR TITLE
config: add hetzner for x86_64 and aarch64

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -55,6 +55,7 @@ default_artifacts:
     - aws
     - azure
     - gcp
+    - hetzner
     - hyperv
   ppc64le:
     - powervs
@@ -69,6 +70,7 @@ default_artifacts:
     - digitalocean
     - exoscale
     - gcp
+    - hetzner
     - hyperv
     - ibmcloud
     - kubevirt


### PR DESCRIPTION
Part of https://github.com/coreos/fedora-coreos-tracker/issues/1874