### PR TITLE
multi-arch-builders/splunk: remove outdated RH Root CA Cert

### DIFF
--- a/multi-arch-builders/builder-splunk.bu
+++ b/multi-arch-builders/builder-splunk.bu
@@ -112,14 +112,10 @@ storage:
           ExecStartPost=-podman image prune --force --filter until=720h
           [Install]
           WantedBy=default.target
-    # Add in Red Hat Root CA Certificates so we can podman build from a
-    # git repo that relies on TLS from one of these CAs. These files will be
+    # Add in Red Hat Root CA Certificate so we can podman build from a
+    # git repo that relies on TLS from one of these CAs. The cert will be
     # processed by coreos-update-ca-trust.service on first boot.
     # See https://certs.corp.redhat.com/ for more information.
-    - path: /etc/pki/ca-trust/source/anchors/2015-IT-Root-CA.pem
-      mode: 0644
-      contents:
-        source: https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem
     - path: /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem
       mode: 0644
       contents:


### PR DESCRIPTION
The 2015 IT Root CA cert is no longer available and is causing the RHCOS multi-arch builders to fail to provision. Let's remove it from the butane config since the 2022 cert is sufficient.