### PR TITLE
jobs/build-node-image: bump timeout

### DIFF
--- a/jobs/build-node-image.Jenkinsfile
+++ b/jobs/build-node-image.Jenkinsfile
@@ -53,7 +53,7 @@ lock(resource: "build-node-image") {
     cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
             memory: "512Mi", kvm: false,
             serviceAccount: "jenkins") {
-    timeout(time: 15, unit: 'MINUTES') {
+    timeout(time: 45, unit: 'MINUTES') {
     try {
 
         def output = shwrapCapture("git ls-remote ${src_config_url} ${src_config_ref}")


### PR DESCRIPTION
All arches finish the node image build in 2 or 3 minutes; ppc64le takes 14 minutes... We really need to get better performance there.

Anyway, since we also need to be able to build the extensions container, we should bump this anyway.