### PR TITLE
jobs/build-node-image: send Slack message on success too

### DIFF
--- a/jobs/build-node-image.Jenkinsfile
+++ b/jobs/build-node-image.Jenkinsfile
@@ -134,10 +134,8 @@ lock(resource: "build-node-image") {
         } else {
             currentBuild.description = "${build_description} ❌"
         }
-        if (currentBuild.result != 'SUCCESS') {
-            message = ":openshift: build-node-image #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> ${build_description}"
-            pipeutils.trySlackSend(message: message)
-        }
+        message = ":openshift: build-node-image #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> ${build_description}"
+        pipeutils.trySlackSend(message: message)
     }
 }}} // cosaPod, timeout, and lock finish here
 


### PR DESCRIPTION
I think it's useful when a new job comes up to start with notifying Slack on success and only later downgrading to on failure only if warranted.

This gives us more insight into how often it runs, whether a rerun passes, or a patch to fix a recent failure worked, etc. And just in general time to evaluate whether that information is useful to us.