### PR TITLE
jobs/release: support triggering build-node-image

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -63,6 +63,9 @@ streams:
       # is equivalent to listing all live artifacts and cloud platforms in
       # `skip_artifacts`.
       skip_disk_images: true
+      # OPTIONAL: make the release job trigger build-node-image for the
+      # following OCP releases once successful
+      build_node_images: ["4.19-9.6"]
     stable:
       type: production
       # OPTIONAL: override cosa image to use for this stream

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -37,41 +37,6 @@ hacks:
   # OPTIONAL: skip UEFI on older RHCOS
   skip_uefi_tests_on_older_rhcos: true
 
-# OPTIONAL: Node image keys
-ocp_node_builds:
-    # REQUIRED: OCP release to build
-    release:
-        "4.19-9.6":
-           # REQUIRED: knobs related to the source config
-           source_config:
-               # REQUIRED: source config repo URL to build
-               url: https://github.com/openshift/os
-               # REQUIRED: source config ref to build
-               ref: master
-               # REQUIRED: image to replace the FROM to build
-           from: quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.6-coreos
-           # REQUIRED: knobs related to the yumrepo to build
-           yumrepo:
-               # REQUIRED: source config repo URL to build
-               url: https://gitlab.cee.redhat.com/coreos/redhat-coreos.git
-               # REQUIRED: source config ref to build
-               ref: master
-               # REQUIRED: repo file name to build
-               file: rhel-9.6.repo
-    # REQUIRED: knobs related to the source config
-    registries:
-        # REQUIRED: staging repo to push the final image built
-        staging: registry.ci.openshift.org/coreos/node-staging
-        # REQUIRED: prodution repo to push the final image built
-        prod:
-          # REQUIRED: the image to push to
-          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-          # REQUIRED: one or more tags to attach to the image
-          tags:
-            - "{RELEASE}-node-image"
-            - "{RELEASE}-{TIMESTAMP}-node-image"
-
-
 # OPTIONAL: coreos-assembler image to build with. Supports ${STREAM} variable.
 # If unset, defaults to `quay.io/coreos-assembler/coreos-assembler:main`.
 cosa_img: quay.io/jlebon/coreos-assembler:pr3139-${STREAM}
@@ -323,3 +288,37 @@ misc:
   generate_release_index: true
   # OPTIONAL: whether to run extended upgrade test kola job
   run_extended_upgrade_test_fcos: true
+
+# OPTIONAL: Node image keys
+ocp_node_builds:
+    # REQUIRED: OCP release to build
+    release:
+        "4.19-9.6":
+           # REQUIRED: knobs related to the source config
+           source_config:
+               # REQUIRED: source config repo URL to build
+               url: https://github.com/openshift/os
+               # REQUIRED: source config ref to build
+               ref: master
+               # REQUIRED: image to replace the FROM to build
+           from: quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.6-coreos
+           # REQUIRED: knobs related to the yumrepo to build
+           yumrepo:
+               # REQUIRED: source config repo URL to build
+               url: https://gitlab.cee.redhat.com/coreos/redhat-coreos.git
+               # REQUIRED: source config ref to build
+               ref: master
+               # REQUIRED: repo file name to build
+               file: rhel-9.6.repo
+    # REQUIRED: knobs related to the source config
+    registries:
+        # REQUIRED: staging repo to push the final image built
+        staging: registry.ci.openshift.org/coreos/node-staginear
+        # REQUIRED: prodution repo to push the final image built
+        prod:
+          # REQUIRED: the image to push to
+          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+          # REQUIRED: one or more tags to attach to the image
+          tags:
+            - "{RELEASE}-node-image"
+            - "{RELEASE}-{TIMESTAMP}-node-image"

--- a/jobs/build-node-image.Jenkinsfile
+++ b/jobs/build-node-image.Jenkinsfile
@@ -8,7 +8,6 @@ node {
 }
 
 properties([
-    pipelineTriggers([cron('H H * * *')]),
     parameters([
       choice(name: 'RELEASE',
              choices: pipeutils.get_streams_choices(pipecfg, true),


### PR DESCRIPTION
We want the ability to trigger build-node-image from the release job
instead of the latter being cron triggered. That way we reduce the
chance of having compose skew when in pre-GA state, and we get fresh
node images soon after the base image is updated.

I had initially made the mechanism more generic, but meh, it didn't seem
worth the complexity. We can always generalize it if another "follow-up
trigger" case shows up.