### PR TITLE
utils: Add timestamp-based tag to avoid image cleanup issues in get_o…

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -61,9 +61,16 @@ ocp_node_builds:
     # REQUIRED: knobs related to the source config
     registries:
         # REQUIRED: staging repo to push the final image built
-        staging: registry.ci.openshift.org/coreos/node-staginear
+        staging: registry.ci.openshift.org/coreos/node-staging
         # REQUIRED: prodution repo to push the final image built
-        prod: quay.io/openshift-release-dev/ocp-v4.0-art-dev:{RELEASE}-node-image
+        prod:
+          # REQUIRED: the image to push to
+          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+          # REQUIRED: one or more tags to attach to the image
+          tags:
+            - "{RELEASE}-node-image"
+            - "{RELEASE}-{TIMESTAMP}-node-image"
+
 
 # OPTIONAL: coreos-assembler image to build with. Supports ${STREAM} variable.
 # If unset, defaults to `quay.io/coreos-assembler/coreos-assembler:main`.

--- a/utils.groovy
+++ b/utils.groovy
@@ -552,16 +552,21 @@ def get_registry_repos(pipecfg, stream, version) {
 
 def get_ocp_node_registry_repo(pipecfg, release, timestamp) {
     def staging_repo = pipecfg.ocp_node_builds.registries.staging
-    def repo_and_tag = utils.substituteStr(pipecfg.ocp_node_builds.registries.prod,
-                                           [RELEASE: release, TIMESTAMP: timestamp])
+    def repo = pipecfg.ocp_node_builds.registries.prod.image
+    def tags = pipecfg.ocp_node_builds.registries.prod.tags
 
-    if (pipecfg.hotfix) {
-        // this is a hotfix build; include the hotfix name
-        // in the tag suffix so we don't clobber official
-        // tags
-        repo_and_tag += "-hotfix-${pipecfg.hotfix.name}"
+    processed_tags = []
+    for (tag in tags) {
+        tag = utils.substituteStr(tag, [RELEASE: release, TIMESTAMP: timestamp])
+        if (pipecfg.hotfix) {
+            // this is a hotfix build; include the hotfix name
+            // in the tag suffix so we don't clobber official
+            // tags
+            tag += "-hotfix-${pipecfg.hotfix.name}"
+        }
+        processed_tags += tag
     }
-    return [staging_repo, repo_and_tag]
+    return [staging_repo, repo, processed_tags]
 }
 
 // Determine if the config.yaml has a test_architectures entry for


### PR DESCRIPTION
…cp_node_registry_repo

- Quay's garbage collection removes untagged images, which can result in lost node images when the same tag is reused. To ensure images persist throughout the CI lifecycle, we need a unique and stable tag.

- While multiple node images may use the same image base (rhel-9.6-coreos), we can't rely solely on that to differentiate them.

- This change introduces a timestamp-based tag (yyyyMMddHHmm) to guarantee uniqueness for each node image build.

- The timestamp is generated at runtime and locked, ensuring no collisions and preserving CI consistency.