### PR TITLE
build: adjust timeout to 300m

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -113,12 +113,7 @@ currentBuild.description = "${build_description} Waiting"
 def newBuildID, basearch
 
 // matches between build/build-arch job
-def timeout_mins = 240
-if (pipecfg.hacks?.ppc64le_kola_minimal) {
-    // XXX: extend the timeout for ppc64le; temporary measure for ppc64le move
-    // in RHCOS pipeline
-    timeout_mins = 300
-}
+def timeout_mins = 300
 
 if (params.WAIT_FOR_RELEASE_JOB) {
     // Waiting for the release job effectively means waiting for all the build-


### PR DESCRIPTION
The build-arch job is already at 300 and we just lost a built because the signing of the OSTree commit took an hour. Sigh..