### PR TITLE
config: enable osbuild_experimental for testing/testing-devel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,12 +3,14 @@ streams:
     type: production
   testing:
     type: production
+    osbuild_experimental: true
   next:
     type: production
     osbuild_experimental: true
   testing-devel:
     type: development
     default: true
+    osbuild_experimental: true
   next-devel:         # do not touch; line managed by `next-devel/manage.py`
     type: development # do not touch; line managed by `next-devel/manage.py`
     osbuild_experimental: true


### PR DESCRIPTION
F42 GA is GO for next Tuesday so we'll go ahead and enable more artifacts for OSBuild building for those streams.