### PR TITLE
jobs:build-node-image: support publishing v2s2 manifests

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -316,12 +316,18 @@ ocp_node_builds:
     # REQUIRED: knobs related to the source config
     registries:
         # REQUIRED: staging repo to push the final image built
-        staging: registry.ci.openshift.org/coreos/node-staginear
+        staging:
+          image: registry.ci.openshift.org/coreos/node-staging
+          # REQUIRED: one or more tags to attach to the image
+          tags: ["${RELEASE}-node-image"]
         # REQUIRED: prodution repo to push the final image built
         prod:
           # REQUIRED: the image to push to
           image: quay.io/openshift-release-dev/ocp-v4.0-art-dev
           # REQUIRED: one or more tags to attach to the image
           tags:
-            - "{RELEASE}-node-image"
-            - "{RELEASE}-{TIMESTAMP}-node-image"
+            - "${RELEASE}-node-image"
+            - "${RELEASE}-${TIMESTAMP}-node-image"
+          # OPTIONAL: whether to push in v2s2 format rather than OCI
+          # Default to false if not specified
+          v2s2: false

--- a/jobs/build-node-image.Jenkinsfile
+++ b/jobs/build-node-image.Jenkinsfile
@@ -73,6 +73,7 @@ lock(resource: "build-node-image") {
         // intermediary images before they are referenced in a multi-arch manifest.
         def registry_staging_tag = registry_staging_tags[0]
 
+        def v2s2 = pipecfg.ocp_node_builds.registries.prod.v2s2 ?: false
         // add any additional root CA cert before we do anything that fetches
         pipeutils.addOptionalRootCA()
 
@@ -100,6 +101,7 @@ lock(resource: "build-node-image") {
                                                 manifest_tag_staging: "${registry_staging_tag}",
                                                 secret: "id=yumrepos,src=${yumrepos_file}", // notsecret (for secret scanners)
                                                 from: build_from,
+                                                v2s2: v2s2,
                                                 extra_build_args: ["--security-opt label=disable", "--mount-host-ca-certs", "--force"])
             }
         }
@@ -115,6 +117,7 @@ lock(resource: "build-node-image") {
                                                manifest_tag_staging: "${registry_staging_tag}-extensions",
                                                secret: "id=yumrepos,src=${yumrepos_file}", // notsecret (for secret scanners)
                                                from: build_from,
+                                               v2s2: v2s2,
                                                extra_build_args: ["--security-opt label=disable", "--mount-host-ca-certs",
                                                                   "--git-containerfile", "extensions/Dockerfile", "--force"])
             }


### PR DESCRIPTION
Some ART tooling does not support OCI manifests yet, so allow creating the manifests in v2s2 support.

This is already supported by COSA so it's just
passing the correct flag and tie it to a knob.
Defaults to false.