### PR TITLE
utils.groovy: use `--preserve-digests` during `skopeo copy`

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -899,7 +899,7 @@ def copy_image(src_image, dest_image, authfile = "") {
         authfile = "--authfile=${authfile}"
     }
     shwrap("""
-        skopeo copy --retry-times 5 --all ${authfile} \
+        skopeo copy --preserve-digests --retry-times 5 --all ${authfile} \
             docker://${src_image} \
             docker://${dest_image}
     """)


### PR DESCRIPTION
We want to ensure that the same digests from the base layers are kept so that we get good deduplication for the initial pivot and also across updates. Make sure that the digests are retained.

Part of https://issues.redhat.com/browse/COS-3144.