### PR TITLE
config: drop osbuild_experimental from most streams

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,25 +1,21 @@
 streams:
   stable:
     type: production
+    osbuild_experimental: true
   testing:
     type: production
-    osbuild_experimental: true
   next:
     type: production
-    osbuild_experimental: true
   testing-devel:
     type: development
     default: true
-    osbuild_experimental: true
   next-devel:         # do not touch; line managed by `next-devel/manage.py`
     type: development # do not touch; line managed by `next-devel/manage.py`
-    osbuild_experimental: true
   rawhide:
     type: mechanical
     osbuild_experimental: true
- #branched:
- #  type: mechanical
- #  osbuild_experimental: true
+  #branched:
+  #  type: mechanical
   # bodhi-updates:
   #   type: mechanical
   # bodhi-updates-testing:


### PR DESCRIPTION
Since https://github.com/coreos/coreos-assembler/pull/4074 most platforms have now been switched to default to osbuild for image building. Let's drop `osbuild_experimental: true` from all streams except for `rawhide` where the next round of experimental osbuild platforms should land first.

Here, we also add it to `stable` stream just in case we do the next build of `stable` (i.e. the first F42 build) with the same COSA that we used for the first F42 `testing` build, which wouldn't have the changed defaults in it.