### PR TITLE
config: enable osbuild_experimental for testing again

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,7 @@ streams:
     osbuild_experimental: true
   testing:
     type: production
+    osbuild_experimental: true
   next:
     type: production
   testing-devel:


### PR DESCRIPTION
We're going to spin a new testing and we're going to use a tagged version of COSA to do it so let's re-enable osbuild_experimental for the testing stream in the config.

See https://github.com/coreos/fedora-coreos-streams/issues/1058#issuecomment-2824575349