### PR TITLE
libcloud: build and replicate aws-winli images for supported streams

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -119,6 +119,8 @@ streams:
       # When mechanical streams have `scheduled` on, then
       # `build-mechanical` will only build those streams
       scheduled: true
+      # OPTIONAL: Create and replicate AWS Windows License Included images for this stream.
+      create_and_replicate_winli_ami: true
 
 # REQUIRED: architectures to build for other than x86_64
 additional_arches: [aarch64, ppc64le, s390x]


### PR DESCRIPTION
Expand the replicate to clouds functionality to build AWS Windows License Included (winli) images for streams that support it before replicating AMIs to other regions. `cosa aws-replicate` will now replicate both traditional AMIs and aws-winli AMIs if present in the metadata.

See: https://github.com/coreos/coreos-assembler/pull/4069

Also add a `winli` knob to the pipeline config clouds.aws section to only build winli images for specific streams.