### PR TITLE
jobs/kola-upgrade: adjust secureboot start version to F37+

### DIFF
--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -200,10 +200,8 @@ EOF
                     // SecureBoot doesn't work on older FCOS builds with latest qemu
                     // so we must run it conditionally.
                     // https://github.com/coreos/fedora-coreos-tracker/issues/1452
-                    def secureboot_start_version = 34
-                    if (start_stream == 'next') {
-                        secureboot_start_version = 35
-                    }
+                    // https://github.com/coreos/fedora-coreos-tracker/issues/1452#issuecomment-2835130860
+                    def secureboot_start_version = 37
                     if ((start_version[0..1] as Integer) >= secureboot_start_version) {
                         k2 = kolaparams.clone()
                         k2.extraArgs += " --qemu-firmware=uefi-secure"


### PR DESCRIPTION
F35 and F36 based FCOS starting points started to fail once we rebased COSA to F42 (and thus update edk2-ovmf).

See https://github.com/coreos/fedora-coreos-tracker/issues/1452#issuecomment-2835130860