### PR TITLE
jobs/nodeimage: use the base image digest for FROM

### DIFF
--- a/jobs/build-node-image.Jenkinsfile
+++ b/jobs/build-node-image.Jenkinsfile
@@ -118,6 +118,7 @@ lock(resource: "build-node-image") {
                                                 secret: "id=yumrepos,src=${yumrepos_file}", // notsecret (for secret scanners)
                                                 from: build_from,
                                                 v2s2: v2s2,
+                                               check_base_match: true,
                                                 extra_build_args: ["--security-opt label=disable", "--mount-host-ca-certs", "--force"] + label_args)
             }
         }


### PR DESCRIPTION
Instead of relying on the tag of the base image, first grab the manifest digest than pass that value to the builders.
This will avoid reusing stale images that may be present in the local containers storage when building.