### PR TITLE
config.yaml: allow stream-level source config URL overrides

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -53,6 +53,8 @@ streams:
       # OPTIONAL: set a stream as the default one
       # This will be the default stream for jobs that take a 'STREAMS' parameter
       default: true
+      # OPTIONAL: override source config URL to use for this stream
+      source_config_url: https://github.com/jlebon/fedora-coreos-config
       # OPTIONAL: override source config ref to use for this stream
       source_config_ref: main
       # OPTIONAL: override OS variant to use for this stream

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -153,19 +153,19 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         // add any additional root CA cert before we do anything that fetches
         pipeutils.addOptionalRootCA()
 
-        def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+        def (url, ref) = pipeutils.get_source_config_for_stream(pipecfg, params.STREAM)
         def src_config_commit
         if (params.SRC_CONFIG_COMMIT) {
             src_config_commit = params.SRC_CONFIG_COMMIT
         } else {
-            src_config_commit = shwrapCapture("git ls-remote ${pipecfg.source_config.url} refs/heads/${ref} | cut -d \$'\t' -f 1")
+            src_config_commit = shwrapCapture("git ls-remote ${url} refs/heads/${ref} | cut -d \$'\t' -f 1")
         }
 
         stage('Init') {
             def yumrepos = pipecfg.source_config.yumrepos ? "--yumrepos ${pipecfg.source_config.yumrepos}" : ""
             def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
             shwrap("""
-            cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${variant} ${pipecfg.source_config.url}
+            cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${variant} ${url}
             """)
         }
 

--- a/jobs/build-fcos-buildroot.Jenkinsfile
+++ b/jobs/build-fcos-buildroot.Jenkinsfile
@@ -4,7 +4,6 @@ node {
     checkout scm
     // these are script global vars
     pipeutils = load("utils.groovy")
-    pipecfg = pipeutils.load_pipecfg()
 }
 
 properties([
@@ -46,7 +45,7 @@ properties([
              trim: true),
       string(name: 'CONFIG_GIT_URL',
              description: 'Override the src/config git repo to use',
-             defaultValue: pipecfg.source_config.url,
+             defaultValue: "https://github.com/coreos/fedora-coreos-config",
              trim: true),
       string(name: 'CONFIG_GIT_REF',
              description: 'Override the src/config git ref to use',

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -173,15 +173,15 @@ lock(resource: "build-${params.STREAM}") {
         // add any additional root CA cert before we do anything that fetches
         pipeutils.addOptionalRootCA()
 
-        def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
-        def src_config_commit = shwrapCapture("git ls-remote ${pipecfg.source_config.url} refs/heads/${ref} | cut -d \$'\t' -f 1")
+        def (url, ref) = pipeutils.get_source_config_for_stream(pipecfg, params.STREAM)
+        def src_config_commit = shwrapCapture("git ls-remote ${url} refs/heads/${ref} | cut -d \$'\t' -f 1")
 
         stage('Init') {
             def yumrepos = pipecfg.source_config.yumrepos ? "--yumrepos ${pipecfg.source_config.yumrepos}" : ""
             def yumrepos_ref = pipecfg.source_config.yumrepos_ref ? "--yumrepos-branch ${pipecfg.source_config.yumrepos_ref}" : ""
             def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
             shwrap("""
-            cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${yumrepos_ref} ${variant} ${pipecfg.source_config.url}
+            cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${yumrepos_ref} ${variant} ${url}
             """)
 
             // for now, just use the PVC to keep cache.qcow2 in a stream-specific dir

--- a/jobs/cloud-replicate.Jenkinsfile
+++ b/jobs/cloud-replicate.Jenkinsfile
@@ -90,10 +90,10 @@ lock(resource: "cloud-replicate-${params.VERSION}") {
 
         // Fetch metadata files for the build we are interested in
         stage('Fetch Metadata') {
-            def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+            def (url, ref) = pipeutils.get_source_config_for_stream(pipecfg, params.STREAM)
             def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
             pipeutils.shwrapWithAWSBuildUploadCredentials("""
-            cosa init --branch ${ref} ${variant} ${pipecfg.source_config.url}
+            cosa init --branch ${ref} ${variant} ${url}
             cosa buildfetch --build=${params.VERSION} \
                 --arch=all --url=s3://${s3_stream_dir}/builds \
                 --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG}

--- a/jobs/debug-pod.Jenkinsfile
+++ b/jobs/debug-pod.Jenkinsfile
@@ -87,19 +87,19 @@ cosaPod(cpu: "${ncpus}",
         // add any additional root CA cert before we do anything that fetches
         pipeutils.addOptionalRootCA()
 
-        def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+        def (url, ref) = pipeutils.get_source_config_for_stream(pipecfg, params.STREAM)
         def src_config_commit
         if (params.SRC_CONFIG_COMMIT) {
             src_config_commit = params.SRC_CONFIG_COMMIT
         } else {
-            src_config_commit = shwrapCapture("git ls-remote ${pipecfg.source_config.url} refs/heads/${ref} | cut -d \$'\t' -f 1")
+            src_config_commit = shwrapCapture("git ls-remote ${url} refs/heads/${ref} | cut -d \$'\t' -f 1")
         }
 
         stage('Init') {
             def yumrepos = pipecfg.source_config.yumrepos ? "--yumrepos ${pipecfg.source_config.yumrepos}" : ""
             def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
             shwrap("""
-            cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${variant} ${pipecfg.source_config.url}
+            cosa init --force --branch ${ref} --commit=${src_config_commit} ${yumrepos} ${variant} ${url}
             """)
         }
 

--- a/jobs/fix-build.Jenkinsfile
+++ b/jobs/fix-build.Jenkinsfile
@@ -94,11 +94,11 @@ lock(resource: "sign-${params.VERSION}") {
 
         // Fetch metadata files for the build we are interested in
         stage('Fetch Metadata') {
-            def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+            def (url, ref) = pipeutils.get_source_config_for_stream(pipecfg, params.STREAM)
             def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
             def arch_args = basearches.collect{"--arch=$it"}
             pipeutils.shwrapWithAWSBuildUploadCredentials("""
-            cosa init --branch ${ref} ${variant} ${pipecfg.source_config.url}
+            cosa init --branch ${ref} ${variant} ${url}
             cosa buildfetch --build=${params.VERSION} \
                 ${arch_args.join(' ')} --artifact=all --url=s3://${s3_stream_dir}/builds \
                 --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG}

--- a/jobs/kola-aws.Jenkinsfile
+++ b/jobs/kola-aws.Jenkinsfile
@@ -59,10 +59,10 @@ cosaPod(memory: "512Mi", kvm: false,
                 }
                 withCredentials([file(variable: 'AWS_CONFIG_FILE',
                                     credentialsId: 'aws-build-upload-config')]) {
-                    def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+                    def (url, ref) = pipeutils.get_source_config_for_stream(pipecfg, params.STREAM)
                     def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                     shwrap("""
-                    cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
+                    cosa init --branch ${ref} ${commitopt} ${variant} ${url}
                     time -v cosa buildfetch --artifact=ostree --build=${params.VERSION} \
                         --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds
                     """)

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -68,10 +68,10 @@ cosaPod(memory: "${cosa_memory_request_mb}Mi", kvm: false,
                 // Grab the metadata. Also grab the image so we can upload it.
                 withCredentials([file(variable: 'AWS_CONFIG_FILE',
                                     credentialsId: 'aws-build-upload-config')]) {
-                    def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+                    def (url, ref) = pipeutils.get_source_config_for_stream(pipecfg, params.STREAM)
                     def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                     shwrap("""
-                    cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
+                    cosa init --branch ${ref} ${commitopt} ${variant} ${url}
                     time -v cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
                         --url=s3://${s3_stream_dir}/builds --artifact=azure
                     """)

--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -59,10 +59,10 @@ cosaPod(memory: "512Mi", kvm: false,
                 }
                 withCredentials([file(variable: 'AWS_CONFIG_FILE',
                                     credentialsId: 'aws-build-upload-config')]) {
-                    def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+                    def (url, ref) = pipeutils.get_source_config_for_stream(pipecfg, params.STREAM)
                     def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                     shwrap("""
-                    cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
+                    cosa init --branch ${ref} ${commitopt} ${variant} ${url}
                     time -v cosa buildfetch --artifact=ostree --build=${params.VERSION} \
                         --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds
                     """)

--- a/jobs/kola-kubernetes.Jenkinsfile
+++ b/jobs/kola-kubernetes.Jenkinsfile
@@ -54,10 +54,10 @@ cosaPod(memory: "512Mi", kvm: false,
             }
             withCredentials([file(variable: 'AWS_CONFIG_FILE',
                                   credentialsId: 'aws-build-upload-config')]) {
-                def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+                def (url, ref) = pipeutils.get_source_config_for_stream(pipecfg, params.STREAM)
                 def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                 shwrap("""
-                cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
+                cosa init --branch ${ref} ${commitopt} ${variant} ${url}
                 cosa buildfetch --build=${params.VERSION} \
                     --arch=${params.ARCH} --url=s3://${s3_stream_dir}/builds
                 """)

--- a/jobs/kola-openstack.Jenkinsfile
+++ b/jobs/kola-openstack.Jenkinsfile
@@ -70,10 +70,10 @@ lock(resource: "kola-openstack-${params.ARCH}") {
                 // Grab the metadata. Also grab the image so we can upload it.
                 withCredentials([file(variable: 'AWS_CONFIG_FILE',
                                     credentialsId: 'aws-build-upload-config')]) {
-                    def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+                    def (url, ref) = pipeutils.get_source_config_for_stream(pipecfg, params.STREAM)
                     def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
                     shwrap("""
-                    cosa init --branch ${ref} ${commitopt} ${variant} ${pipecfg.source_config.url}
+                    cosa init --branch ${ref} ${commitopt} ${variant} ${url}
                     time -v cosa buildfetch --build=${params.VERSION} --arch=${params.ARCH} \
                         --url=s3://${s3_stream_dir}/builds --artifact=openstack
                     """)

--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -155,9 +155,9 @@ lock(resource: "kola-upgrade-${params.ARCH}") {
                 if (params.SRC_CONFIG_COMMIT != '') {
                     commitopt = "--commit=${params.SRC_CONFIG_COMMIT}"
                 }
-                def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+                def (url, ref) = pipeutils.get_source_config_for_stream(pipecfg, params.STREAM)
                 pipeutils.shwrapWithAWSBuildUploadCredentials("""
-                cosa init --force --branch ${ref} ${commitopt} ${pipecfg.source_config.url}
+                cosa init --force --branch ${ref} ${commitopt} ${url}
                 cosa buildfetch --artifact=qemu --stream=${start_stream} --build=${start_version} --arch=${params.ARCH}
                 cosa decompress --build=${start_version}
                 """)

--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -115,10 +115,10 @@ lock(resource: "release-${params.STREAM}", extra: locks) {
 
         // Fetch metadata files for the build we are interested in
         stage('Fetch Metadata') {
-            def ref = pipeutils.get_source_config_ref_for_stream(pipecfg, params.STREAM)
+            def (url, ref) = pipeutils.get_source_config_for_stream(pipecfg, params.STREAM)
             def variant = stream_info.variant ? "--variant ${stream_info.variant}" : ""
             pipeutils.shwrapWithAWSBuildUploadCredentials("""
-            cosa init --branch ${ref} ${variant} ${pipecfg.source_config.url}
+            cosa init --branch ${ref} ${variant} ${url}
             cosa buildfetch --build=${params.VERSION} \
                 --arch=all --url=s3://${s3_stream_dir}/builds \
                 --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \

--- a/utils.groovy
+++ b/utils.groovy
@@ -131,14 +131,20 @@ def add_hotfix_parameters_if_supported() {
     return []
 }
 
-def get_source_config_ref_for_stream(pipecfg, stream) {
-    if (pipecfg.streams[stream].source_config_ref) {
-        return pipecfg.streams[stream].source_config_ref
-    } else if (pipecfg.source_config.ref) {
-        return utils.substituteStr(pipecfg.source_config.ref, [STREAM: stream])
-    } else {
-        return stream
+def get_source_config_for_stream(pipecfg, stream) {
+    def url = pipecfg.source_config.url
+    if (pipecfg.streams[stream].source_config_url) {
+        url = pipecfg.streams[stream].source_config_url
     }
+
+    def ref = stream
+    if (pipecfg.streams[stream].source_config_ref) {
+        ref = pipecfg.streams[stream].source_config_ref
+    } else if (pipecfg.source_config.ref) {
+        ref = utils.substituteStr(pipecfg.source_config.ref, [STREAM: stream])
+    }
+
+    return [url, ref]
 }
 
 def get_env_vars_for_stream(pipecfg, stream) {


### PR DESCRIPTION
For https://github.com/openshift/os/issues/1775, we want the new el-only
streams to build from coreos/rhel-coreos-config. But for the older OCP
releases, we want to continue building from openshift/os to minimize
disruption.

Make the source config URL configurable at the stream level to allow
this. This matches the source config ref.

