### PR TITLE
Switch Jenkins image tracking to registry tag due to Samples Operator… … deprecation

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -454,10 +454,21 @@ oc annotate secret/github-coreosbot-token-username-password  \
     jenkins.io/credentials-description="GitHub coreosbot token as username/password"
 ```
 
-### [PROD, OPTIONAL] Create additional root CA certificate secret
+### Create root CA certificate secret
 
-If an additional root CA certificate is needed, create it as
-a secret. This assumes `ca.crt` is a file in the working directory:
+The root CA certificate (ca.crt) is required and should be created as a secret.
+This example assumes that the ca.crt file is present in your current working
+directory.
+
+If you are working in an environment that doesn't need a custom root CA, you
+still need to create a dummy configuration file as shown below:
+
+```
+cat <<'EOF' > ca.crt
+dummy
+EOF
+```
+Then create the secret:
 
 ```
 oc create secret generic additional-root-ca-cert \
@@ -517,7 +528,6 @@ oc create secret generic krb5-conf \
 
 ```
 oc new-app --file=manifests/jenkins.yaml \
-  --param=NAMESPACE=fedora-coreos-pipeline \
   --param=STORAGE_CLASS_NAME=ocs-storagecluster-ceph-rbd
 ```
 
@@ -532,12 +542,6 @@ using a development cluster, it normally isn't, and you can drop it. For
 the Fedora prod cluster, use `ocs-storagecluster-ceph-rbd` as shown
 above.
 
-If using an additional root CA certificate, then you will also need to
-specify the `AGENT_NAMESPACE` parameter to yours, e.g.:
-
-```
-  --param=AGENT_NAMESPACE=fedora-coreos-pipeline \
-```
 
 Now, create the Jenkins configmap:
 
@@ -583,11 +587,12 @@ This will create:
 
 1. the Jenkins controller imagestream,
 2. the Jenkins agent imagestream,
-3. the Jenkins agent BuildConfig (if a root CA cert was provided),
+3. the Jenkins agent BuildConfig,
 4. the jenkins-config configmap.
 
-If a root CA cert was provided, we need to build the base images that
-will bake in the cert in the controller and agent:
+Note: If you are working with the Fedora staging pipeline, specify the
+`staging` branch for the pipecfg: `--pipecfg
+https://github.com/coreos/fedora-coreos-pipeline@staging`.
 
 ```
 oc start-build --follow jenkins-with-cert

--- a/deploy
+++ b/deploy
@@ -47,7 +47,7 @@ def get_username():
 
 
 def process_template(args):
-    templates = ['pipeline.yaml', 'jenkins-s2i.yaml']
+    templates = ['pipeline.yaml', 'jenkins-images.yaml', 'jenkins-s2i.yaml']
 
     params = {}
     if args.pipeline:
@@ -57,8 +57,6 @@ def process_template(args):
         params.update(params_from_git_refspec(args.pipecfg, 'PIPECFG'))
     if has_additional_root_ca(args):
         templates += ['jenkins-with-cert.yaml']
-        params['JENKINS_S2I_SRC_IMAGESTREAM_NAME'] = "jenkins:latest"
-        params['JENKINS_S2I_SRC_IMAGESTREAM_NAMESPACE'] = get_current_namespace(args)
 
     print("Parameters:")
     for k, v in params.items():

--- a/manifests/jenkins-images.yaml
+++ b/manifests/jenkins-images.yaml
@@ -1,0 +1,34 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: jenkins-images-template
+objects:
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      name: jenkins-agent-base
+    spec:
+      tags:
+        - name: upstream
+          from:
+            kind: DockerImage
+            name: registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel9:v4.17.0
+          importPolicy:
+            scheduled: true
+          referencePolicy:
+            type: Local
+
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      name: jenkins
+    spec:
+      tags:
+        - name: upstream
+          from:
+            kind: DockerImage
+            name: registry.redhat.io/ocp-tools-4/jenkins-rhel9:v4.17.0
+          importPolicy:
+            scheduled: true
+          referencePolicy:
+            type: Local

--- a/manifests/jenkins-s2i.yaml
+++ b/manifests/jenkins-s2i.yaml
@@ -12,45 +12,21 @@ parameters:
   - description: Git branch/tag reference for Jenkins S2I
     name: JENKINS_S2I_REF
     value: main
-  - description: Source imagestream
-    name: JENKINS_S2I_SRC_IMAGESTREAM_NAME
-    value: jenkins:scheduled-upgrade-redeploy
-  - description: Namespace of source imagestream
-    name: JENKINS_S2I_SRC_IMAGESTREAM_NAMESPACE
-    value: openshift
 
-# Here's what the flow looks like when no cert is required:
 #
-# ┌──────────────────────────────────────────────┐   ┌─────────────┐   ┌─────────────┐
-# │ imagestream                                  │   │ buildconfig │   │ imagestream │
-# │ openshift/jenkins:scheduled-upgrade-redeploy ├──►│ jenkins-s2i ├──►│ jenkins:2   │
-# └──────────────────────────────────────────────┘   └─────────────┘   └─────────────┘
+# ┌──────────────────┐   ┌───────────────────┐   ┌──────────────────┐   ┌─────────────┐   ┌────────────────┐
+# │ imagestream      │   │ buildconfig       │   │ imagestream      │   │ buildconfig │   │ imagestream    │
+# │ jenkins:upstream ├──►│ jenkins-with-cert ├──►│ jenkins:withcert ├──►│ jenkins-s2i ├──►│ jenkins:latest │
+# └──────────────────┘   └───────────────────┘   └──────────────────┘   └─────────────┘   └────────────────┘
 #
-# ┌────────────────────────────────────────────────┐
-# │ imagestream                                    │
-# │ openshift/jenkins-agent-base:scheduled-upgrade │
-# └────────────────────────────────────────────────┘
-#
-# And with cert required (see `jenkins-with-cert.yaml`):
-#
-# ┌──────────────────────────────────────────────┐   ┌───────────────────┐   ┌────────────────┐   ┌─────────────┐   ┌─────────────┐
-# │ imagestream                                  │   │ buildconfig       │   │ imagestream    │   │ buildconfig │   │ imagestream │
-# │ openshift/jenkins:scheduled-upgrade-redeploy ├──►│ jenkins-with-cert ├──►│ jenkins:latest ├──►│ jenkins-s2i ├──►│ jenkins:2   │
-# └──────────────────────────────────────────────┘   └───────────────────┘   └────────────────┘   └─────────────┘   └─────────────┘
-#
-# ┌────────────────────────────────────────────────┐   ┌──────────────────────────────┐   ┌───────────────────────────┐
-# │ imagestream                                    │   │ buildconfig                  │   │ imagestream               │
-# │ openshift/jenkins-agent-base:scheduled-upgrade ├──►│ jenkins-agent-base-with-cert ├──►│ jenkins-agent-base:latest │
-# └────────────────────────────────────────────────┘   └──────────────────────────────┘   └───────────────────────────┘
+# ┌─────────────────────────────┐   ┌──────────────────────────────┐   ┌───────────────────────────┐
+# │ imagestream                 │   │ buildconfig                  │   │ imagestream               │
+# │ jenkins-agent-base:upstream ├──►│ jenkins-agent-base-with-cert ├──►│ jenkins-agent-base:latest │
+# └─────────────────────────────┘   └──────────────────────────────┘   └───────────────────────────┘
 
 objects:
 
   ### JENKINS CONTROLLER ###
-
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      name: jenkins
   - kind: BuildConfig
     apiVersion: v1
     metadata:
@@ -70,8 +46,7 @@ objects:
         sourceStrategy:
           from:
             kind: ImageStreamTag
-            name: ${JENKINS_S2I_SRC_IMAGESTREAM_NAME}
-            namespace: ${JENKINS_S2I_SRC_IMAGESTREAM_NAMESPACE}
+            name: jenkins:withcert
           env:
             - name: JENKINS_UC_DOWNLOAD
               value: 'https://archives.jenkins.io'
@@ -79,13 +54,6 @@ objects:
       output:
         to:
           kind: ImageStreamTag
-          name: jenkins:2
+          name: jenkins:latest
       successfulBuildsHistoryLimit: 2
       failedBuildsHistoryLimit: 2
-
-  ### JENKINS AGENT ###
-
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      name: jenkins-agent-base

--- a/manifests/jenkins-with-cert.yaml
+++ b/manifests/jenkins-with-cert.yaml
@@ -1,4 +1,5 @@
-# This template is instantiated only if an additional root CA is needed. Note it
+# This template is always required to create the jenkins and jenkins-agent-base
+# ImageStreams with the new tags that will be used later.
 # doesn't actually need to be a template (there are no parameters), but the way
 # `deploy` currently works expects it as a template.
 
@@ -20,7 +21,11 @@ objects:
           FROM overridden
           COPY cert/data /etc/pki/ca-trust/source/anchors/root-ca.crt
           USER root
-          RUN update-ca-trust
+          RUN if grep -q 'dummy' /etc/pki/ca-trust/source/anchors/root-ca.crt; then \
+              rm /etc/pki/ca-trust/source/anchors/root-ca.crt; \
+          else \
+              update-ca-trust; \
+          fi
           # restore previous user ID
           # https://github.com/openshift/jenkins/blob/7bae76f4412d28c18ed2b33aaf73306734b7f6d5/2/Dockerfile.rhel8#L107
           USER 1001
@@ -32,13 +37,12 @@ objects:
         dockerStrategy:
           from:
             kind: ImageStreamTag
-            name: jenkins:scheduled-upgrade-redeploy
-            namespace: openshift
+            name: jenkins:upstream
           forcePull: true
       output:
         to:
           kind: ImageStreamTag
-          name: jenkins:latest
+          name: jenkins:withcert
       successfulBuildsHistoryLimit: 2
       failedBuildsHistoryLimit: 2
       triggers:
@@ -54,7 +58,11 @@ objects:
         dockerfile: |
           FROM overridden
           COPY cert/data /etc/pki/ca-trust/source/anchors/root-ca.crt
-          RUN update-ca-trust
+          RUN if grep -q 'dummy' /etc/pki/ca-trust/source/anchors/root-ca.crt; then \
+              rm /etc/pki/ca-trust/source/anchors/root-ca.crt; \
+          else \
+              update-ca-trust; \
+          fi
         secrets:
           - destinationDir: cert
             secret:
@@ -63,8 +71,7 @@ objects:
         dockerStrategy:
           from:
             kind: ImageStreamTag
-            name: jenkins-agent-base:scheduled-upgrade
-            namespace: openshift
+            name: jenkins-agent-base:upstream
           forcePull: true
       output:
         to:

--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -100,7 +100,7 @@ objects:
               -Dfile.encoding=UTF-8
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=900
               -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true
-              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage=image-registry.openshift-image-registry.svc:5000/${AGENT_NAMESPACE}/jenkins-agent-base:latest
+              -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultImage=jenkins-agent-base:latest
               -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultCpuRequest=1
               -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultMemoryRequest=512Mi
               -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateStepExecution.defaultContainer.defaultCpuLimit=1
@@ -172,8 +172,7 @@ objects:
         - jenkins
         from:
           kind: ImageStreamTag
-          name: ${JENKINS_IMAGE_STREAM_TAG}
-          namespace: ${NAMESPACE}
+          name: jenkins:latest
         lastTriggeredImage: ""
       type: ImageChange
     - type: ConfigChange
@@ -252,25 +251,12 @@ parameters:
   required: true
   # DELTA: changed from 1Gi
   value: 25Gi
-- description: The OpenShift Namespace where the Jenkins ImageStream resides.
-  displayName: Jenkins ImageStream Namespace
-  name: NAMESPACE
-  value: openshift
-# DELTA: add separate agent namespace parameter
-- description: The OpenShift Namespace where the Jenkins Agent ImageStream resides.
-  displayName: Jenkins Agent ImageStream Namespace
-  name: AGENT_NAMESPACE
-  value: openshift
 - description: Whether to perform memory intensive, possibly slow, synchronization
     with the Jenkins Update Center on start.  If true, the Jenkins core update monitor
     and site warnings monitor are disabled.
   displayName: Disable memory intensive administrative monitors
   name: DISABLE_ADMINISTRATIVE_MONITORS
   value: "false"
-- description: Name of the ImageStreamTag to be used for the Jenkins image.
-  displayName: Jenkins ImageStreamTag
-  name: JENKINS_IMAGE_STREAM_TAG
-  value: jenkins:2
 - description: When a fatal error occurs, an error log is created with information
     and the state obtained at the time of the fatal error.
   displayName: Fatal Error Log File


### PR DESCRIPTION
Added jenkins-stg-agent-base.yaml to work around limitations in the Staging environment.  Also updated documentation to note the unreliability of the Staging registry and instructed users to use their own agent image.