### PR TITLE
jobs/kola-azure: run kola tests on both Managed and Gen2 Gallery Images

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -93,6 +93,7 @@ clouds:
     test_resource_group: fedora-coreos-testing
     test_storage_account: fedoracoreostesting
     test_storage_container: fedora-coreos-testing-image-blobs
+    test_gallery: fedora-coreos-testing-gallery
     test_architectures: [x86_64]
   gcp:
     bucket: fedora-coreos-cloud-image-uploads/image-import


### PR DESCRIPTION
Expand the job to build Hyper-V Gen2 gallery images and run kola tests on both traditional managed images and new Gen2 gallery images`[1]`. The new NVMe test`[2]` is explicitly denylisted from managed image testing since since it requires Gen2 support. This will essentially allow all* Azure kola tests to be validated on both kinds of images.

A pipeline config variable, `test_gallery`, is introduced to the Azure section to specify the gallery used to create Gen2 images.

`[1]`: https://github.com/coreos/coreos-assembler/pull/4109
`[2]`: https://github.com/coreos/fedora-coreos-config/pull/3519

*with the exception of the NVMe test on traditional managed images.

---

Note: this requires https://github.com/coreos/coreos-assembler/pull/4109 to merge first.