### PR TITLE
manifests/jenkins: Migrate from DeploymentConfig to Deployment

### DIFF
--- a/manifests/jenkins.yaml
+++ b/manifests/jenkins.yaml
@@ -39,21 +39,23 @@ objects:
         storage: ${VOLUME_CAPACITY}
     # DELTA: support specifying storage class
     storageClassName: "${STORAGE_CLASS_NAME}"
-- apiVersion: v1
-  kind: DeploymentConfig
+# DELTA: Migrated from DeploymentConfig to Deployment
+- apiVersion: apps/v1
+  kind: Deployment
   metadata:
     annotations:
+      # DELTA: added image trigger annotation to replace DeploymentConfig's triggers
+      image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"jenkins:latest"},"lastTriggeredImage":"","fieldPath":"spec.template.spec.containers[?(@.name==\"jenkins\")].image","paused":false}]'
       template.alpha.openshift.io/wait-for-ready: "true"
     name: ${JENKINS_SERVICE_NAME}
   spec:
     replicas: 1
+    # DELTA: added selector.matchLabels (required for Deployment)
     selector:
-      name: ${JENKINS_SERVICE_NAME}
+      matchLabels:
+        name: ${JENKINS_SERVICE_NAME}
     strategy:
       type: Recreate
-      # DELTA: allow 20 mins for pod to be ready to account for slow NFS
-      recreateParams:
-        timeoutSeconds: 1200
     template:
       metadata:
         labels:
@@ -126,6 +128,14 @@ objects:
             periodSeconds: 360
             timeoutSeconds: 240
           name: jenkins
+          # DELTA: startupProbe in Deployment takes over the functionality of previously used `recreateParams.timeoutSeconds: 1200`.
+          startupProbe:
+            httpGet:
+              path: /login
+              port: 8080
+            periodSeconds: 30
+            failureThreshold: 40
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: /login
@@ -165,20 +175,7 @@ objects:
           secret:
             secretName: splunk-casc-cfg
             optional: true
-    triggers:
-    - imageChangeParams:
-        automatic: true
-        containerNames:
-        - jenkins
-        from:
-          kind: ImageStreamTag
-          name: jenkins:latest
-          # DELTA: No need to use namespace here because we are
-          # using the ImageStream inside our own namespace.
-          # namespace: ${NAMESPACE}
-        lastTriggeredImage: ""
-      type: ImageChange
-    - type: ConfigChange
+# DELTA: Removed triggers section as Deployment uses different trigger mechanism (image.openshift.io/triggers)
 - apiVersion: v1
   kind: ServiceAccount
   metadata:


### PR DESCRIPTION
This file is little different from other projects in our sphere which were using DeploymentConfig and recently migrated to Deployment. It's using the JCasC plugin to make Jenkins deployments easier. Changes include modifications of :
* `API Version and Kind`
* `Selector Structure`
* `Strategy Configuration`
* `Triggers Modification`

See: https://github.com/coreos/fedora-coreos-pipeline/issues/1090