### PR TITLE
jobs/kola-azure: add missing `\` to create-gallery-image command

### DIFF
--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -126,7 +126,7 @@ cosaPod(memory: "${cosa_memory_request_mb}Mi", kvm: false,
                 # create the testing gallery if it does not exist, but
                 # it will be a no-op on gallery creation given the
                 # gallery exists in the specified region.
-                ore azure create-gallery-image --log-level=INFO
+                ore azure create-gallery-image --log-level=INFO         \
                     --azure-credentials \${AZURE_KOLA_TESTS_CONFIG}     \
                     --azure-location $region                            \
                     --resource-group $azure_testing_resource_group      \


### PR DESCRIPTION
The command to `create-gallery-image` was added in a previous commit`[1]` and is missing the `\` to make it a multi-line command causing the the job in the FCOS pipeline to fail. Let's fix that here so we can unblock the FCOS pipeline.

`[1]`: https://github.com/coreos/fedora-coreos-pipeline/commit/f8cf2bb42ac4a8d9ab9c8d9743bd16132c7b735b