### PR TITLE
jobs/kola-azure: update testing gallery name and vm size for tests

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -94,7 +94,7 @@ clouds:
     test_resource_group: fedora-coreos-testing
     test_storage_account: fedoracoreostesting
     test_storage_container: fedora-coreos-testing-image-blobs
-    test_gallery: fedora-coreos-testing-gallery
+    test_gallery: fedoracoreostestinggallery
     test_architectures: [x86_64]
   gcp:
     bucket: fedora-coreos-cloud-image-uploads/image-import

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -130,6 +130,7 @@ cosaPod(memory: "${cosa_memory_request_mb}Mi", kvm: false,
                     --azure-credentials \${AZURE_KOLA_TESTS_CONFIG}     \
                     --azure-location $region                            \
                     --resource-group $azure_testing_resource_group      \
+                    --gallery-name $azure_testing_gallery               \
                     --gallery-image-name $azure_image_name              \
                     --image-blob "https://${azure_testing_storage_account}.blob.core.windows.net/${azure_testing_storage_container}/${azure_image_name}"
                 """)


### PR DESCRIPTION
Azure doesn't allow dashes (-) in gallery names so the gallery name is updated to not include them. Also, set the gallery name on image creation which should have been done in a previous commit.

See: https://github.com/coreos/fedora-coreos-pipeline/pull/1153