### PR TITLE
jobs/build-node-image: use `--add-openshift-build-labels`

### DIFF
--- a/jobs/build-node-image.Jenkinsfile
+++ b/jobs/build-node-image.Jenkinsfile
@@ -121,7 +121,8 @@ lock(resource: "build-node-image") {
                                                 secret: "id=yumrepos,src=${yumrepos_file}", // notsecret (for secret scanners)
                                                 from: build_from,
                                                 v2s2: v2s2,
-                                                extra_build_args: ["--security-opt label=disable", "--mount-host-ca-certs", "--force"] + label_args)
+                                                extra_build_args: ["--security-opt label=disable", "--mount-host-ca-certs", "--force",
+                                                                   "--add-openshift-build-labels"] + label_args)
             }
         }
         stage('Build Extensions Image') {
@@ -142,7 +143,8 @@ lock(resource: "build-node-image") {
                                                from: build_from,
                                                v2s2: v2s2,
                                                extra_build_args: ["--security-opt label=disable", "--mount-host-ca-certs",
-                                                                  "--git-containerfile", "extensions/Dockerfile", "--force"] + label_args)
+                                                                  "--git-containerfile", "extensions/Dockerfile", "--force",
+                                                                  "--add-openshift-build-labels"] + label_args)
             }
         }
         stage("Brew Upload") {


### PR DESCRIPTION
This will fix a small UX issue in the release controller: it will add working links for our images to the openshift/os commit they were built from, just like the other images.

See also https://github.com/coreos/coreos-assembler/pull/4124 which this requires.