### PR TITLE
kola-azure: start building and testing aarch64 images

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -95,7 +95,6 @@ clouds:
     test_storage_account: fedoracoreostesting
     test_storage_container: fedora-coreos-testing-image-blobs
     test_gallery: fedoracoreostestinggallery
-    test_architectures: [x86_64]
   gcp:
     bucket: fedora-coreos-cloud-image-uploads/image-import
     description: "Fedora, Fedora CoreOS ${STREAM}, ${BUILDID}, ${BASEARCH} published on ${DATE}"

--- a/jobs/kola-azure.Jenkinsfile
+++ b/jobs/kola-azure.Jenkinsfile
@@ -127,6 +127,7 @@ cosaPod(memory: "${cosa_memory_request_mb}Mi", kvm: false,
                 # it will be a no-op on gallery creation given the
                 # gallery exists in the specified region.
                 ore azure create-gallery-image --log-level=INFO         \
+                    --arch $params.ARCH                                 \
                     --azure-credentials \${AZURE_KOLA_TESTS_CONFIG}     \
                     --azure-location $region                            \
                     --resource-group $azure_testing_resource_group      \


### PR DESCRIPTION
Begin building aarch64 gallery images in Azure and run all kola test on them. The feature for overriding the instance type per test does not account for architecture, and the `platforms.azure.nvme` test uses a hard-coded x86_64 instance type, so it's denylisted for aarch64.