### PR TITLE
jobs/build-cosa: reduce possible match in regex

### DIFF
--- a/jobs/build-cosa.Jenkinsfile
+++ b/jobs/build-cosa.Jenkinsfile
@@ -25,7 +25,7 @@ properties([
          printPostContent: true,
          silentResponse: false,
          regexpFilterText: '$COREOS_ASSEMBLER_GIT_REF',
-         regexpFilterExpression: 'main|rhcos-.*'
+         regexpFilterExpression: '^main|^rhcos-.*'
         ], 
         cron('H H * * 1,3')
     ]),


### PR DESCRIPTION
Konflux is pushing branches to main coreos-assembler repo which contains `main` keyword. We don't want Jenkins to build them, so we reduce the possibility to the only branches we want to build.