### PR TITLE
[staging] config: add azure testing gallery and remove arch limitation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -99,7 +99,7 @@ clouds:
     test_resource_group: fedora-coreos-testing
     test_storage_account: fedoracoreostesting
     test_storage_container: fedora-coreos-testing-image-blobs
-    test_architectures: [x86_64]
+    test_gallery: fedoracoreostestinggallery
   gcp:
     bucket: fedora-coreos-devel-image-uploads/image-import
     description: "Fedora, Fedora CoreOS Devel ${STREAM}, ${BUILDID}, ${BASEARCH} published on ${DATE}"


### PR DESCRIPTION
Sync with the main branch by adding the Azure testing gallery name to the config and removing the limitation to test only on x86_64, so we can also test aarch64 in staging.