### PR TITLE
 feat(build-node-image): add option to skip brew upload stage 

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -317,6 +317,8 @@ ocp_node_builds:
                ref: master
                # REQUIRED: repo file name to build
                file: rhel-9.6.repo
+           # OPTIONAL: skip upload to brew. Defaults to false
+           skip_brew_upload: false
     # REQUIRED: knobs related to the source config
     registries:
         # REQUIRED: staging repo to push the final image built


### PR DESCRIPTION
Adds an option to skip the Brew upload stage when building the Node image. Useful for test builds where publishing to the Brew repository is not needed.