### PR TITLE
Add pipeline-graph-view plugin

### DIFF
--- a/jenkins/controller/plugins.txt
+++ b/jenkins/controller/plugins.txt
@@ -32,6 +32,7 @@ splunk-devops-extend:1.10.2
 splunk-devops:1.10.2
 antisamy-markup-formatter:173.v680e3a_b_69ff3
 jms-messaging:1.1.28
+pipeline-graph-view:419.v946ff4a_49e1c
 
 # The below list are plugins that are also in base-plugins.txt but for
 # some reason or other we need to temporarily freeze or fast-track.


### PR DESCRIPTION
Apparently Blue Ocean Jenkins view is deprecated. There is a new "Pipeline Graph View" plugin that is recommended instead. The pipeline-graph-view version `419.v946ff4a_49e1c `is compatible with our current jenkins version.

Ref: https://github.com/jenkinsci/dark-theme-plugin/issues/89#issuecomment-2939077690