### PR TITLE
config: limit proxmoxve to `testing/stable` for now

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,9 @@
 streams:
   stable:
     type: production
+    skip_artifacts:
+      x86_64:
+        - proxmoxve
   testing:
     type: production
   next:


### PR DESCRIPTION
We're still working out a little bit what the best format is for the uploaded disk images in https://github.com/coreos/fedora-coreos-tracker/issues/1652