### PR TITLE
config: disable ppc64le architecture for now

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ streams:
   # bodhi-updates-testing:
   #   type: mechanical
 
-additional_arches: [aarch64, ppc64le, s390x]
+additional_arches: [aarch64, s390x]
 
 source_config:
   url: https://github.com/coreos/fedora-coreos-config


### PR DESCRIPTION
We are moving to a new datacenter and don't have a ppc64le builder set up there yet. This will aid in the migration.