### PR TITLE
utils: add new FCOS jenkins to protected jenkinses

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ streams:
   # bodhi-updates-testing:
   #   type: mechanical
 
-additional_arches: [aarch64, s390x]
+additional_arches: [aarch64, ppc64le, s390x]
 
 source_config:
   url: https://github.com/coreos/fedora-coreos-config

--- a/utils.groovy
+++ b/utils.groovy
@@ -6,7 +6,7 @@ import org.yaml.snakeyaml.Yaml
 
 // map of Jenkins URL to (S3 bucket, S3 bucket builds key, hotfix allowed)
 PROTECTED_JENKINSES = [
-    'https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/':
+    'https://jenkins-fedora-coreos-pipeline.apps.ocp-rdu3.fedoraproject.org/':
         ['fcos-builds', 'prod/streams/${STREAM}', false],
     'https://jenkins-rhcos--devel-pipeline.apps.int.preprod-stable-spoke1-dc-iad2.itup.redhat.com/':
         ['rhcos-ci', 'prod/streams/${STREAM}', true],


### PR DESCRIPTION
We've moved the FCOS pipeline to a new cluster, so we need to update the
list of protected jenkinses to mark this cluster as the official one.

We also have access to the ppc64le builder from the new cluster, so we can
add ppc64le back into the list of additional arches.