### PR TITLE
manifests: set local lookup policy for jenkins-agent-base

### DIFF
--- a/manifests/jenkins-images.yaml
+++ b/manifests/jenkins-images.yaml
@@ -8,6 +8,8 @@ objects:
     metadata:
       name: jenkins-agent-base
     spec:
+      lookupPolicy:
+        local: true
       tags:
         - name: upstream
           from:


### PR DESCRIPTION
Otherwise local started pods can't find it with the non namespaced definition in https://github.com/coreos/fedora-coreos-pipeline/blob/ebef883e40ec93e4baf6fcfab2664552b9c9774a/manifests/jenkins.yaml#L105

This makes it so that the imagestream can be found that way and prevents errors like:

```
14:41:08  	Container [jnlp] waiting [ErrImagePull] initializing source docker://jenkins-agent-base:latest: reading manifest latest in docker.io/library/jenkins-agent-base: requested access to the resource is denied
14:41:08  	Pod [Pending][ContainersNotReady] containers with unready status: [jnlp]
14:41:21  ERROR: Unable to pull container image "jenkins-agent-base:latest". Check if image tag name is spelled correctly.
```

Closes https://github.com/coreos/fedora-coreos-pipeline/issues/1165