### PR TITLE
Run OpenShift-specific node image tests before Brew upload

### DIFF
--- a/jobs/build-node-image.Jenkinsfile
+++ b/jobs/build-node-image.Jenkinsfile
@@ -50,7 +50,7 @@ def src_config_url = stream_info.source_config.url
 
 lock(resource: "build-node-image") {
     cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
-            memory: "512Mi", kvm: false,
+            memory: "2Gi", kvm: true,
             serviceAccount: "jenkins",
             secrets: ["brew-keytab", "brew-ca:ca.crt:/etc/pki/ca.crt",
                       "koji-conf:koji.conf:/etc/koji.conf",
@@ -125,6 +125,7 @@ lock(resource: "build-node-image") {
                                                                    "--add-openshift-build-labels"] + label_args)
             }
         }
+
         stage('Build Extensions Image') {
             withCredentials([file(credentialsId: 'oscontainer-push-registry-secret', variable: 'REGISTRY_AUTH_FILE')]) {
                 // Use the node image as from
@@ -145,6 +146,35 @@ lock(resource: "build-node-image") {
                                                extra_build_args: ["--security-opt label=disable", "--mount-host-ca-certs",
                                                                   "--git-containerfile", "extensions/Dockerfile", "--force",
                                                                   "--add-openshift-build-labels"] + label_args)
+            }
+        }
+        stage("Run Tests"){
+            withCredentials([file(credentialsId: 'oscontainer-push-registry-secret', variable: 'REGISTRY_AUTH_FILE')]) {
+                def openshift_stream = params.RELEASE.split("-")[0]
+                def rhel_stream = params.RELEASE.split("-")[1]
+
+                // TODO: handle multiple architectures
+                pipeutils.shwrapWithAWSBuildUploadCredentials("""
+                    mkdir tmp
+                    cosa buildfetch \
+                        --arch=x86_64 --artifact qemu --url=s3://art-rhcos-ci/prod/streams/rhel-${rhel_stream}/builds \
+                        --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG}
+                    cp builds/latest/x86_64/*.gz rhcos.qcow2.gz
+                    gunzip rhcos.qcow2.gz
+                """)
+
+
+                shwrap("skopeo copy --authfile $REGISTRY_AUTH_FILE docker://${registry_staging_repo}@${node_image_manifest_digest} oci-archive:./openshift.ociarchive")
+
+                shwrap("""
+                    set +o pipefail
+                    mkdir openshift
+                    cd openshift
+                    cosa init https://github.com/openshift/os --branch release-${openshift_stream} | true
+                    mkdir -p tmp
+                    kola run -b rhcos --tag 'openshift' --qemu-image ../rhcos.qcow2 --oscontainer ../openshift.ociarchive 
+                    kola run -E src/config "ext.*" --qemu-image ../rhcos.qcow2 --oscontainer ../openshift.ociarchive 
+                """)
             }
         }
         stage("Brew Upload") {


### PR DESCRIPTION
This change re-enables previously removed OpenShift-specific node image tests and ensures they are run before the Brew upload stage to catch potential issues