### PR TITLE
utils: revert to the main URL for prod FCOS jenkins

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -6,7 +6,7 @@ import org.yaml.snakeyaml.Yaml
 
 // map of Jenkins URL to (S3 bucket, S3 bucket builds key, hotfix allowed)
 PROTECTED_JENKINSES = [
-    'https://jenkins-fedora-coreos-pipeline.apps.ocp-rdu3.fedoraproject.org/':
+    'https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/':
         ['fcos-builds', 'prod/streams/${STREAM}', false],
     'https://jenkins-rhcos--devel-pipeline.apps.int.preprod-stable-spoke1-dc-iad2.itup.redhat.com/':
         ['rhcos-ci', 'prod/streams/${STREAM}', true],


### PR DESCRIPTION
The Fedora datacenter move is complete now so we can use the main URL again.