### PR TITLE
jobs/build-node-image: only request 1 CPU

### DIFF
--- a/jobs/build-node-image.Jenkinsfile
+++ b/jobs/build-node-image.Jenkinsfile
@@ -50,8 +50,9 @@ def src_config_ref = stream_info.source_config.ref
 def src_config_url = stream_info.source_config.url
 
 lock(resource: "build-node-image") {
+    // building actually happens on builders so we don't need much resources
     cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
-            memory: "512Mi", kvm: false,
+            memory: "512Mi", cpu: "1", kvm: false,
             serviceAccount: "jenkins",
             secrets: ["brew-keytab", "brew-ca:ca.crt:/etc/pki/ca.crt",
                       "koji-conf:koji.conf:/etc/koji.conf",


### PR DESCRIPTION
Like some of our other jobs, all the heavy lifting is done in dedicated builders so we can be more conservative here. The default request is 2 (which adds up to 3 with the jnlp container, which... we could probably cut that down to a quarter).