### PR TITLE
config: promote proxmoxve to stable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,6 @@
 streams:
   stable:
     type: production
-    skip_artifacts:
-      x86_64:
-        - proxmoxve
   testing:
     type: production
   next:


### PR DESCRIPTION
We've decided to keep with the .xz compression for now so
we can just promote this to stable.

https://github.com/coreos/fedora-coreos-tracker/issues/1652#issuecomment-3057966216
