### PR TITLE
jobs/build: support importing OCI image using `cosa import` and skipping build stages

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -65,6 +65,9 @@ streams:
       # is equivalent to listing all live artifacts and cloud platforms in
       # `skip_artifacts`.
       skip_disk_images: true
+      # OPTIONAL: Whether to skip building ostree in the build pipeline.
+      # The build would be imported using `cosa import` with the specified image uri.
+      source_oci_image: quay.io/coreos-devel/fedora-coreos:rawhide
       # OPTIONAL: make the release job trigger build-node-image for the
       # following OCP releases once successful
       build_node_images: ["4.19-9.6"]


### PR DESCRIPTION
This allows the build pipeline to skip the fetch and the build ostree stages if source_oci_image is defined in the stream config. In that case, the image is imported using cosa import.

latest build logs: 
[jenkins](https://jenkins-fedora-coreos-pipeline.apps.ocp.stg.fedoraproject.org/job/rosh-build/15/)
[blue ocean](https://jenkins-fedora-coreos-pipeline.apps.ocp.stg.fedoraproject.org/blue/organizations/jenkins/rosh-build/detail/rosh-build/15/pipeline)

The failed tests are tracked here:
[#1996](https://github.com/coreos/fedora-coreos-tracker/issues/1996) 
[#1995](https://github.com/coreos/fedora-coreos-tracker/issues/1995)