### PR TITLE
jobs/build-node-image: update s3 stream directory

### DIFF
--- a/jobs/build-node-image.Jenkinsfile
+++ b/jobs/build-node-image.Jenkinsfile
@@ -157,7 +157,7 @@ lock(resource: "build-node-image") {
         stage("Run Tests") {
             withCredentials([file(credentialsId: 'oscontainer-push-registry-secret', variable: 'REGISTRY_AUTH_FILE')]) {
                 def openshift_stream = params.RELEASE.split("-")[0]
-                def rhel_stream = params.RELEASE.split("-")[1]
+                def rhel_stream = "rhel-" + params.RELEASE.split("-")[1]
 
                 parallel basearches.collectEntries { arch ->
                     [arch, {


### PR DESCRIPTION
Append "rhel-" to the `rhel_stream` variable to get the correct s3 stream directory for the `cosa buildfetch` command.