### PR TITLE
jobs/build-node-image: fix skopeo arch mapping for aarch64

### DIFF
--- a/jobs/build-node-image.Jenkinsfile
+++ b/jobs/build-node-image.Jenkinsfile
@@ -184,7 +184,7 @@ lock(resource: "build-node-image") {
                                 cosa shell basename \$link
                             """)
                             shwrap("cosa decompress --build $build_id")
-                            def skopeo_arch_override = (arch == "x86_64") ? "amd64" : arch
+                            def skopeo_arch_override = rpm_to_go_arch(arch)
                             shwrap("cosa shell skopeo copy --override-arch ${skopeo_arch_override} --authfile $REGISTRY_AUTH_FILE docker://${registry_staging_repo}@${node_image_manifest_digest} oci-archive:./openshift-${arch}.ociarchive")
                             kola(
                                 cosaDir: WORKSPACE,

--- a/utils.groovy
+++ b/utils.groovy
@@ -975,14 +975,8 @@ def get_arch_image_digest(from) {
 def brew_upload(arches, release, repo, manifest_digest, extensions_manifest_digest, version, pipecfg) {
     def node_digest_arch_map = get_arch_image_digest("${repo}@${manifest_digest}")
     def extensions_node_digest_arch_map  = get_arch_image_digest("${repo}@${extensions_manifest_digest}")
-    def archAliasMap = [
-        "x86_64"  : "amd64",
-        "aarch64" : "arm64",
-        "s390x"   : "s390x",
-        "ppc64le" : "ppc64le"
-    ]
     for (arch in arches) {
-        def inspect_arch = archAliasMap[arch]
+        def inspect_arch = rpm_to_go_arch(arch)
         def node_image = "${repo}@${node_digest_arch_map[inspect_arch]}"
         def extensions_node_image = "${repo}@${extensions_node_digest_arch_map[inspect_arch]}"
 
@@ -1004,6 +998,18 @@ def brew_upload(arches, release, repo, manifest_digest, extensions_manifest_dige
                 --node-image
         """)
     }
+}
+
+// maps RPM-style architecture names to Go-style architecture names
+// used by skopeo and container manifests.
+def rpm_to_go_arch(arch) {
+    def archAliasMap = [
+        "x86_64"  : "amd64",
+        "aarch64" : "arm64",
+        "s390x"   : "s390x",
+        "ppc64le" : "ppc64le"
+    ]
+    return archAliasMap[arch]
 }
 
 return this


### PR DESCRIPTION
The skopeo command expects Go-style architecture names like `amd64` and `arm64`. Introduce a map to handle both `x86_64` and `aarch64` translations.