### PR TITLE
config: enable branched stream

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,8 +12,8 @@ streams:
     # type: development # do not touch; line managed by `next-devel/manage.py`
   rawhide:
     type: mechanical
-  #branched:
-  #  type: mechanical
+  branched:
+   type: mechanical
   # bodhi-updates:
   #   type: mechanical
   # bodhi-updates-testing:


### PR DESCRIPTION
Fedora 43 branches from rawhide on `2025-08-12`. Enable the branched stream to build Fedora 43 CoreOS.

see:
- https://github.com/coreos/fedora-coreos-tracker/issues/1935
- https://github.com/coreos/fedora-coreos-config/pull/3660