### PR TITLE
libcloud.groovy: add and use new winli_billing_code mapping

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -122,6 +122,7 @@ streams:
       # `build-mechanical` will only build those streams
       scheduled: true
       # OPTIONAL: Create and replicate AWS Windows License Included images for this stream.
+      # requires winli_billing_code under the 'aws' mapping
       create_and_replicate_winli_ami: true
 
 # REQUIRED: architectures to build for other than x86_64
@@ -212,6 +213,9 @@ clouds:
       # OPTIONAL: boolean: whether or not to set the image/snapshot as public on
       # initial upload (AMIs of released builds are always made public)
       public: true
+    # OPTIONAL: billing code to create a Windows License Included Image
+    # required if using 'create_and_replicate_winli_ami' under the stream mappings
+    winli_billing_code: "bp-12345abcde"
   aliyun:
     # REQUIRED (if Aliyun build upload credentials provided): the region to do
     # initial image creation in.


### PR DESCRIPTION
Add a new `winli_billing_code` mapping for RHCOS to be used by the cloud-replicate job.

```
commit a6bd287c54a1a1e3edbb650f8a86d5f987589697
Author: Michael Armijo <marmijo@redhat.com>
Date:   Mon Aug 11 17:24:27 2025 -0600

    libcloud: update aws-winli creation to use billing code
    
    The Windows License Included (winli) AMI creation logic was reworked in
    coreos assembler [1] to append the winli billing code to an
    already-created RHCOS AMI, instead of creating an AMI based on a
    modified Windows instance. Update the winli build closure to use the new
    imageupload-aws option. We no longer need to discover and use the latest
    windows server 2022 AMI ID.
    
    [1]: https://github.com/coreos/coreos-assembler/pull/4237

commit 8dd4b5ff7f1990d39db4db57a9ef0c8063f7feff
Author: Michael Armijo <marmijo@redhat.com>
Date:   Mon Aug 11 16:49:46 2025 -0600

    docs/config: add winli_billing_code to aws mapping
    
    Introduce a new `winli_billing_code` field under the `aws` mapping to
    support configuration of AWS billing details.
```