### PR TITLE
config.yaml: turn on COSA_BUILD_WITH_BUILDAH for rawhide

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,9 @@ streams:
     # type: development # do not touch; line managed by `next-devel/manage.py`
   rawhide:
     type: mechanical
+    env:
+      # https://github.com/coreos/fedora-coreos-tracker/issues/1969
+      COSA_BUILD_WITH_BUILDAH: true
   branched:
    type: mechanical
   # bodhi-updates:


### PR DESCRIPTION
As per https://github.com/coreos/fedora-coreos-tracker/issues/1969, we are switching to the container-native path for building FCOS in Fedora 43.

Enable this using the ready-made `COSA_BUILD_WITH_BUILDAH` env var.

Fedora 43 has already brached so once this bakes a bit in Rawhide, we should do the same to the `branched` stream as well.