### PR TITLE
build: conditionally allow missing arches

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -570,14 +570,15 @@ def run_multiarch_jobs(arches, src_commit, version, cosa_img, wait) {
 
 def run_release_job(buildID) {
     stage('Publish') {
-        // Since we are only running this stage for non-production (i.e.
-        // mechanical and development) builds we'll default to allowing failures
-        // for additional architectures.
+        // For RHCOS, we never allow missing architectures to prevent incomplete manifests
+        // For FCOS development/mechanical builds, we allow missing architectures for flexibility
+        def allow_missing = pipeutils.is_rhcos_jenkins() ? false : true
+        
         build job: 'release', wait: params.WAIT_FOR_RELEASE_JOB, parameters: [
             string(name: 'STREAM', value: params.STREAM),
             string(name: 'ADDITIONAL_ARCHES', value: params.ADDITIONAL_ARCHES),
             string(name: 'VERSION', value: buildID),
-            booleanParam(name: 'ALLOW_MISSING_ARCHES', value: true),
+            booleanParam(name: 'ALLOW_MISSING_ARCHES', value: allow_missing),
             booleanParam(name: 'CLOUD_REPLICATION', value: params.CLOUD_REPLICATION),
             string(name: 'PIPECFG_HOTFIX_REPO', value: params.PIPECFG_HOTFIX_REPO),
             string(name: 'PIPECFG_HOTFIX_REF', value: params.PIPECFG_HOTFIX_REF)

--- a/utils.groovy
+++ b/utils.groovy
@@ -131,6 +131,10 @@ def add_hotfix_parameters_if_supported() {
     return []
 }
 
+def is_rhcos_jenkins() {
+    return env.JENKINS_URL && env.JENKINS_URL.contains('rhcos')
+}
+
 def get_source_config_for_stream(pipecfg, stream) {
     def url = pipecfg.source_config.url
     if (pipecfg.streams[stream].source_config_url) {


### PR DESCRIPTION
Publishing incomplete OCI manifests results in failures for OCP images. Update build to identify and pivot based on target.

#1186 