### PR TITLE
jobs: use newer API for coreos config git rev

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -308,7 +308,7 @@ lock(resource: "build-${params.STREAM}") {
                 def missing_arches = additional_arches - builds.builds[0].arches
                 if (missing_arches) {
                     def meta = readJSON(text: shwrapCapture("cosa meta --build=${buildID} --dump"))
-                    def rev = meta["coreos-assembler.config-gitrev"]
+                    def rev = meta["coreos-assembler.container-config-git"]["commit"]
                     currentBuild.description = "${build_description} 🔨 ${buildID}"
                     // Run the mArch jobs and wait. We wait here because if they fail
                     // we don't want to bother running the release job again since the

--- a/jobs/fix-build.Jenkinsfile
+++ b/jobs/fix-build.Jenkinsfile
@@ -122,9 +122,8 @@ lock(resource: "sign-${params.VERSION}") {
         build_description = "[${params.STREAM}][${basearches.join(' ')}][${params.VERSION}]"
         currentBuild.description = "${build_description} Running"
 
-        def src_config_commit = shwrapCapture("""
-            jq '.[\"coreos-assembler.config-gitrev\"]' builds/${params.VERSION}/${basearches[0]}/meta.json
-        """)
+        def meta = readJSON(file: "builds/${params.VERSION}/${basearches[0]}/meta.json")
+        def src_config_commit = meta["coreos-assembler.container-config-git"]["commit"]
 
         for (basearch in basearches) {
             pipeutils.tryWithMessagingCredentials() {


### PR DESCRIPTION
The .config-gitrev is legacy. Let's update to use the newer API.

xref: https://github.com/coreos/coreos-assembler/pull/4282