### PR TITLE
jobs/build-arch: add --autolock to the `cosa build` call

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -247,7 +247,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             def version = "--version ${params.VERSION}"
             def force = params.FORCE ? "--force" : ""
             shwrap("""
-            cosa build ostree ${strict_build_param} --skip-prune ${force} ${version} ${parent_arg}
+            cosa build ostree ${strict_build_param} --skip-prune ${force} ${version} ${parent_arg} ${autolock_arg}
             """)
 
             // Insert the parent info into meta.json so we can display it in


### PR DESCRIPTION
In the build-with-buildah workflow `cosa fetch` doesn't do anything so we need to add the `--autolock=VERSION` argument to the `cosa build` call.