### PR TITLE
Revert "jobs/build-arch: add --autolock to the `cosa build` call"

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -247,7 +247,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             def version = "--version ${params.VERSION}"
             def force = params.FORCE ? "--force" : ""
             shwrap("""
-            cosa build ostree ${strict_build_param} --skip-prune ${force} ${version} ${parent_arg} ${autolock_arg}
+            cosa build ostree ${strict_build_param} --skip-prune ${force} ${version} ${parent_arg}
             """)
 
             // Insert the parent info into meta.json so we can display it in


### PR DESCRIPTION
It turns out the underlying code will autolock anyway even without --autolock if it detects the right conditions so this change didn't actually do anything. The reason for the inconsistent behavior I was seeing that caused me to implement this change was fixed by https://github.com/coreos/fedora-coreos-config/pull/3705

The other reason to revert this is older COSA (i.e. 4.14 and older) don't recognize this option at all.

This reverts commit 0e1c9742351ec83e1c9978a4cec209997f06c75e.