### PR TITLE
jobs/fix-build: skip ostree import for F43+

### DIFF
--- a/jobs/fix-build.Jenkinsfile
+++ b/jobs/fix-build.Jenkinsfile
@@ -140,8 +140,15 @@ lock(resource: "sign-${params.VERSION}") {
                     }
                 }
                 if (!params.SKIP_COMPOSE_IMPORT) {
-                    parallelruns['OSTree Import: Compose Repo'] = {
-                        pipeutils.composeRepoImport(params.VERSION, basearch, s3_stream_dir)
+                    // Import into the OSTree repo if we are F42. We stopped
+                    // doing this for F43+ because we distribute updates from
+                    // the container registry now.
+                    if (params.VERSION.tokenize('.')[0] == '42') {
+                        parallelruns['OSTree Import: Compose Repo'] = {
+                            pipeutils.composeRepoImport(params.VERSION, basearch, s3_stream_dir)
+                        }
+                    } else {
+                        echo "Skipping OSTree repo import for F43+"
                     }
                 }
                 // process this batch


### PR DESCRIPTION
This should have been done as part of 71bbc5e