### PR TITLE
feat(build): add no_upload config knob

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -124,6 +124,9 @@ streams:
       # OPTIONAL: Create and replicate AWS Windows License Included images for this stream.
       # requires winli_billing_code under the 'aws' mapping
       create_and_replicate_winli_ami: true
+      # OPTIONAL: Do not not upload results to S3
+      # Default to false if not specified
+      no_upload: true
 
 # REQUIRED: architectures to build for other than x86_64
 additional_arches: [aarch64, ppc64le, s390x]

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -83,6 +83,10 @@ if (params.ADDITIONAL_ARCHES != "none") {
 
 def stream_info = pipecfg.streams[params.STREAM]
 
+// Default to false, override with runtime param or stream_info
+// runtime parameter always wins
+def no_upload = params.NO_UPLOAD ?: stream_info.get('no_upload', false)
+
 // Grab any environment variables we should set
 def container_env = pipeutils.get_env_vars_for_stream(pipecfg, params.STREAM)
 
@@ -166,7 +170,7 @@ lock(resource: "build-${params.STREAM}") {
         // Now, determine if we should do any uploads to remote s3 buckets or clouds
         // Don't upload if the user told us not to or we're debugging with KOLA_RUN_SLEEP
         def uploading = false
-        if (s3_stream_dir && (!params.NO_UPLOAD || params.KOLA_RUN_SLEEP)) {
+        if (s3_stream_dir && (!no_upload || params.KOLA_RUN_SLEEP)) {
             uploading = true
         }
 


### PR DESCRIPTION
Adds support for a no_upload flag in the config to skip S3 uploads. If both the config and pipeline specify the flag, the pipeline value takes precedence.