### PR TITLE
libcloud.groovy: buildfetch ostree artifact before creating winli image

### DIFF
--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -9,6 +9,7 @@ def replicate_to_clouds(pipecfg, basearch, buildID, stream) {
     def builders = [:]
     def credentials
     def stream_info = pipecfg.streams[stream]
+    def pipeutils = load("utils.groovy")
 
     credentials = [file(variable: "ALIYUN_IMAGE_UPLOAD_CONFIG",
                         credentialsId: "aliyun-image-upload-config")]
@@ -52,20 +53,23 @@ def replicate_to_clouds(pipecfg, basearch, buildID, stream) {
     // all regions, if the option is set for the current stream. `cosa aws-replicate` 
     // will handle both traditional AMIs and aws-winli AMIs if present in the metadata. 
     // aws-winli is only supported on x86_64.
-    def awsWinLIBuildClosure = { config, aws_image_name, credentialId ->
+    def awsWinLIBuildClosure = { config, credentialId ->
         def creds = [file(variable: "AWS_CONFIG_FILE", credentialsId: credentialId)]
         withCredentials(creds) {
             utils.syncCredentialsIfInRemoteSession(["AWS_CONFIG_FILE"])
-            def c = config
-
-            // Since we are not uploading anything, let's just touch the vmdk image
-            // file to satisfy the cosa ore wrapper, which still requires the file 
-            // in the cosa working dir.
-            def aws_image_path = "builds/${buildID}/${basearch}/${aws_image_name}"
+            def s3_stream_dir = pipeutils.get_s3_streams_dir(config, stream)
+            // the AWS ore wrapper relies on information stored in image.json. We need to buildfetch
+            // the ostree artifact to be consistent and use the same values as the original AMI.
             shwrap("""
-                touch ${aws_image_path}
+                cosa buildfetch \
+                    --build=${buildID} \
+                    --arch=${basearch} \
+                    --artifact=ostree \
+                    --url=s3://${s3_stream_dir}/builds \
+                    --aws-config-file \${AWS_CONFIG_FILE}
             """)
 
+            def c = config.clouds.aws
             def extraArgs = []
             if (c.grant_users) {
                 extraArgs += c.grant_users.collect{"--grant-user=${it}"}
@@ -101,15 +105,10 @@ def replicate_to_clouds(pipecfg, basearch, buildID, stream) {
         if (pipecfg.clouds?.aws &&
             utils.credentialsExist(credentials)) {
 
-            // grab the aws vmdk image name from the metadata to pass to the winli closure.
-            // the cosa ore wrapper still requires the image to exist, but we dont upload 
-            // anything so we'll just touch the file in the cosa working dir.
-            def aws_image_name = meta.images.aws.path
             // aws-winli is only supported on x86_64
             if ((basearch == "x86_64") && (stream_info.create_and_replicate_winli_ami)) {
                 builders["☁️ 🔨:aws-winli"] = {
-                    awsWinLIBuildClosure.call(pipecfg.clouds.aws, aws_image_name,
-                                        "aws-build-upload-config")
+                    awsWinLIBuildClosure.call(pipecfg, "aws-build-upload-config")
                 }
             }
             replicators["☁️ 🔄:aws"] = {


### PR DESCRIPTION
The AWS ore wrapper relies on information from image.json. Buildfetch the ostree artifact before creating and replicating the AWS Windows License Included (winli) image to be consistent and use the same values as the original AMI.

Also, remove the hack to get around buildfetch'ing the vmdk image since the build artifact is no longer required in the winli build case.

See: https://github.com/coreos/coreos-assembler/pull/4315