### PR TITLE
jobs/build-nvidia-bfb fix checksum

### DIFF
--- a/jobs/build-nvidia-bfb.Jenkinsfile
+++ b/jobs/build-nvidia-bfb.Jenkinsfile
@@ -190,7 +190,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
                 cd -
 
                 artifactjson=$(readlink -f tmp/artifactjson.json)
-                checksum=$(sha256sum $outfile)
+                checksum=$(sha256sum $outfile | cut -d ' ' -f 1)
                 size=$(stat -c '%s' $outfile)
                 cat <<EOM > "$artifactjson"
                 {


### PR DESCRIPTION
`sha256sum` will default to printing out the name of the file too. Let's cut off that part so we just end up with the hash.