### PR TITLE
config: enable next-devel 2025-09

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,8 +8,8 @@ streams:
   testing-devel:
     type: development
     default: true
-  # next-devel:         # do not touch; line managed by `next-devel/manage.py`
-    # type: development # do not touch; line managed by `next-devel/manage.py`
+  next-devel:         # do not touch; line managed by `next-devel/manage.py`
+    type: development # do not touch; line managed by `next-devel/manage.py`
   rawhide:
     type: mechanical
     env:

--- a/next-devel/badge.json
+++ b/next-devel/badge.json
@@ -2,6 +2,6 @@
     "schemaVersion": 1,
     "style": "for-the-badge",
     "label": "next-devel",
-    "message": "closed",
-    "color": "lightgrey"
+    "message": "open",
+    "color": "green"
 }

--- a/next-devel/status.json
+++ b/next-devel/status.json
@@ -1,3 +1,3 @@
 {
-    "enabled": false
+    "enabled": true
 }


### PR DESCRIPTION
We are ready to have `next` differ from `testing`. We are doing a migration to container signing [1] for `next` only for now and then immediately after we'll be switching over `next` to F43 content because the F43 beta release is ready to go next week.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/2029