### PR TITLE
Add locking to make kola-upgrade jobs run after release job.

### DIFF
--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -76,6 +76,13 @@ if (params.ARCH == 'x86_64') {
     cosa_memory_request_mb = 1024 + 1024 + 1536 + 512
 }
 
+
+echo "Waiting for release job to finish (release-${params.STREAM} lock)"
+sleep 10 // to prevent race with release job starting up
+lock(resource: "release-${params.STREAM}") {
+    echo "release-${params.STREAM} lock acquired"
+}
+echo "release-${params.STREAM} lock released"
 lock(resource: "kola-upgrade-${params.ARCH}") {
     cosaPod(memory: "${cosa_memory_request_mb}Mi",
             image: params.COREOS_ASSEMBLER_IMAGE,


### PR DESCRIPTION
The release job is the one that pushes (and signs) containers. If we want our kola-upgrade test to be more realistic it makes sense to have it run after the containers have been pushed so we can test pulling from the registry and also signature verification.

Here we make the kola-upgrade job wait until the release job is done before starting the upgrade tests. For the production builds this won't really have any effect because we don't autorun the release job, but that's OK.