### PR TITLE
config: adjust COSA_BUILD_WITH_BUILDAH value

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,12 +14,12 @@ streams:
     type: mechanical
     env:
       # https://github.com/coreos/fedora-coreos-tracker/issues/1969
-      COSA_BUILD_WITH_BUILDAH: true
+      COSA_BUILD_WITH_BUILDAH: 1
   branched:
     type: mechanical
     env:
       # https://github.com/coreos/fedora-coreos-tracker/issues/1969
-      COSA_BUILD_WITH_BUILDAH: true
+      COSA_BUILD_WITH_BUILDAH: 1
   # bodhi-updates:
   #   type: mechanical
   # bodhi-updates-testing:


### PR DESCRIPTION
In COSA the requirements got a bit more strict for opting in here [1]. Let's just change it rather than go back and adjust the code.

[1] https://github.com/coreos/coreos-assembler/commit/bb7443a6c22d336a92b88759417c0a34aa631260