### PR TITLE
config.yaml: remove COSA_BUILD_WITH_BUILDAH

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,14 +12,8 @@ streams:
     type: development # do not touch; line managed by `next-devel/manage.py`
   rawhide:
     type: mechanical
-    env:
-      # https://github.com/coreos/fedora-coreos-tracker/issues/1969
-      COSA_BUILD_WITH_BUILDAH: 1
   branched:
     type: mechanical
-    env:
-      # https://github.com/coreos/fedora-coreos-tracker/issues/1969
-      COSA_BUILD_WITH_BUILDAH: 1
   # bodhi-updates:
   #   type: mechanical
   # bodhi-updates-testing:


### PR DESCRIPTION
This was useful to get started but nowadays this is enabled by the src config itself so there's no need for this.