### PR TITLE
jobs/build-cosa: increase cosaPod memory allocation to 1014Mi

### DIFF
--- a/jobs/build-cosa.Jenkinsfile
+++ b/jobs/build-cosa.Jenkinsfile
@@ -93,7 +93,7 @@ def basearches = params.ARCHES.split() as Set
 
 lock(resource: "build-${containername}") {
     cosaPod(image: params.COREOS_ASSEMBLER_IMAGE,
-            memory: "512Mi", kvm: false,
+            memory: "1024Mi", kvm: false,
             serviceAccount: "jenkins") {
     timeout(time: 60, unit: 'MINUTES') {
     try {


### PR DESCRIPTION
The build-cosa job is being OOMKilled during its initializiation steps. Increase the memory of the cosaPod to 1024Mi to provide more headroom.