### PR TITLE
config: disable branched stream

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,8 +12,8 @@ streams:
     type: development # do not touch; line managed by `next-devel/manage.py`
   rawhide:
     type: mechanical
-  branched:
-    type: mechanical
+  #branched:
+  #  type: mechanical
   # bodhi-updates:
   #   type: mechanical
   # bodhi-updates-testing:


### PR DESCRIPTION
Fedora 43 is now being tracked in the `next-devel` branch, so we can disable the `branched` stream now.