### PR TITLE
Move build-mechnical to 04:00 UTC

### DIFF
--- a/jobs/build-mechanical.Jenkinsfile
+++ b/jobs/build-mechanical.Jenkinsfile
@@ -7,8 +7,8 @@ node {
 
 properties([
     pipelineTriggers([
-        // run every 24h at 10:00 UTC
-        cron("0 10 * * *")
+        // run every 24h at 04:00 UTC
+        cron("0 4 * * *")
     ]),
     buildDiscarder(logRotator(
         numToKeepStr: '100',


### PR DESCRIPTION
The goal being to ensure build-mechnical and the downstream build-node-image jobs finish before we typically see content changed, which tends to be EMEA to US East AM hours. In situations where we're hoping to pick up late changes this may cause delays, if that becomes an issue I'd propose we consider adding a second run at 17:00 UTC (EDT 12:00 + 5hr), but ideally we'd limit that to only versions where we hope to have rapid turn around. Those versions would be 9.6 today, then 9.6, 9.8, and 10.2 starting approximately May 2026.