### PR TITLE
jobs/bump-lockfile: force fetch to be effective

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -141,7 +141,7 @@ lock(resource: "bump-lockfile") {
                         cosa buildfetch --arch=${arch} --find-build-for-arch \
                             --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
                             --url=s3://${s3_stream_dir}/builds
-                        cosa fetch --update-lockfile --dry-run
+                        COSA_BUILD_WITH_BUILDAH=0 cosa fetch --update-lockfile --dry-run
                         """)
                     } else {
                         pipeutils.withExistingCosaRemoteSession(
@@ -150,7 +150,7 @@ lock(resource: "bump-lockfile") {
                             cosa buildfetch --arch=${arch} --find-build-for-arch \
                                 --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
                                 --url=s3://${s3_stream_dir}/builds
-                            cosa fetch --update-lockfile --dry-run
+                            COSA_BUILD_WITH_BUILDAH=0 cosa fetch --update-lockfile --dry-run
                             cosa remote-session sync {:,}src/config/manifest-lock.${arch}.json
                             """)
                         }


### PR DESCRIPTION
In the new build-with-buildah path for building `cosa fetch` is typically useless so we effectively made it exit early [1] [2] if building with buildah is enabled.

In the case of the bump-lockfile job, though, we are actually using the fetch to update the lockfiles first, and then use them as inputs to the build. In this case we need `cosa fetch` to actually update the lockfiles, so let's override with COSA_BUILD_WITH_BUILDAH=0 here.

[1] https://github.com/coreos/coreos-assembler/commit/0ce8501ded7e3ab4d370e8333b2800716d20d655
[2] https://github.com/coreos/coreos-assembler/commit/bb7443a6c22d336a92b88759417c0a34aa631260