### PR TITLE
jobs/bump-lockfile: fix setting env for remote builders

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -141,7 +141,7 @@ lock(resource: "bump-lockfile") {
                         cosa buildfetch --arch=${arch} --find-build-for-arch \
                             --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
                             --url=s3://${s3_stream_dir}/builds
-                        COSA_BUILD_WITH_BUILDAH=0 cosa fetch --update-lockfile --dry-run
+                        cosa shell -- env COSA_BUILD_WITH_BUILDAH=0 cosa fetch --update-lockfile --dry-run
                         """)
                     } else {
                         pipeutils.withExistingCosaRemoteSession(
@@ -150,7 +150,7 @@ lock(resource: "bump-lockfile") {
                             cosa buildfetch --arch=${arch} --find-build-for-arch \
                                 --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
                                 --url=s3://${s3_stream_dir}/builds
-                            COSA_BUILD_WITH_BUILDAH=0 cosa fetch --update-lockfile --dry-run
+                            cosa shell -- env COSA_BUILD_WITH_BUILDAH=0 cosa fetch --update-lockfile --dry-run
                             cosa remote-session sync {:,}src/config/manifest-lock.${arch}.json
                             """)
                         }


### PR DESCRIPTION
The setting of the COSA_BUILD_WITH_BUILDAH env variable gets lost here when proxying it across to a remote builder. Which means that only x86_64 is getting lockfile bumps [1] (i.e. the only arch that isn't using a remote builder). Let's wrap it in a `cosa shell` to fix this.

Fixes 66b653b

[1] https://github.com/coreos/fedora-coreos-config/commit/a94a13aebc341a9e17f407b0766a6bc511202230