### PR TITLE
jobs/kola-upgrade: bump timeout to 150m

### DIFF
--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -87,7 +87,7 @@ lock(resource: "kola-upgrade-${params.ARCH}") {
     cosaPod(memory: "${cosa_memory_request_mb}Mi",
             image: params.COREOS_ASSEMBLER_IMAGE,
             serviceAccount: "jenkins") {
-    timeout(time: 90, unit: 'MINUTES') {
+    timeout(time: 150, unit: 'MINUTES') {
     try {
 
         // Determine the target version. If no params.TARGET_VERSION was


### PR DESCRIPTION
The test itself [1] was just modified to have a longer timeout so let's adjust here to twice that time since there's an initial run and also a rerun that could happen.

[1] https://github.com/coreos/fedora-coreos-config/commit/7f21e359fd27a26edff30894f72857e22a577f2b