### PR TITLE
kola-upgrade: rework architecture detection logic

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -184,7 +184,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
                 def releases = readJSON file: "releases.json"
                 // check if there's a previous release we should use as parent
                 for (release in releases["releases"].reverse()) {
-                    def oci_image = release["oci-images"].find{ images -> images["architecture"] == basearch }
+                    def oci_image = release["oci-images"].find{ image -> image["architecture"] == basearch }
                     if (oci_image != null) {
                         parent_version = release["version"]
                         break

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -231,7 +231,7 @@ lock(resource: "build-${params.STREAM}") {
                 def releases = readJSON file: "releases.json"
                 // check if there's a previous release we should use as parent
                 for (release in releases["releases"].reverse()) {
-                    def oci_image = release["oci-images"].find{ images -> images["architecture"] == basearch }
+                    def oci_image = release["oci-images"].find{ image -> image["architecture"] == basearch }
                     if (oci_image != null) {
                         parent_version = release["version"]
                         break

--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -112,7 +112,7 @@ lock(resource: "kola-upgrade-${params.ARCH}") {
             def releases = readJSON file: "releases.json"
             def newest_version = releases["releases"][-1]["version"]
             for (release in releases["releases"]) {
-                def has_arch = release["commits"].find{ commit -> commit["architecture"] == params.ARCH }
+                def has_arch = release["oci-images"].find{ image -> image["architecture"] == params.ARCH }
                 if (release["version"] in deadends || has_arch == null) {
                     continue // This release has been disqualified
                 }


### PR DESCRIPTION
Similar to c25521d we need to update the logic in the upgrade test
for finding if a given release is built for the given architecture.
