### PR TITLE
release: fix the lock for releases containing 1 arch

### DIFF
--- a/jobs/release.Jenkinsfile
+++ b/jobs/release.Jenkinsfile
@@ -92,7 +92,7 @@ currentBuild.description = "${build_description} Waiting"
 lock(resource: "release-${params.STREAM}") {
 // Also lock version-arch-specific locks to make sure these builds are finished.
 def locks = basearches.collect{[resource: "release-${params.VERSION}-${it}"]}
-lock(resource: locks[0].resource, extra: locks[1..-1]) {
+lock(resource: locks.remove(0).resource, extra: locks) {
     // We should probably try to change this behavior in the coreos-ci-lib
     // So we won't need to handle the secret case here.
     // Request 4.5Gi: in the worst case, we need to upload 4 container images in


### PR DESCRIPTION
In 3051996 we added a second level of locking on a per-arch basis. However if the release job is started only for 1 architecture, using `1..-1` results in an index out of bounds as the inital array is one. Use a remove in place operation instead.