### PR TITLE
kola-upgrade: fix architecture check for older releases

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -184,12 +184,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
                 def releases = readJSON file: "releases.json"
                 // check if there's a previous release we should use as parent
                 for (release in releases["releases"].reverse()) {
-                    // older releases are only carrying an ostree commit
-                    def media = "oci-images"
-                    if (release[media] == null) {
-                        media = "commits"
-                    }
-                    def oci_image = release[media].find{ image -> image["architecture"] == basearch }
+                    def oci_image = release["oci-images"].find{ image -> image["architecture"] == basearch }
                     if (oci_image != null) {
                         parent_version = release["version"]
                         break

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -231,12 +231,7 @@ lock(resource: "build-${params.STREAM}") {
                 def releases = readJSON file: "releases.json"
                 // check if there's a previous release we should use as parent
                 for (release in releases["releases"].reverse()) {
-                    // older releases are only carrying an ostree commit
-                    def media = "oci-images"
-                    if (release[media] == null) {
-                        media = "commits"
-                    }
-                    def oci_image = release[media].find{ image -> image["architecture"] == basearch }
+                    def oci_image = release["oci-images"].find{ image -> image["architecture"] == basearch }
                     if (oci_image != null) {
                         parent_version = release["version"]
                         break

--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -112,12 +112,11 @@ lock(resource: "kola-upgrade-${params.ARCH}") {
             def releases = readJSON file: "releases.json"
             def newest_version = releases["releases"][-1]["version"]
             for (release in releases["releases"]) {
-                // for older releases that don't have OCI images we get the ostree commit
-                def media = "oci-images"
-                if ( release[media] == null) {
-                    media = "commits"
+                def has_arch = release["oci-images"].find{ image -> image["architecture"] == params.ARCH }
+                if (has_arch == null) {
+                    // releases older than 42 only had commits, no oci-images, so let's also check commits
+                    has_arch = release["commits"].find{ commit -> commit["architecture"] == params.ARCH }
                 }
-                has_arch = release[media].find{ image -> image["architecture"] == params.ARCH }
                 if (release["version"] in deadends || has_arch == null) {
                     continue // This release has been disqualified
                 }


### PR DESCRIPTION
Unlike the build and build-arch jobs we need to still have compat here for older releases < 42 where no oci-images entry in the release metadata existed. i.e. we want to start the upgrade test from those older versions so we need to have compat here for that case.

Fixes 2becf34