### PR TITLE
libcloud.groovy: drop outdated cleanup step

### DIFF
--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -79,12 +79,6 @@ def replicate_to_clouds(pipecfg, basearch, buildID, stream) {
                     --credentials-file=\${AWS_CONFIG_FILE} \
                     ${extraArgs.join(' ')}
             """)
-
-            // remove the false vmdk file from the builds directory so it doesn't get
-            // uploaded by some other process
-            shwrap("""
-                rm ${aws_image_path}
-            """)
         }
     }
     if (meta.amis) {


### PR DESCRIPTION
This code was supposed to be removed in an earlier change`[1]`. Removing it now fixes the cloud-replicate job, which is failing due to the undeclared variable.

`[1]`: https://github.com/coreos/fedora-coreos-pipeline/pull/1217