### PR TITLE
bump-lockfile: Add hermeto lockfile generation

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -141,7 +141,7 @@ lock(resource: "bump-lockfile") {
                         cosa buildfetch --arch=${arch} --find-build-for-arch \
                             --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
                             --url=s3://${s3_stream_dir}/builds
-                        cosa shell -- env COSA_BUILD_WITH_BUILDAH=0 cosa fetch --update-lockfile --dry-run
+                        cosa shell -- env COSA_BUILD_WITH_BUILDAH=0 cosa fetch --update-lockfile --dry-run --konflux
                         """)
                     } else {
                         pipeutils.withExistingCosaRemoteSession(
@@ -150,8 +150,9 @@ lock(resource: "bump-lockfile") {
                             cosa buildfetch --arch=${arch} --find-build-for-arch \
                                 --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
                                 --url=s3://${s3_stream_dir}/builds
-                            cosa shell -- env COSA_BUILD_WITH_BUILDAH=0 cosa fetch --update-lockfile --dry-run
+                            cosa shell -- env COSA_BUILD_WITH_BUILDAH=0 cosa fetch --update-lockfile --dry-run --konflux
                             cosa remote-session sync {:,}src/config/manifest-lock.${arch}.json
+                            cosa remote-session sync {:,}src/config/${arch}.rpms.lock.yaml
                             """)
                         }
                     }
@@ -185,12 +186,21 @@ lock(resource: "bump-lockfile") {
             return
         }
 
-        // sanity-check only base lockfiles were changed
+        // Merge the hermeto lockfiles and delete the intermediaries files
+        def archExpansion = "{${archinfo.keySet().join(',')}}"
+        shwrap("""
+          pushd src/config
+          /usr/lib/coreos-assembler/konflux-rpm-lockfile merge --input ${archExpansion}.rpms.lock.yaml --override konflux-lockfile-override.yaml
+          rm ${archExpansion}.rpms.lock.yaml
+          popd
+        """)
+        
+        // sanity-check only base and konflux lockfiles were changed
         shwrap("""
           # do this separately so set -e kicks in if it fails
           files=\$(git -C src/config ls-files --modified --deleted)
           for f in \${files}; do
-            if ! [[ \${f} =~ ^manifest-lock\\.[0-9a-z_]+\\.json ]]; then
+            if ! [[ \${f} =~ ^(manifest-lock\\.[0-9a-z_]+\\.json|rpms\\.lock\\.yaml) ]]; then
               echo "Unexpected modified file \${f}"
               exit 1
             fi
@@ -270,6 +280,8 @@ lock(resource: "bump-lockfile") {
             if (!haveChanges && forceTimestamp) {
                 message="lockfiles: bump timestamp"
             }
+
+            shwrap("git -C src/config add rpms.lock.yaml")
             shwrap("git -C src/config add manifest-lock.*.json")
             shwrap("git -C src/config commit -m '${message}' -m 'Job URL: ${env.BUILD_URL}' -m 'Job definition: https://github.com/coreos/fedora-coreos-pipeline/blob/main/jobs/bump-lockfile.Jenkinsfile'")
             withCredentials([usernamePassword(credentialsId: botCreds,


### PR DESCRIPTION
At the same time we bump the rpm-ostree lockfiles, let's derive the hermeto config from them to support hermetic builds. Commit everything in one go.

Requires https://github.com/coreos/fedora-coreos-config/pull/3644