### PR TITLE
utils: make it robust to null check

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -400,7 +400,7 @@ def scheduled_streams(config, streams_subset) {
 // Returns a list of stream names from `streams_subset` that do not have `konflux_driven: true` set
 def non_konflux_driven_streams(config, streams_subset) {
     return streams_subset.findAll{stream ->
-        !config.streams[stream].konflux_driven}.collect{k, v -> k}
+        !config.streams[stream]?.konflux_driven ?: false}.collect{k, v -> k}
 }
 
 def get_streams_choices(config, node = null) {


### PR DESCRIPTION
In RHCOS pipeline, a plugin makes the `build-node-image` job fail because the `non_konflux_driven_stream` function raises java.lang.NullPointerException. This commit edits the function to handle the potential null value.

Fixes https://github.com/coreos/fedora-coreos-pipeline/pull/1246