### PR TITLE
config.yaml: disable next-devel 2025-10-27

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,8 +8,8 @@ streams:
   testing-devel:
     type: development
     default: true
-  next-devel:         # do not touch; line managed by `next-devel/manage.py`
-    type: development # do not touch; line managed by `next-devel/manage.py`
+  # next-devel:         # do not touch; line managed by `next-devel/manage.py`
+    # type: development # do not touch; line managed by `next-devel/manage.py`
   rawhide:
     type: mechanical
   #branched:

--- a/next-devel/badge.json
+++ b/next-devel/badge.json
@@ -2,6 +2,6 @@
     "schemaVersion": 1,
     "style": "for-the-badge",
     "label": "next-devel",
-    "message": "open",
-    "color": "green"
+    "message": "closed",
+    "color": "lightgrey"
 }

--- a/next-devel/status.json
+++ b/next-devel/status.json
@@ -1,3 +1,3 @@
 {
-    "enabled": true
+    "enabled": false
 }


### PR DESCRIPTION
Now that testing-devel is tracking Fedora 43`[1]`* there is no difference between testing-devel and next-devel, so we can disable it.

`[1]`: https://github.com/coreos/fedora-coreos-config/pull/3852

`*` PR hasn't merged yet