### PR TITLE
jobs/bump-lockfile: enable for mechanical streams

### DIFF
--- a/jobs/bump-lockfiles.Jenkinsfile
+++ b/jobs/bump-lockfiles.Jenkinsfile
@@ -15,8 +15,10 @@ node {
     def pipeutils = load("utils.groovy")
     def pipecfg = pipeutils.load_pipecfg()
     def development_streams = pipeutils.streams_of_type(pipecfg, 'development')
+    def mechanical_streams = pipeutils.streams_of_type(pipecfg, 'mechanical')
+    streams_to_bump = development_streams + mechanical_streams
 
-    parallel development_streams.collectEntries { stream -> [stream, {
+    parallel streams_to_bump.collectEntries { stream -> [stream, {
         build job: 'bump-lockfile', wait: false, parameters: [
             string(name: 'STREAM', value: stream)
         ]


### PR DESCRIPTION
As Konflux is commit-based, enabling lockfiles for all the streams (not only development ones) will ensure us to have a new build when necessary i.e: when new tested packages set exists. 
This addresses part of the plan described in [1].

[1] https://github.com/coreos/fedora-coreos-tracker/issues/2038#issuecomment-3498258143