### PR TITLE
config.yaml: trigger rawhide with Konflux only

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,7 @@ streams:
     # type: development # do not touch; line managed by `next-devel/manage.py`
   rawhide:
     type: mechanical
+    konflux_driven: true
   #branched:
   #  type: mechanical
   # bodhi-updates:


### PR DESCRIPTION
Currently, Rawhide stream build is triggered twice: with Jenkins cron and with the new Konflux workflow (commit based trigger). The latter is working fine now, so we can disable the Jenkins cron. This is the last piece to close the tracker issue below.

Closes https://github.com/coreos/fedora-coreos-tracker/issues/2038