### PR TITLE
Revert "utils: hide Konflux-driven streams from job UI"

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -408,8 +408,7 @@ def get_streams_choices(config, node = null) {
 
     def default_stream = stream_source.find { k, v -> v['default'] == true }?.key
     def other_streams = stream_source.keySet().minus(default_stream) as List
-    def non_konflux_driven_streams = non_konflux_driven_streams(config, other_streams)
-    return [default_stream] + non_konflux_driven_streams
+    return [default_stream] + other_streams
 }
 
 // Returns the default trigger for push notifications. This will trigger builds


### PR DESCRIPTION
This reverts commit 0addd8ee60f14b8723ffa8a90a9554da31529e8a.


@joelcapitao  and @dustymabe found this change resulted in failures in our pipeline example seen here => https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/build-arch/918/pipeline-overview/