### PR TITLE
Fix build.Jenkinsfile to use string parameter for SKIP_UNTESTED_ARTIFACTS

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -610,7 +610,7 @@ def run_multiarch_jobs(arches, src_commit, version, src_oci, cosa_img, wait) {
             build job: 'build-arch', wait: wait, parameters: [
                 booleanParam(name: 'FORCE', value: true),
                 booleanParam(name: 'ALLOW_KOLA_UPGRADE_FAILURE', value: params.ALLOW_KOLA_UPGRADE_FAILURE),
-                booleanParam(name: 'SKIP_UNTESTED_ARTIFACTS', value: params.SKIP_UNTESTED_ARTIFACTS),
+                string(name: 'SKIP_UNTESTED_ARTIFACTS', value: params.SKIP_UNTESTED_ARTIFACTS),
                 string(name: 'SRC_CONFIG_COMMIT', value: src_commit),
                 string(name: 'SOURCE_OCI_IMAGE', value: src_oci),
                 string(name: 'COREOS_ASSEMBLER_IMAGE', value: cosa_img),


### PR DESCRIPTION
build-arch.Jenkinsfile uses a choice parameter for SKIP_UNTESTED_ARTIFACTS, this fix changes build.Jenkinsfile to use a string parameter for SKIP_UNTESTED_ARTIFACTS, instead of a boolean parameter when calling build-arch job