### PR TITLE
build-node-image: support passing build-args file to builds

### DIFF
--- a/jobs/build-node-image.Jenkinsfile
+++ b/jobs/build-node-image.Jenkinsfile
@@ -57,10 +57,15 @@ def cosa_img = params.COREOS_ASSEMBLER_IMAGE
 // the `io.openshift.os.streamclass` label. The streamclass is based on
 // the rhel major version and is used by the MCO to later select the right
 // image stream when multiple RHEL versions coexist.
-def rhel_segment = params.RELEASE.split('-')[1]
-def rhel_major = rhel_segment.split('\\.')[0]
+def rhel_version = params.RELEASE.split('-')[1]
+def rhel_major = rhel_version.split('\\.')[0]
 def stream_class = "rhel-${rhel_major}"
 def stream_class_label = "io.openshift.os.streamclass=${stream_class}"
+
+// Derive the build-args file for labels.json and OCI LABELs.
+// RELEASE is e.g. "4.22-9.8" or "4.22-c9s".
+def ocp_version = params.RELEASE.split('-')[0]
+def build_args_file = "build-args-${rhel_version}-${ocp_version}.conf"
 
 // Get the tag that's unique
 def unique_tag = ""
@@ -138,12 +143,17 @@ lock(resource: "build-node-image") {
         stage('Build Node Image') {
             withCredentials([file(credentialsId: 'oscontainer-push-registry-secret', variable: 'REGISTRY_AUTH_FILE')]) {
                  def build_from = params.FROM ?: stream_info.from
-                 def label_args = []
+                 def extra_build_args = []
                  if (stream_class_label) {
-                     label_args += ["--label", "${stream_class_label}"]
+                     extra_build_args += ["--label", "${stream_class_label}"]
                  }
                  if (unique_tag != "") {
-                     label_args += ["--label", "coreos.build.manifest-list-tag=${unique_tag}"]
+                     extra_build_args += ["--label", "coreos.build.manifest-list-tag=${unique_tag}"]
+                 }
+                 // for now this is opt-in, but once it propagates we can flip
+                 // it to opt-out (or just unconditional)
+                 if (stream_info.build_args_file) {
+                     extra_build_args += ["--build-arg-file", build_args_file]
                  }
 
                  node_image_manifest_digest = pipeutils.build_and_push_image(arches: arches,
@@ -157,7 +167,7 @@ lock(resource: "build-node-image") {
                                                 from: build_from,
                                                 v2s2: v2s2,
                                                 extra_build_args: ["--security-opt label=disable", "--mount-host-ca-certs", "--force",
-                                                                   "--add-openshift-build-labels"] + label_args)
+                                                                   "--add-openshift-build-labels"] + extra_build_args)
             }
         }
 


### PR DESCRIPTION
Add support for passing a `--build-arg-file` to `cosa remote-build-container` during node image builds. The build-args filename is derived from the `RELEASE` parameter (e.g. build-args-9.8-4.22.conf) and is only passed when the `build_args_file` knob is enabled in pipecfg.

Part of https://redhat.atlassian.net/browse/COS-4051 where we'll add build arg files for setting various security labels on the node image.

Assisted-by: OpenCode (Claude Opus 4.6)