### PR TITLE
Revert "strongly couple versionary use to build-with-buildah"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -112,6 +112,7 @@ clouds:
     test_architectures: [x86_64, aarch64]
 
 misc:
+  versionary: true
   generate_release_index: true
   run_extended_upgrade_test_fcos: true
   allow_missing_architectures_when_autotriggering_release_job: true

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -59,6 +59,8 @@ streams:
       source_config_ref: main
       # OPTIONAL: override OS variant to use for this stream
       variant: rhcos-9.0
+      # OPTIONAL: override whether to use a versionary for this stream
+      versionary: false
       # OPTIONAL: Whether to skip building ostree in the build pipeline.
       # The build would be imported using `cosa import` with the specified image uri.
       import_oci_image: quay.io/coreos-devel/fedora-coreos:rawhide
@@ -301,6 +303,8 @@ clouds:
 
 # OPTIONAL: miscellaneous options
 misc:
+  # OPTIONAL: whether to use a versionary to derive version numbers
+  versionary: true
   # OPTIONAL: whether to generate a release index
   generate_release_index: true
   # OPTIONAL: whether to run extended upgrade test kola job

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -299,7 +299,12 @@ lock(resource: "build-${params.STREAM}") {
                 if (params.VERSION) {
                     version_arg = "--version ${params.VERSION}"
                 } else {
-                    if (should_use_versionary()) {
+                    def use_versionary = pipecfg.misc?.versionary
+                    if (stream_info.containsKey('versionary')) {
+                        // stream override always wins
+                        use_versionary = stream_info.versionary
+                    }
+                    if (use_versionary) {
                         version_arg = "--versionary"
                     }
                 }
@@ -624,18 +629,4 @@ def buildid_has_work_pending(buildID, arches) {
         locked = false
     }
     return locked
-}
-
-// A function to tell us if we should use versionary for the
-// build versioning or not. Right now we tightly couple this to
-// if we should build with buildah. So we basically say if build-with-buildah
-// is set then we'll definitely use versionary, which is safe for
-// now because all of FCOS is using build-with-buildah (i.e. using
-// versionary), but we are phasing in build-with-buildah in rhel-coreos-config.
-def should_use_versionary() {
-    if (shwrapRc("source /usr/lib/coreos-assembler/cmdlib.sh; should_build_with_buildah") == 0) {
-        return true
-    } else {
-        return false
-    }
 }

--- a/utils.groovy
+++ b/utils.groovy
@@ -1041,18 +1041,4 @@ def should_we_skip_untested_artifacts(pipecfg) {
     }
 }
 
-// A function to tell us if we should use versionary for the
-// build versioning or not. Right now we tightly couple this to
-// if we should build with buildah. So we basically say if build-with-buildah
-// is set then we'll definitely use versionary, which is safe for
-// now because all of FCOS is using build-with-buildah (i.e. using
-// versionary), but we are phasing in build-with-buildah in rhel-coreos-config.
-def should_use_versionary() {
-    if (shwrapRc("source /usr/lib/coreos-assembler/cmdlib.sh; should_build_with_buildah") == 0) {
-        return true
-    } else {
-        return false
-    }
-}
-
 return this


### PR DESCRIPTION
This reverts commit 7dc87c44ded20e27231b8dbeed501ac570502aa7. In COSA we recently made `build_qith_buildah` the default, dropping old the dead code[1].
This made `should_build_with_buildah` an undefined function. Since we can't use it anymore to decide whether to use versionnary, let's revert to the previous behaviour whith a pipecfg setting.

[1] https://github.com/coreos/coreos-assembler/pull/4527