### PR TITLE
jobs/build: change coupling for versionary

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -628,12 +628,9 @@ def buildid_has_work_pending(buildID, arches) {
 
 // A function to tell us if we should use versionary for the
 // build versioning or not. Right now we tightly couple this to
-// if we should build with buildah. So we basically say if build-with-buildah
-// is set then we'll definitely use versionary, which is safe for
-// now because all of FCOS is using build-with-buildah (i.e. using
-// versionary), but we are phasing in build-with-buildah in rhel-coreos-config.
+// if a versionary script exists in the src/config repo.
 def should_use_versionary() {
-    if (shwrapRc("source /usr/lib/coreos-assembler/cmdlib.sh; should_build_with_buildah") == 0) {
+    if (shwrapRc("test -f src/config/versionary") == 0) {
         return true
     } else {
         return false

--- a/utils.groovy
+++ b/utils.groovy
@@ -1041,18 +1041,4 @@ def should_we_skip_untested_artifacts(pipecfg) {
     }
 }
 
-// A function to tell us if we should use versionary for the
-// build versioning or not. Right now we tightly couple this to
-// if we should build with buildah. So we basically say if build-with-buildah
-// is set then we'll definitely use versionary, which is safe for
-// now because all of FCOS is using build-with-buildah (i.e. using
-// versionary), but we are phasing in build-with-buildah in rhel-coreos-config.
-def should_use_versionary() {
-    if (shwrapRc("source /usr/lib/coreos-assembler/cmdlib.sh; should_build_with_buildah") == 0) {
-        return true
-    } else {
-        return false
-    }
-}
-
 return this


### PR DESCRIPTION
We made the build-with-buildah path the default in [1] so
there's no longer any should_build_with_buildah function for
us to check for here. Instead let's just check if the versionary
script is in the src/config repo and we know if it exists we should
use it.

[1] https://github.com/coreos/coreos-assembler/commit/939d4fb7794908d29f03d3b3d35a740e27b1e61b
