### PR TITLE
jobs/bump-lockfile: drop custom versionary logic

### DIFF
--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -164,9 +164,6 @@ lock(resource: "bump-lockfile") {
         // later) what packages changed.
         stage("Container Build") {
             def parallelruns = [:]
-            // Use a development version when doing the build. Otherwise versionary
-            // will complain since this stream should be locked.
-            def dev_version = shwrapCapture("src/config/versionary --dev")
             for (architecture in archinfo.keySet()) {
                 def arch = architecture
                 parallelruns[arch] = {
@@ -180,7 +177,7 @@ lock(resource: "bump-lockfile") {
                             # Delete the non-overrides lockfile so this build will be
                             # unlocked so we'll get new RPM updates.
                             cosa shell -- rm src/config/manifest-lock.${arch}.json
-                            cosa build --force --version ${dev_version}
+                            cosa build --force
                             # Copy the generated lockfile into place.
                             # NOTE: if on a remote builder this will copy to the x86_64 pod
                             cosa shell -- cat builds/latest/${arch}/manifest-lock.generated.${arch}.json \


### PR DESCRIPTION
When this was introduced I can't remember why it was needed and the git history doesn't help explain it much. Either way, now if you don't pass a version `cosa build` will automatically do the dev version thing so we won't have any risk of collisions especially since we delete the lockfiles prior to calling `cosa build`.