### PR TITLE
jobs/kola-gcp: Update gcp zone to us-central1-a

### DIFF
--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -33,7 +33,7 @@ properties([
              trim: true),
       string(name: 'GCP_ZONE',
              description: 'The GCP zone to be used',
-             defaultValue: 'us-central1-b',
+             defaultValue: 'us-central1-a',
              trim: true),
     ]),
     buildDiscarder(logRotator(


### PR DESCRIPTION
The kola-gcp test seems to fail with gcp zone us-central1-b due to insufficient resources. Changing the zone to us-central1-a seems to address this issue.