### PR TITLE
utils: add retry(3) to push_manifest for transient registry failures

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -894,10 +894,18 @@ def push_manifest(digests, repo, manifest_tag, v2s2) {
     // locally because podman wants user namespacing (yes, even just
     // to push a manifest...)
     pipeutils.withPodmanRemoteArchBuilder(arch: "s390x") {
-        shwrap("""
-        cosa push-container-manifest \
-            --tag ${manifest_tag} --repo ${repo} ${images} ${push_args.join(' ')}
-        """)
+        // Retry to handle transient registry failures (e.g., HTTP 500/503)
+        retry(3) {
+            try {
+                shwrap("""
+                cosa push-container-manifest \
+                    --tag ${manifest_tag} --repo ${repo} ${images} ${push_args.join(' ')}
+                """)
+            } catch (e) {
+                sleep 10
+                throw e
+            }
+        }
     }
     digest = readFile(digest_file)
     shwrap("rm ${digest_file}")


### PR DESCRIPTION
The cosa push-container-manifest command (which calls podman manifest add/push) has no built-in retry mechanism. Transient registry failures (HTTP 500/503) during manifest list creation cause build failures that succeed on manual retry.

Add Jenkins retry(3) block around the push operation to automatically recover from transient registry.ci.openshift.org failures. Addresses failures like COS-4156, COS-4113, COS-4112 where podman manifest add failed due to transient registry errors.


Assisted-by: OpenCode (GLM-5)