### PR TITLE
jobs: adjust pipeline to build artifacts befora running kola tests

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -41,6 +41,7 @@ registry_repos:
 
 default_artifacts:
   all:
+    - qemu
     - metal
     - metal4k
     - live

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -14,6 +14,7 @@ source_config:
 default_artifacts:
   # default artifacts on all arches
   all:
+    - qemu
     - metal
     - metal4k
     - live

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -313,6 +313,11 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             shwrap("cosa buildextend-qemu")
         }
 
+        // Build the remaining artifacts
+        stage("Build Artifacts") {
+            pipeutils.build_artifacts(pipecfg, params.STREAM, basearch, skip_untested_artifacts)
+        }
+
         // This is a temporary hack to help debug https://github.com/coreos/fedora-coreos-tracker/issues/1108.
         if (params.KOLA_RUN_SLEEP) {
             echo "Hit KOLA_RUN_SLEEP; going to sleep..."
@@ -328,11 +333,6 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
                  allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
                  skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack,
                  skipKolaTags: stream_info.skip_kola_tags)
-        }
-
-        // Build the remaining artifacts
-        stage("Build Artifacts") {
-            pipeutils.build_artifacts(pipecfg, params.STREAM, basearch, skip_untested_artifacts)
         }
 
         // secex specific tests. 

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -347,8 +347,10 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             }
         }
 
-        // Run Kola TestISO tests for metal artifacts
-        if (shwrapCapture("cosa meta --get-value images.live-iso") != "None") {
+        // Run kola testiso tests if supported (legacy). On older releases testiso
+        // tests were run separately from other kola tests. If we are on one of those
+        // releases run testiso tests now.
+        if (pipeutils.kola_has_testiso() && shwrapCapture("cosa meta --get-value images.live-iso") != "None") {
             stage("Kola:TestISO") {
                 kolaTestIso(cosaDir: env.WORKSPACE, arch: basearch,
                             skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack)

--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -308,12 +308,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
             """)
         }
 
-        // Build QEMU image
-        stage("Build QEMU") {
-            shwrap("cosa buildextend-qemu")
-        }
-
-        // Build the remaining artifacts
+        // Build artifacts (including QEMU)
         stage("Build Artifacts") {
             pipeutils.build_artifacts(pipecfg, params.STREAM, basearch, skip_untested_artifacts)
         }

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -387,6 +387,24 @@ lock(resource: "build-${params.STREAM}") {
             shwrap("cosa buildextend-qemu")
         }
 
+        // Build the remaining artifacts
+        stage("Build Artifacts") {
+            pipeutils.build_artifacts(pipecfg, params.STREAM, basearch, skip_untested_artifacts)
+
+            // Stop the build if the kernel + kernel-rt versions do not match.
+            // This check runs on x86_64 RHCOS builds only.
+            // NOTE: This approach only checks the legacy extensions and not the new extensions
+            // container. This check can be removed for 9.3+ builds when we drop the legacy
+            // oscontainer as the versions will be matched using `match-base-evr` in `extensions.yaml`.
+            if (stream_info.check_kernel_rt_mismatch_rhcos) {
+                echo("Verifying kernel + kernel-rt versions match")
+                def build_meta = [readJSON(file: "builds/latest/${basearch}/commitmeta.json"), readJSON(file: "builds/latest/${basearch}/meta.json")]
+                def kernel_version = build_meta[0]['ostree.linux'].split('.el')[0]
+                def kernel_rt_version = build_meta[1]['extensions']['manifest']['kernel-rt-core'].split('.rt')[0]
+                assert kernel_version == kernel_rt_version : "kernel-rt version: ${kernel_rt_version} does not match kernel version: ${kernel_version}"
+            }
+        }
+
         // This is a temporary hack to help debug https://github.com/coreos/fedora-coreos-tracker/issues/1108.
         if (params.KOLA_RUN_SLEEP) {
             echo "Hit KOLA_RUN_SLEEP; going to sleep..."
@@ -408,24 +426,6 @@ lock(resource: "build-${params.STREAM}") {
         if (params.EARLY_ARCH_JOBS && uploading) {
             archive_ostree(newBuildID, basearch, s3_stream_dir)
             run_multiarch_jobs(additional_arches, src_config_commit, newBuildID, import_oci_image, cosa_img, false)
-        }
-
-        // Build the remaining artifacts
-        stage("Build Artifacts") {
-            pipeutils.build_artifacts(pipecfg, params.STREAM, basearch, skip_untested_artifacts)
-
-            // Stop the build if the kernel + kernel-rt versions do not match.
-            // This check runs on x86_64 RHCOS builds only.
-            // NOTE: This approach only checks the legacy extensions and not the new extensions
-            // container. This check can be removed for 9.3+ builds when we drop the legacy
-            // oscontainer as the versions will be matched using `match-base-evr` in `extensions.yaml`.
-            if (stream_info.check_kernel_rt_mismatch_rhcos) {
-                echo("Verifying kernel + kernel-rt versions match")
-                def build_meta = [readJSON(file: "builds/latest/${basearch}/commitmeta.json"), readJSON(file: "builds/latest/${basearch}/meta.json")]
-                def kernel_version = build_meta[0]['ostree.linux'].split('.el')[0]
-                def kernel_rt_version = build_meta[1]['extensions']['manifest']['kernel-rt-core'].split('.rt')[0]
-                assert kernel_version == kernel_rt_version : "kernel-rt version: ${kernel_rt_version} does not match kernel version: ${kernel_version}"
-            }
         }
 
         // Run Kola TestISO tests for metal artifacts

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -428,8 +428,10 @@ lock(resource: "build-${params.STREAM}") {
             run_multiarch_jobs(additional_arches, src_config_commit, newBuildID, import_oci_image, cosa_img, false)
         }
 
-        // Run Kola TestISO tests for metal artifacts
-        if (shwrapCapture("cosa meta --get-value images.live-iso") != "None") {
+        // Run kola testiso tests if supported (legacy). On older releases testiso
+        // tests were run separately from other kola tests. If we are on one of those
+        // releases run testiso tests now.
+        if (pipeutils.kola_has_testiso() && shwrapCapture("cosa meta --get-value images.live-iso") != "None") {
             if (pipecfg.hacks?.skip_uefi_tests_on_older_rhcos &&
                 (params.STREAM in ['4.6', '4.7', '4.8', '4.9'])) {
                 // UEFI tests on x86_64 seem to fail on older RHCOS. skip UEFI tests here.

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -382,12 +382,7 @@ lock(resource: "build-${params.STREAM}") {
             """)
         }
 
-        // Build QEMU image
-        stage("Build QEMU") {
-            shwrap("cosa buildextend-qemu")
-        }
-
-        // Build the remaining artifacts
+        // Build artifacts (including QEMU)
         stage("Build Artifacts") {
             pipeutils.build_artifacts(pipecfg, params.STREAM, basearch, skip_untested_artifacts)
 

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -263,8 +263,13 @@ lock(resource: "bump-lockfile") {
                             // OOMkilled.
                             shwrap("cosa shell -- env XZ_DEFAULTS=--memlimit=4G cosa compress --artifact=metal")
                         }
-                        stage("${arch}:kola:testiso") {
-                            kolaTestIso(cosaDir: env.WORKSPACE, arch: arch, marker: arch)
+                        // Run kola testiso tests if supported (legacy). On older releases testiso
+                        // tests were run separately from other kola tests. If we are on one of those
+                        // releases run testiso tests now.
+                        if (pipeutils.kola_has_testiso()) {
+                            stage("${arch}:kola:testiso") {
+                                kolaTestIso(cosaDir: env.WORKSPACE, arch: arch, marker: arch)
+                            }
                         }
                     }
                     if (arch == "x86_64") {

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -252,10 +252,6 @@ lock(resource: "bump-lockfile") {
                         stage("${arch}:OSBuild") {
                             shwrap("cosa osbuild qemu metal metal4k live")
                         }
-                        def n = ncpus - 1 // remove 1 for upgrade test
-                        kola(cosaDir: env.WORKSPACE, parallel: n, arch: arch,
-                             marker: arch, allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
-                             skipKolaTags: stream_info.skip_kola_tags)
                         stage("${arch}:Compress Metal") {
                             // Test metal4k with an uncompressed image and
                             // metal with a compressed one. Limit to 4G to be
@@ -263,6 +259,10 @@ lock(resource: "bump-lockfile") {
                             // OOMkilled.
                             shwrap("cosa shell -- env XZ_DEFAULTS=--memlimit=4G cosa compress --artifact=metal")
                         }
+                        def n = ncpus - 1 // remove 1 for upgrade test
+                        kola(cosaDir: env.WORKSPACE, parallel: n, arch: arch,
+                             marker: arch, allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
+                             skipKolaTags: stream_info.skip_kola_tags)
                         // Run kola testiso tests if supported (legacy). On older releases testiso
                         // tests were run separately from other kola tests. If we are on one of those
                         // releases run testiso tests now.

--- a/utils.groovy
+++ b/utils.groovy
@@ -1049,4 +1049,9 @@ def should_we_skip_untested_artifacts(pipecfg) {
     }
 }
 
+// Check if kola has testiso command available
+def kola_has_testiso() {
+    return shwrapRc("cosa kola help | grep -q testiso") == 0
+}
+
 return this

--- a/utils.groovy
+++ b/utils.groovy
@@ -446,9 +446,8 @@ def get_artifacts_to_build(pipecfg, stream, basearch, skip_untested) {
         artifacts.removeAll(pipecfg.streams[stream].skip_artifacts?."${basearch}" ?: [])
     }
     if (skip_untested) {
-        // Only build the testable artifacts. Note that the QEMU artifact is
-        // usually built before this step so it's not listed here.
-        def testable_artifacts = ["metal", "metal4k", "live"]
+        // Only build the testable artifacts.
+        def testable_artifacts = ["qemu", "metal", "metal4k", "live"]
         for (artifact in artifacts) {
             if (cloud_testing_enabled_for_arch(pipecfg, artifact, basearch)) {
                 testable_artifacts += artifact
@@ -494,10 +493,19 @@ def build_artifacts(pipecfg, stream, basearch, skip_untested) {
             }
         }
         if (!osbuild_artifacts.isEmpty()) {
+            // Remove OSBuild artifacts from the list (including qemu if supported)
             artifacts.removeAll(osbuild_artifacts)
             stage('💽:OSBuild') {
                 shwrap("cosa osbuild ${osbuild_artifacts.join(' ')}")
             }
+        }
+    }
+
+    // Build qemu first if not already built by OSBuild (other artifacts depend on it)
+    if (artifacts.contains('qemu')) {
+        artifacts.remove('qemu')
+        stage('💽:qemu') {
+            shwrap("cosa buildextend-qemu")
         }
     }
 


### PR DESCRIPTION
We are going to drop the `testiso` command and consolidate all ISO tests under `kola run iso.* ....`
This PR prepares the pipeline for that change and remains backward compatible with current and older `cosa` releases.

Related:
- https://github.com/coreos/coreos-assembler/issues/3989
- https://github.com/coreos/coreos-assembler/pull/4377