### PR TITLE
bootimagebump: reorder slack notification 

### DIFF
--- a/jobs/bootimagebump.Jenkinsfile
+++ b/jobs/bootimagebump.Jenkinsfile
@@ -281,7 +281,7 @@ plume cosa2stream --target ${SECONDARY_METADATA_FILE}                 \\
             def streamLabel = isDualStream ? "${params.STREAM} + ${params.SECONDARY_STREAM}" : params.STREAM
             def message = "[bootimage-bump][${streamLabel}] #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:>"
             if (currentBuild.result == 'SUCCESS') {
-                message = ":sparkles: :rocket: ${message} <${pr_url}|:pr:>"
+                message = ":sparkles: :rocket: ${message}${pr_url ? ' <' + pr_url + '|:pr:>' : ''}"
             } else if (currentBuild.result == 'UNSTABLE') {
                 message = ":warning: ${message}"
             } else {

--- a/jobs/bootimagebump.Jenkinsfile
+++ b/jobs/bootimagebump.Jenkinsfile
@@ -279,9 +279,9 @@ plume cosa2stream --target ${SECONDARY_METADATA_FILE}                 \\
             throw e
         } finally {
             def streamLabel = isDualStream ? "${params.STREAM} + ${params.SECONDARY_STREAM}" : params.STREAM
-            def message = "[${streamLabel}][bootimage-bump] #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:>"
+            def message = "[bootimage-bump][${streamLabel}] #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:>"
             if (currentBuild.result == 'SUCCESS') {
-                message = ":sparkles: ${message} <${pr_url}|:pr:>"
+                message = ":sparkles: :rocket: ${message} <${pr_url}|:pr:>"
             } else if (currentBuild.result == 'UNSTABLE') {
                 message = ":warning: ${message}"
             } else {


### PR DESCRIPTION
Put [bootimage-bump] before [stream] in the Slack message and add `:rocket:` to the success notification for better visual consistency.