### PR TITLE
config: disable next-devel 2026-05

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,8 +8,8 @@ streams:
   testing-devel:
     type: development
     default: true
-  next-devel:         # do not touch; line managed by `next-devel/manage.py`
-    type: development # do not touch; line managed by `next-devel/manage.py`
+  # next-devel:         # do not touch; line managed by `next-devel/manage.py`
+    # type: development # do not touch; line managed by `next-devel/manage.py`
   rawhide:
     type: development
     # Stop building with Konflux, see https://github.com/coreos/fedora-coreos-tracker/issues/2105

--- a/next-devel/badge.json
+++ b/next-devel/badge.json
@@ -2,6 +2,6 @@
     "schemaVersion": 1,
     "style": "for-the-badge",
     "label": "next-devel",
-    "message": "open",
-    "color": "green"
+    "message": "closed",
+    "color": "lightgrey"
 }

--- a/next-devel/status.json
+++ b/next-devel/status.json
@@ -1,3 +1,3 @@
 {
-    "enabled": true
+    "enabled": false
 }


### PR DESCRIPTION
We've switched `testing-devel` to be based on Fedora 44 so we can disable `next-devel` now since there's no difference in `testing-devel` and `next-devel` now.