### PR TITLE
jobs: add --inst-insecure flag to kola tests

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -324,6 +324,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         stage("Kola") {
             def n = 4 // VMs are 2G each and arch builders have approx 32G
             kola(cosaDir: env.WORKSPACE, parallel: n, arch: basearch,
+                 extraArgs: "--inst-insecure",
                  skipUpgrade: pipecfg.hacks?.skip_upgrade_tests,
                  allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
                  skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack,

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -411,6 +411,7 @@ lock(resource: "build-${params.STREAM}") {
         stage("Kola") {
             def n = ncpus - 1 // remove 1 for upgrade test
             kola(cosaDir: env.WORKSPACE, parallel: n, arch: basearch,
+                 extraArgs: "--inst-insecure",
                  skipUpgrade: pipecfg.hacks?.skip_upgrade_tests,
                  allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
                  skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack,

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -261,6 +261,7 @@ lock(resource: "bump-lockfile") {
                         }
                         def n = ncpus - 1 // remove 1 for upgrade test
                         kola(cosaDir: env.WORKSPACE, parallel: n, arch: arch,
+                             extraArgs: "--inst-insecure",
                              marker: arch, allowUpgradeFail: params.ALLOW_KOLA_UPGRADE_FAILURE,
                              skipKolaTags: stream_info.skip_kola_tags)
                         // Run kola testiso tests if supported (legacy). On older releases testiso


### PR DESCRIPTION
Autodetection of dev builds fails on builds where 'dev' is not part of the filename scheme, like 'rhcos-9.8.20260506-0-live-iso.x86_64.iso'. This causes kola tests to fail when they should run in insecure mode.

The obsolete coreos-ci-lib/vars/kolaTestIso.groovy used the insecure flag by default, so this restores that behavior explicitly.