### PR TITLE
jobs/kola-gcp: Update gcp zone to europe-west4-a

### DIFF
--- a/jobs/kola-gcp.Jenkinsfile
+++ b/jobs/kola-gcp.Jenkinsfile
@@ -33,7 +33,7 @@ properties([
              trim: true),
       string(name: 'GCP_ZONE',
              description: 'The GCP zone to be used',
-             defaultValue: 'us-central1-a',
+             defaultValue: 'europe-west4-a',
              trim: true),
     ]),
     buildDiscarder(logRotator(


### PR DESCRIPTION
Too many issues with instance availability in us-central1-a. Let's move to a different region that has t2a-standard-1 instances.