### PR TITLE
kola: use isTestisoSupported() from coreos-ci-lib

### DIFF
--- a/jobs/build-arch.Jenkinsfile
+++ b/jobs/build-arch.Jenkinsfile
@@ -345,7 +345,7 @@ lock(resource: "build-${params.STREAM}-${basearch}") {
         // Run kola testiso tests if supported (legacy). On older releases testiso
         // tests were run separately from other kola tests. If we are on one of those
         // releases run testiso tests now.
-        if (pipeutils.kola_has_testiso() && shwrapCapture("cosa meta --get-value images.live-iso") != "None") {
+        if (shwrapCapture("cosa meta --get-value images.live-iso") != "None" && utils.isTestisoSupported()) {
             stage("Kola:TestISO") {
                 kolaTestIso(cosaDir: env.WORKSPACE, arch: basearch,
                             skipSecureBoot: pipecfg.hotfix?.skip_secureboot_tests_hack)

--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -426,7 +426,7 @@ lock(resource: "build-${params.STREAM}") {
         // Run kola testiso tests if supported (legacy). On older releases testiso
         // tests were run separately from other kola tests. If we are on one of those
         // releases run testiso tests now.
-        if (pipeutils.kola_has_testiso() && shwrapCapture("cosa meta --get-value images.live-iso") != "None") {
+        if (shwrapCapture("cosa meta --get-value images.live-iso") != "None" && utils.isTestisoSupported()) {
             if (pipecfg.hacks?.skip_uefi_tests_on_older_rhcos &&
                 (params.STREAM in ['4.6', '4.7', '4.8', '4.9'])) {
                 // UEFI tests on x86_64 seem to fail on older RHCOS. skip UEFI tests here.

--- a/jobs/bump-lockfile.Jenkinsfile
+++ b/jobs/bump-lockfile.Jenkinsfile
@@ -266,7 +266,7 @@ lock(resource: "bump-lockfile") {
                         // Run kola testiso tests if supported (legacy). On older releases testiso
                         // tests were run separately from other kola tests. If we are on one of those
                         // releases run testiso tests now.
-                        if (pipeutils.kola_has_testiso()) {
+                        if (utils.isTestisoSupported()) {
                             stage("${arch}:kola:testiso") {
                                 kolaTestIso(cosaDir: env.WORKSPACE, arch: arch, marker: arch)
                             }

--- a/utils.groovy
+++ b/utils.groovy
@@ -1057,9 +1057,4 @@ def should_we_skip_untested_artifacts(pipecfg) {
     }
 }
 
-// Check if kola has testiso command available
-def kola_has_testiso() {
-    return shwrapRc("cosa kola help | grep -q testiso") == 0
-}
-
 return this


### PR DESCRIPTION
Replace local kola_has_testiso() with isTestisoSupported() from coreos-ci-lib shared library for more reliable testiso detection.

Aligns with coreos-ci-lib commit [5e96d552bbf2974342b049597b8c02004d72bee5](https://github.com/coreos/coreos-ci-lib/commit/5e96d552bbf2974342b049597b8c02004d72bee5)