### PR TITLE
[staging] config: Add qemu to artifacts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -54,6 +54,7 @@ versionary_hack: true
 
 default_artifacts:
   all:
+    - qemu
     - metal
     - metal4k
     - live


### PR DESCRIPTION
The devlopment pipeline is faling all tests, as it cannot bring up the VM

```
[2026-05-14T11:24:46.804Z] qemu-img: /var/tmp/mantle-qemu1834214650/disk1123545163: Image creation needs a size parameter
[2026-05-14T11:24:46.804Z] qemu-img: /var/tmp/mantle-qemu2531995189/disk3263789937: Image creation needs a size parameter
[2026-05-14T11:24:46.804Z] 2026-05-14T11:24:46Z kola: retryloop: failed to bring up machines: exit status 1
[2026-05-14T11:24:46.804Z] qemu-img:qemu-img:  /var/tmp/mantle-qemu3940257098/disk1389840531: Image creation needs a size parameter/var/tmp/mantle-qemu1364006694/disk3376424700: Image creation needs a size parameter
```
Adding `qemu` to the `default_artifacts.all` lists may help with this.