### PR TITLE
kola-upgrade: add --debug so we can get more insight on failures

### DIFF
--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -195,7 +195,7 @@ EOF
                 arch: params.ARCH,
                 build: start_version,
                 cosaDir: env.WORKSPACE,
-                extraArgs: "--tag extended-upgrade --append-butane tmp/target_stream.bu",
+                extraArgs: "--debug --tag extended-upgrade --append-butane tmp/target_stream.bu",
                 skipBasicScenarios: true,
                 skipUpgrade: true,
                 skipKolaTags: pipecfg.streams[params.STREAM].skip_kola_tags,


### PR DESCRIPTION
We're noticing a lot of the upgrades time out. Let's add debug for now so we can get more information.