### PR TITLE
kola-upgrade: patch to not use CDN

### DIFF
--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -188,6 +188,35 @@ storage:
       contents:
         inline: |
           ${params.STREAM}
+    # XXX: delete this when https://github.com/coreos/fedora-coreos-config/pull/4181
+    # XXX: merges and is in `stable` stream.
+    # Switch to non CDN ostree repo. The pull through cache that the
+    # CDN (cloudfront) uses is probably now more harmful than it is
+    # useful because no one is using the OSTree repo for FCOS these days.
+    # We noticed painfully slow downloads in our upgrade tests and
+    # this should help.
+    - path: /etc/ostree/remotes.d/fedora.conf
+      # make writable by all so below zincati ExecStartPre copy over it
+      mode: 0666
+      overwrite: true
+      contents:
+        inline: |
+          [remote "fedora"]
+          url=https://kojipkgs.fedoraproject.org/ostree/repo/
+          gpg-verify=true
+          gpgkeypath=/etc/pki/rpm-gpg/
+    # The oci migration script had a check for the URL to make sure we only
+    # migrated the people who were using the defaults so we need to switch
+    # it back when the oci migraiton happens.
+    # https://github.com/coreos/fedora-coreos-config/blob/d4c815329d88dd9dbaf1902a2b60a08df4b41c1a/overlay.d/35oci-migration/usr/libexec/coreos-oci-rebase#L43
+    - path: /etc/systemd/system/zincati.service.d/005-fixup-remote-url.conf
+      mode: 0644
+      contents:
+        inline: |
+          [Service]
+          ExecStartPre=/bin/bash -c \
+            "test -f /usr/lib/systemd/system/zincati.service.d/010-oci-migration.conf && \
+                cp -v /usr/etc/ostree/remotes.d/fedora.conf /etc/ostree/remotes.d/fedora.conf || true"
 EOF
 """)
 


### PR DESCRIPTION
This is a hack to implement [1] sooner for upgrade tests until that PR lands in all streams.

[1] https://github.com/coreos/fedora-coreos-config/pull/4181