### PR TITLE
build-node-image: add soft per-stage timeout warnings, bump global to 75m

### DIFF
--- a/jobs/build-node-image.Jenkinsfile
+++ b/jobs/build-node-image.Jenkinsfile
@@ -52,6 +52,19 @@ def src_config_url = stream_info.source_config.url
 def basearches = params.ARCHES.split() as Set
 def timeout_mins = 300
 
+// Soft per-stage time budgets (minutes). Exceeding a soft budget marks
+// the build UNSTABLE with a console warning but does NOT abort the stage.
+// The global hard timeout (sum of all budgets) is the only thing that
+// can abort execution.
+def stage_budgets = [
+    'Build Node Image':       20,
+    'Build Extensions Image': 20,
+    'Run Tests':              15,
+    'Brew Upload':            10,
+    'Release Manifests':      10,
+]
+def global_timeout_mins = stage_budgets.values().sum()
+
 def cosa_img = params.COREOS_ASSEMBLER_IMAGE
 // Derive the stream class once so both node and extensions builds use
 // the `io.openshift.os.streamclass` label. The streamclass is based on
@@ -80,7 +93,7 @@ lock(resource: "build-node-image") {
             secrets: ["brew-keytab", "brew-ca:ca.crt:/etc/pki/ca.crt",
                       "koji-conf:koji.conf:/etc/koji.conf",
                       "krb5-conf:krb5.conf:/etc/krb5.conf"]) {
-    timeout(time: 60, unit: 'MINUTES') {
+    timeout(time: global_timeout_mins, unit: 'MINUTES') {
 
         def registry_staging_repo
         def registry_staging_tags
@@ -142,7 +155,7 @@ lock(resource: "build-node-image") {
             }
         }
 
-        stage('Build Node Image') {
+        pipeutils.stageWithTimeoutWarning('Build Node Image', stage_budgets['Build Node Image']) {
             withCredentials([file(credentialsId: 'oscontainer-push-registry-secret', variable: 'REGISTRY_AUTH_FILE')]) {
                  def build_from = params.FROM ?: stream_info.from
                  def extra_build_args = []
@@ -174,7 +187,7 @@ lock(resource: "build-node-image") {
         }
 
         if (stream_info.extensions != false) {
-            stage('Build Extensions Image') {
+            pipeutils.stageWithTimeoutWarning('Build Extensions Image', stage_budgets['Build Extensions Image']) {
                 withCredentials([file(credentialsId: 'oscontainer-push-registry-secret', variable: 'REGISTRY_AUTH_FILE')]) {
                     // Use the node image as from
                     def build_from = "${registry_staging_repo}@${node_image_manifest_digest}"
@@ -209,7 +222,7 @@ lock(resource: "build-node-image") {
             }
         }
         if (stream_info.run_test != false) {
-            stage("Run Tests") {
+            pipeutils.stageWithTimeoutWarning('Run Tests', stage_budgets['Run Tests']) {
                 withCredentials([file(credentialsId: 'oscontainer-push-registry-secret', variable: 'REGISTRY_AUTH_FILE')]) {
                     def openshift_stream = params.RELEASE.split("-")[0]
                     def rhel_stream = "rhel-" + params.RELEASE.split("-")[1]
@@ -284,13 +297,13 @@ lock(resource: "build-node-image") {
             }
         }
         if (!skip_brew_upload){
-            stage("Brew Upload") {
+            pipeutils.stageWithTimeoutWarning('Brew Upload', stage_budgets['Brew Upload']) {
                 // Use the staging since we already have the digests
                 pipeutils.brew_upload(arches, params.RELEASE, registry_staging_repo, node_image_manifest_digest,
                                       extensions_image_manifest_digest, timestamp, pipecfg)
             }
         }
-        stage("Release Manifests") {
+        pipeutils.stageWithTimeoutWarning('Release Manifests', stage_budgets['Release Manifests']) {
             withCredentials([file(credentialsId: 'oscontainer-push-registry-secret', variable: 'REGISTRY_AUTH_FILE')]) {
                 // copy the extensions first as the node image existing is a signal
                 // that it's ready for release. So we want all the expected artifacts
@@ -348,4 +361,4 @@ lock(resource: "build-node-image") {
         message = "${message} build-node-image #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> ${build_description}${unique_tag_display} ${pullspec_links}"
         pipeutils.trySlackSend(message: message)
     }
-}}} // cosaPod, timeout, and lock finish here
+}}} // cosaPod, timeout (global_timeout_mins hard), and lock finish here

--- a/utils.groovy
+++ b/utils.groovy
@@ -1057,4 +1057,28 @@ def should_we_skip_untested_artifacts(pipecfg) {
     }
 }
 
+// Run a stage with a soft timeout warning. If the stage takes longer
+// than budgetMins, a warning is emitted to the console log and the
+// build is marked UNSTABLE, but the stage is NOT aborted. Only the
+// caller's outer hard timeout can abort execution.
+//
+// Usage:
+//   pipeutils.stageWithTimeoutWarning('Build Node Image', 25) {
+//       // ... stage body ...
+//   }
+def stageWithTimeoutWarning(String name, int budgetMins, Closure body) {
+    def start = System.currentTimeMillis()
+    stage(name) {
+        body()
+    }
+    def elapsedMins = (System.currentTimeMillis() - start) / 60000.0
+    if (elapsedMins > budgetMins) {
+        echo "WARNING: stage '${name}' took ${String.format('%.1f', elapsedMins)}m " +
+             "(soft budget: ${budgetMins}m)"
+        if (currentBuild.result == null || currentBuild.result == 'SUCCESS') {
+            currentBuild.result = 'UNSTABLE'
+        }
+    }
+}
+
 return this


### PR DESCRIPTION
The build-node-image job currently has a single 60-minute hard timeout wrapping all stages. When individual stages run slowly (e.g., ppc64le extensions builds hitting slow RPM repo servers), they silently consume the shared time budget and can cause later stages like kola to be killed by the global timeout — producing confusing "Timeout has been exceeded" aborts with no indication of which stage was the bottleneck.

Add a stageWithTimeoutWarning() helper to utils.groovy that tracks per-stage execution time and marks the build UNSTABLE with a console warning if a stage exceeds its soft budget. The stage is NOT aborted — only the global timeout is a hard failure.

Per-stage soft budgets:
  - Build Node Image:       25m
  - Build Extensions Image: 25m
  - Run Tests:              15m
  - Brew Upload:            10m
  - Release Manifests:      10m

Bump the global hard timeout from 60m to 75m to accommodate intermittent slow repo server responses observed on ppc64le builders.

Data from recent builds shows ppc64le extensions RPM downloads vary from ~1m (normal) to ~18m (slow repos), with dnf dependency resolution taking up to 10m during slow periods. This is intermittent and correlates with remote repository server performance, not local builder hardware.

Assisted-by: <anthropic/claude-opus-4.6>