### PR TITLE
jobs/check-aws-regions: run `ore aws ensure-public` daily and add `clouds.aws.skipped_regions`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -93,6 +93,10 @@ clouds:
     # Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1605
     tags:
       - "FedoraGroup=coreos"
+    # These regions are experiencing outages in AWS
+    skipped_regions:
+      - me-central-1
+      - me-south-1
   azure:
     test_resource_group: fedora-coreos-testing
     test_storage_account: fedoracoreostesting

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -231,6 +231,11 @@ clouds:
     # releases. When enabled, the check-aws-regions job runs `ore aws ensure-public`
     # for each enabled region on its daily schedule. Defaults to false.
     ensure_public: true
+    # OPTIONAL: list of regions to skip in various stages in the pipeline.
+    # This is useful when AWS regions experience outages.
+    skipped_regions:
+      - me-central-1
+      - me-south-1
   aliyun:
     # REQUIRED (if Aliyun build upload credentials provided): the region to do
     # initial image creation in.

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -223,6 +223,14 @@ clouds:
     # OPTIONAL: billing code to create a Windows License Included Image
     # required if using 'create_and_replicate_winli_ami' under the stream mappings
     winli_billing_code: "bp-12345abcde"
+    # OPTIONAL: boolean: whether to periodically check all production AMIs across
+    # all enabled regions and restore their public launch permission if AWS has
+    # silently revoked it due to AMI deprecation age. AWS automatically deprecates
+    # public AMIs after 2 years and removes public sharing after a further period
+    # of inactivity, which causes node scale-up failures for customers on older
+    # releases. When enabled, the check-aws-regions job runs `ore aws ensure-public`
+    # for each enabled region on its daily schedule. Defaults to false.
+    ensure_public: true
   aliyun:
     # REQUIRED (if Aliyun build upload credentials provided): the region to do
     # initial image creation in.

--- a/jobs/check-aws-regions.Jenkinsfile
+++ b/jobs/check-aws-regions.Jenkinsfile
@@ -6,6 +6,7 @@ node {
     checkout scm
     // these are script global vars
     pipeutils = load("utils.groovy")
+    pipecfg = pipeutils.load_pipecfg()
 }
 
 properties([
@@ -21,14 +22,49 @@ properties([
 ])
 
 cosaPod(serviceAccount: "jenkins"){
-    def disabled_regions = ""
     withCredentials([file(variable: 'AWS_CONFIG_FILE',
                            credentialsId: 'aws-build-upload-config')]) {
-        disabled_regions = shwrapCapture("ore aws list-regions --disabled")
+
+        def slack_message = ""
+        def job_ref = ":aws: check-aws-regions #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:>"
+
+        stage("Check Disabled Regions") {
+            // Check for disabled regions
+            def disabled_regions = shwrapCapture("ore aws list-regions --disabled")
+            if (disabled_regions != "") {
+                warn("Disabled AWS regions detected: ${disabled_regions}")
+                slack_message += "${job_ref} detected disabled regions: ${disabled_regions}\n :pencil: To enable region -> <https://github.com/coreos/fedora-coreos-pipeline/blob/main/docs/aws-region-enable.md|AWS Region Enablement>"
+            }
+        }
+
+        // Restore public launch permission on any production AMIs that AWS has
+        // silently made private due to deprecation age. Only runs when
+        // clouds.aws.ensure_public is set to true in config.yaml (e.g. RHCOS).
+        if (pipecfg.clouds?.aws?.ensure_public) {
+            stage("Restore Public Permissions") {
+                def failed_regions = []
+                def all_regions = shwrapCapture("ore aws list-regions").split('\n').collect { it.trim() }.findAll { it }
+                def all_regions = shwrapCapture("ore aws list-regions").tokenize()
+                for (region in all_regions) {
+                    def rc = sh(script: "ore aws --region ${region} ensure-public", returnStatus: true)
+                    def rc = sh(script: "ore aws --region '${region}' ensure-public", returnStatus: true)
+                    if (rc != 0) {
+                        failed_regions += region
+                    }
+                }
+                if (failed_regions) {
+                    def failed_str = failed_regions.join(', ')
+                    warn("Failed to restore public AMIs in regions: ${failed_str}")
+                    if (slack_message != "") {
+                        slack_message += "\n"
+                    }
+                    slack_message += "${job_ref} failed to restore public AMIs in regions: ${failed_str}"
+                }
+            }
+        }
+
+        if (slack_message != "") {
+            pipeutils.trySlackSend(message: slack_message)
+        }
     }
-    if (disabled_regions != "") {
-        warn("Disabled AWS regions detected: ${disabled_regions}")
-        pipeutils.trySlackSend(message: ":aws: check-aws-regions #${env.BUILD_NUMBER} <${env.BUILD_URL}|:jenkins:> <${env.RUN_DISPLAY_URL}|:ocean:> detected disabled regions: ${disabled_regions}\n :pencil: To enable region -> <https://github.com/coreos/fedora-coreos-pipeline/blob/main/docs/aws-region-enable.md|AWS Region Enablement>")
-        return
-    }    
 }

--- a/jobs/check-aws-regions.Jenkinsfile
+++ b/jobs/check-aws-regions.Jenkinsfile
@@ -43,10 +43,12 @@ cosaPod(serviceAccount: "jenkins"){
         if (pipecfg.clouds?.aws?.ensure_public) {
             stage("Restore Public Permissions") {
                 def failed_regions = []
-                def all_regions = shwrapCapture("ore aws list-regions").split('\n').collect { it.trim() }.findAll { it }
+                def skipped_regions = pipecfg.clouds?.aws?.skipped_regions ?: []
                 def all_regions = shwrapCapture("ore aws list-regions").tokenize()
                 for (region in all_regions) {
-                    def rc = sh(script: "ore aws --region ${region} ensure-public", returnStatus: true)
+                    if (region in skipped_regions) {
+                        continue
+                    }
                     def rc = sh(script: "ore aws --region '${region}' ensure-public", returnStatus: true)
                     if (rc != 0) {
                         failed_regions += region

--- a/libcloud.groovy
+++ b/libcloud.groovy
@@ -43,7 +43,6 @@ def replicate_to_clouds(pipecfg, basearch, buildID, stream) {
                 extraArgs += "--winli"
             }
             if (c.primary_region == "us-east-1") {
-                // Exclude "me-central-1" and "me-south-1" due to AWS outages
                 def aws_regions = [
                     "af-south-1",
                     "ap-east-1",
@@ -71,6 +70,8 @@ def replicate_to_clouds(pipecfg, basearch, buildID, stream) {
                     "eu-west-2",
                     "eu-west-3",
                     "il-central-1",
+                    "me-central-1",
+                    "me-south-1",
                     "mx-central-1",
                     "sa-east-1",
                     "us-east-1",
@@ -78,7 +79,7 @@ def replicate_to_clouds(pipecfg, basearch, buildID, stream) {
                     "us-west-1",
                     "us-west-2"
                 ]
-                def aws_regions_arg = aws_regions.join(" ")
+                def aws_regions_arg = (aws_regions - (c.skipped_regions ?: [])).join(" ")
                 extraArgs += "--regions ${aws_regions_arg}"
             }
             shwrap("""


### PR DESCRIPTION
AWS automatically deprecates public AMIs after 2 years and silently removes their public launch permission after a further period of inactivity. This causes node scale-up failures for customers on older releases who still rely on those AMIs.

Add a new "Restore Public Permissions" stage that iterates all enabled regions and runs `ore aws ensure-public` `[1]` in each one. All regions are attempted regardless of individual failures; any that could not be restored are collected and reported via the existing Slack notification path at the end of the job.

The stage is gated on a new `clouds.aws.ensure_public` config knob so it only runs for pipelines that opt in (e.g. RHCOS) and is a no-op for FCOS.

`[1]`: https://github.com/coreos/coreos-assembler/pull/4562 (required before this merges)

Assisted-by: Claude <Sonnet 4.6>