### PR TITLE
kola-upgrade: don't run uefi and uefi-secure tests

### DIFF
--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -72,8 +72,8 @@ currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${start_version
 def cosa_memory_request_mb = 1024
 if (params.ARCH == 'x86_64') {
     // local (qemu+x86_64) testing will require more memory
-    // bios=1024, uefi=1024, uefi-secure=1536, overhead=512
-    cosa_memory_request_mb = 1024 + 1024 + 1536 + 512
+    // bios=1024, uefi-secure=1536, overhead=512
+    cosa_memory_request_mb = 1024 + 1536 + 512
 }
 
 
@@ -229,35 +229,37 @@ EOF
                 skipUpgrade: true,
                 skipKolaTags: pipecfg.streams[params.STREAM].skip_kola_tags,
             ]
-            def k1, k2, k3
+            def k1, k2
 
             switch(params.ARCH) {
                 case 'x86_64':
-                    k1 = kolaparams.clone()
-                    k1.extraArgs += " --qemu-firmware=uefi"
-                    k1.marker = "uefi"
-                    parallelruns['Kola:UEFI'] = { kola(k1) }
                     // SecureBoot doesn't work on older FCOS builds with latest qemu
                     // so we must run it conditionally.
                     // https://github.com/coreos/fedora-coreos-tracker/issues/1452
                     // https://github.com/coreos/fedora-coreos-tracker/issues/1452#issuecomment-2835130860
                     def secureboot_start_version = 37
                     if ((start_version[0..1] as Integer) >= secureboot_start_version) {
-                        k2 = kolaparams.clone()
-                        k2.extraArgs += " --qemu-firmware=uefi-secure"
+                        // uefi-secure also tests uefi so no need for a separate uefi run
+                        k1 = kolaparams.clone()
+                        k1.extraArgs += " --qemu-firmware=uefi-secure"
                         if ((start_version[0..1] as Integer) <= 37) {
                             // workaround a bug where grub would fail to allocate memory
                             // when start_version is <= 37.20230110.2.0
                             // https://github.com/coreos/fedora-coreos-tracker/issues/1456
-                            k2.extraArgs += " --qemu-memory=1536"
+                            k1.extraArgs += " --qemu-memory=1536"
                         }
-                        k2.marker = "uefi-secure"
-                        parallelruns['Kola:UEFI-SECURE'] = { kola(k2) }
+                        k1.marker = "uefi-secure"
+                        parallelruns['Kola:UEFI-SECURE'] = { kola(k1) }
+                    } else {
+                        k1 = kolaparams.clone()
+                        k1.extraArgs += " --qemu-firmware=uefi"
+                        k1.marker = "uefi"
+                        parallelruns['Kola:UEFI'] = { kola(k1) }
                     }
-                    k3 = kolaparams.clone()
-                    k3.extraArgs += " --qemu-firmware=bios"
-                    k3.marker = "bios"
-                    parallelruns['Kola:BIOS'] = { kola(k3) }
+                    k2 = kolaparams.clone()
+                    k2.extraArgs += " --qemu-firmware=bios"
+                    k2.marker = "bios"
+                    parallelruns['Kola:BIOS'] = { kola(k2) }
                     break;
                 case 'aarch64':
                     k1 = kolaparams.clone()


### PR DESCRIPTION
uefi-secure tests uefi as well so no need really to run both tests on x86_64 for starting points that support it.

Let's drop running them both and just do one or the other based on the starting version.

Assisted-by: <anthropic/claude-opus-4.6>