### PR TITLE
build: only pass hotfix params to downstream jobs when supported

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -587,9 +587,10 @@ def run_multiarch_jobs(arches, src_commit, version, src_oci, cosa_img, wait) {
                 string(name: 'STREAM', value: params.STREAM),
                 string(name: 'VERSION', value: version),
                 string(name: 'ARCH', value: arch),
+            ] + ((params.PIPECFG_HOTFIX_REPO) ? [
                 string(name: 'PIPECFG_HOTFIX_REPO', value: params.PIPECFG_HOTFIX_REPO),
                 string(name: 'PIPECFG_HOTFIX_REF', value: params.PIPECFG_HOTFIX_REF)
-            ]
+            ] : [])
         }]}
     }
 }
@@ -606,9 +607,10 @@ def run_release_job(buildID) {
             string(name: 'VERSION', value: buildID),
             booleanParam(name: 'ALLOW_MISSING_ARCHES', value: allow_missing),
             booleanParam(name: 'CLOUD_REPLICATION', value: params.CLOUD_REPLICATION),
+        ] + ((params.PIPECFG_HOTFIX_REPO) ? [
             string(name: 'PIPECFG_HOTFIX_REPO', value: params.PIPECFG_HOTFIX_REPO),
             string(name: 'PIPECFG_HOTFIX_REF', value: params.PIPECFG_HOTFIX_REF)
-        ]
+        ] : [])
     }
 }
 


### PR DESCRIPTION
Today the `aarch64` and `s390x` build-arch jobs for rawhide failed around the same time with:

> 11:21:41  Error: Get "http://d/v5.8.2/libpod/exec/5c17e71b98a49b25dcdcf159c71301b346e4673e24210a5dafdab4772813ad21/json": read tcp 10.130.2.221:48280->****:22: read: connection timed out
>
> 11:21:54  Error: Get "http://d/v5.8.2/libpod/exec/a9d17c3c34ca6c564ab9c930cb32b4d49cdfec7cd3221ca364248fb5f31930ef/json": read tcp 10.130.2.222:51298->****:22: read: connection timed out


The `ppc64le` job did pass, but it has a gap in the `kola` step where it finishes one section at `10:59:44` and starts the next one at `12:10:40`.

Looking at [these logs](https://github.com/user-attachments/files/28798811/jenkins_log.gz) I see this error being spammed until `11:36:03`:

> 2026-06-06 11:01:58 WARNING hudson.model.ParametersAction filter Skipped parameter `PIPECFG_HOTFIX_REPO` as it is undefined on `build-arch` (#1,876). Set `-Dhudson.model.ParametersAction.keepUndefinedParameters=true` to allow undefined parameters to be injected as environment variables or `-Dhudson.model.ParametersAction.safeParameters=[comma-separated list]` to whitelist specific parameter names, even though it represents a security breach or `-Dhudson.model.ParametersAction.keepUndefinedParameters=false` to no longer show this message.

I'm not entirely sure it's the cause of the failures, but we may as well try to avoid that warning if possible.