### PR TITLE
jenkins/plugins: add the cloudbees-disk-usage-simple plugin

### DIFF
--- a/jenkins/controller/plugins.txt
+++ b/jenkins/controller/plugins.txt
@@ -35,6 +35,7 @@ jms-messaging:1.1.28
 pipeline-graph-view:803.vb_88f7a_a_1cb_47
 theme-manager:346.v06cca_64c6a_37
 dark-theme:652.vea_da_dfea_e769
+cloudbees-disk-usage-simple:270.vfb_6898193d8d
 
 # The below list are plugins that are also in base-plugins.txt but for
 # some reason or other we need to temporarily freeze or fast-track.


### PR DESCRIPTION
This plugin is a dependency of the Prometheus plugin from the base OpenShift Jenkins image, since it has collectDiskUsage enabled by default. Without this plugin, we're getting a warning in the logs roughly every 2 minutes:

> Cannot collect disk usage data because plugin CloudBees Disk Usage
> Simple is not installed: java.lang.NoClassDefFoundError:
> com/cloudbees/simplediskusage/QuickDiskUsagePlugin

Let's install the plugin so disk usage metrics are actually collected, and to avoid the added noise in the logs.

---

Alternatively, we could disable `collectDiskUsage`, which means this plugin is no longer required. I guess that would be fine since if we haven't had this plugin, the metriscs haven't been collected before and probably aren't important to us then?

For reference, the logs I found these warnings in: [jenkins_log.gz](https://github.com/user-attachments/files/28834643/jenkins_log.gz)
