### PR TITLE
jobs/kola-upgrade: conditionally download related OSTree tarball

### DIFF
--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -177,6 +177,18 @@ lock(resource: "kola-upgrade-${params.ARCH}") {
                 """)
             }
 
+            // Prior to F42 we used the OSTree repo for upgrades. Pull
+            // down the tarball with all the OSTree repo content in it.
+            if ((start_major_version as Integer) < 42) {
+                stage('OSTreeArchiveFetch') {
+                    shwrap("""
+                    cosa shell -- \
+                        curl -o src/config/tests/kola/upgrade/extended/data/ostree-repo.tar \
+                        https://fcos-upgrade-test-fixtures.s3.us-east-1.amazonaws.com/ostree-repo-${params.STREAM}-${params.ARCH}-starting-f${start_major_version}.tar
+                    """)
+                }
+            }
+
             // A few independent tasks that can be run in parallel
             def parallelruns = [:]
 
@@ -191,35 +203,6 @@ storage:
       contents:
         inline: |
           ${params.STREAM}
-    # XXX: delete this when https://github.com/coreos/fedora-coreos-config/pull/4181
-    # XXX: merges and is in `stable` stream.
-    # Switch to non CDN ostree repo. The pull through cache that the
-    # CDN (cloudfront) uses is probably now more harmful than it is
-    # useful because no one is using the OSTree repo for FCOS these days.
-    # We noticed painfully slow downloads in our upgrade tests and
-    # this should help.
-    - path: /etc/ostree/remotes.d/fedora.conf
-      # make writable by all so below zincati ExecStartPre copy over it
-      mode: 0666
-      overwrite: true
-      contents:
-        inline: |
-          [remote "fedora"]
-          url=https://kojipkgs.fedoraproject.org/ostree/repo/
-          gpg-verify=true
-          gpgkeypath=/etc/pki/rpm-gpg/
-    # The oci migration script had a check for the URL to make sure we only
-    # migrated the people who were using the defaults so we need to switch
-    # it back when the oci migraiton happens.
-    # https://github.com/coreos/fedora-coreos-config/blob/d4c815329d88dd9dbaf1902a2b60a08df4b41c1a/overlay.d/35oci-migration/usr/libexec/coreos-oci-rebase#L43
-    - path: /etc/systemd/system/zincati.service.d/005-fixup-remote-url.conf
-      mode: 0644
-      contents:
-        inline: |
-          [Service]
-          ExecStartPre=/bin/bash -c \
-            "test -f /usr/lib/systemd/system/zincati.service.d/010-oci-migration.conf && \
-                cp -v /usr/etc/ostree/remotes.d/fedora.conf /etc/ostree/remotes.d/fedora.conf || true"
 EOF
 """)
 

--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -145,6 +145,9 @@ lock(resource: "kola-upgrade-${params.ARCH}") {
         echo "Selected ${start_version} as the starting version to test"
         currentBuild.description = "[${params.STREAM}][${params.ARCH}] - ${start_version}->${target_version}"
 
+        // Get the starting major version. Used for some comparisons below.
+        def start_major_version = start_version[0..1]
+
         def remoteSession = ""
         if (params.ARCH != 'x86_64') {
             // If we're on mArch and using QEMU then initialize the
@@ -238,11 +241,11 @@ EOF
                     // https://github.com/coreos/fedora-coreos-tracker/issues/1452
                     // https://github.com/coreos/fedora-coreos-tracker/issues/1452#issuecomment-2835130860
                     def secureboot_start_version = 37
-                    if ((start_version[0..1] as Integer) >= secureboot_start_version) {
+                    if ((start_major_version as Integer) >= secureboot_start_version) {
                         // uefi-secure also tests uefi so no need for a separate uefi run
                         k1 = kolaparams.clone()
                         k1.extraArgs += " --qemu-firmware=uefi-secure"
-                        if ((start_version[0..1] as Integer) <= 37) {
+                        if ((start_major_version as Integer) <= 37) {
                             // workaround a bug where grub would fail to allocate memory
                             // when start_version is <= 37.20230110.2.0
                             // https://github.com/coreos/fedora-coreos-tracker/issues/1456


### PR DESCRIPTION
The OSTree repo in Fedora can be slow and might go away one day.
Since we know exactly the path updates are going to take let's
just download pre-built tarballs with an OSTree repo inside
that has exactly the contents that this upgrade will need.

These tarballs were created by a script [1].

[1] https://github.com/coreos/fedora-coreos-releng-automation/pull/231