### PR TITLE
jobs/kola-upgrade: pull tar from start_stream; retry failures

### DIFF
--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -183,8 +183,8 @@ lock(resource: "kola-upgrade-${params.ARCH}") {
                 stage('OSTreeArchiveFetch') {
                     shwrap("""
                     cosa shell -- \
-                        curl -o src/config/tests/kola/upgrade/extended/data/ostree-repo.tar \
-                        https://fcos-upgrade-test-fixtures.s3.us-east-1.amazonaws.com/ostree-repo-${params.STREAM}-${params.ARCH}-starting-f${start_major_version}.tar
+                        curl --retry 3 --fail -o src/config/tests/kola/upgrade/extended/data/ostree-repo.tar \
+                        https://fcos-upgrade-test-fixtures.s3.us-east-1.amazonaws.com/ostree-repo-${start_stream}-${params.ARCH}-starting-f${start_major_version}.tar
                     """)
                 }
             }


### PR DESCRIPTION
We need to pull the tarball from the start_stream (since that's how the files are named).

Also, let's retry failures in case flakes happen.