### PR TITLE
 utils: adjust fcos upgrade tests to limit to 10 releases

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -673,7 +673,7 @@ def run_fcos_upgrade_tests(pipecfg, stream, version, cosa, basearch, commit) {
     def stream_info = pipecfg.streams[stream]
 
     def min_supported_start_versions = [
-        aarch64: 34,
+        aarch64: 35,
         ppc64le: 38,
         s390x:   36,
         x86_64:  32,

--- a/utils.groovy
+++ b/utils.groovy
@@ -687,6 +687,14 @@ def run_fcos_upgrade_tests(pipecfg, stream, version, cosa, basearch, commit) {
     // The Fedora major is the first component of the provided version.
     def max_version = version.tokenize('.')[0] as Integer
 
+    // We decided that we won't test all iterations forever so we'll
+    // limit testing to the past 10 releases of Fedora.
+    // https://github.com/coreos/fedora-coreos-tracker/issues/2146
+    def n_minus_ten = max_version - 10
+    if (min_version < n_minus_ten) {
+        min_version = n_minus_ten
+    }
+
     // A list of all the start versions we want to run tests for
     def start_versions = []
 


### PR DESCRIPTION
We decided that we won't test all iterations forever so we'll
limit testing to the past 10 releases of Fedora.

See https://github.com/coreos/fedora-coreos-tracker/issues/2146


Also limit aarch64 testing to F35+ (see commit messsage). 