### PR TITLE
tmt: enforce fedora-44 compose.

### DIFF
--- a/tmt/plans/main.fmf
+++ b/tmt/plans/main.fmf
@@ -1,7 +1,7 @@
 adjust+:
   - when: arch == x86_64 or arch == aarch64
     provision:
-      image: Fedora-44
+      compose: Fedora-44
       hardware:
         cpu:
           processors: ">= 4"


### PR DESCRIPTION
This will make TMT to use a Fedora-44 (stable) as en environnement to run the tests instead of rawhide. This should be more stable. We are just creating VMs from within a COSA container anyway so let's have a stable base.

Ideally, this should be in sync with the Fedora release COSA is built on.