### PR TITLE
brew_upload: drop [-1] layer index from oc image extract

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -991,8 +991,8 @@ def brew_upload(arches, release, repo, manifest_digest, extensions_manifest_dige
         def extensions_node_image = "${repo}@${extensions_node_digest_arch_map[inspect_arch]}"
 
         // Get metadata files with package information
-        shwrap("""oc image extract $node_image[-1] --file /usr/share/openshift/base/meta.json
-                  oc image extract $extensions_node_image[-1] --file usr/share/rpm-ostree/extensions.json
+        shwrap("""oc image extract $node_image --file /usr/share/openshift/base/meta.json
+                  oc image extract $extensions_node_image --file usr/share/rpm-ostree/extensions.json
         """)
         shwrap("""
             coreos-assembler koji-upload \


### PR DESCRIPTION
## Summary

- Remove `[-1]` layer index from `oc image extract` calls in `brew_upload()` to fix Brew Upload failures caused by changed image layer ordering

## Problem

After [openshift/os#1946](https://github.com/openshift/os/pull/1946) merged (2026-07-29), all `build-node-image` runs for streams using the new commits fail at the Brew Upload stage:

```
FileNotFoundError: [Errno 2] No such file or directory: './meta.json'
```

The PR added a second `COPY --from=metadata /usr/share/buildinfo /usr/share/buildinfo` layer to the node image Containerfile. The `[-1]` index in `oc image extract` previously selected the last layer which contained `meta.json`. Now the last layer contains `buildinfo/labels.json` instead.

First failure: [build-node-image #7767](https://jenkins-rhcos--prod-pipeline.apps.int.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/build-node-image/7767/) (`[4.22-9.8]`)

## Fix

Drop `[-1]` from both `oc image extract` calls. The image references are already arch-specific digests resolved by `get_arch_image_digest()`, so no index selection is needed. Without `[-1]`, `oc image extract` searches the full merged image filesystem, which works regardless of layer ordering.

## Test plan

- [ ] Re-run `build-node-image` for `4.22-9.8` with this patch and verify Brew Upload succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)