### PR TITLE
jobs/build-mechanical: Increase cron frequency to every 12h

### DIFF
--- a/jobs/build-mechanical.Jenkinsfile
+++ b/jobs/build-mechanical.Jenkinsfile
@@ -7,8 +7,8 @@ node {
 
 properties([
     pipelineTriggers([
-        // run every 24h at 10:00 UTC
-        cron("0 10 * * *")
+        // run every 12h at 10:00 and 22:00 UTC
+        cron("0 10,22 * * *")
     ]),
     buildDiscarder(logRotator(
         numToKeepStr: '100',


### PR DESCRIPTION
Run the mechanical build every 12 hours (10:00 and 22:00 UTC) instead of once daily to catch issues sooner.