### PR TITLE
config: enable branched stream F45

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,8 +13,8 @@ streams:
   rawhide:
     type: development
     konflux_driven: true
-  # branched:
-  #   type: development
+  branched:
+    type: development
 
 additional_arches: [aarch64, ppc64le, s390x]
 


### PR DESCRIPTION
Fedora 45 has branched from rawhide and is now being tracked in branched.

See: https://github.com/coreos/fedora-coreos-tracker/issues/2127

---

Needs https://github.com/coreos/fedora-coreos-config/pull/4289 to merge first.