### PR TITLE
jobs/kola-upgrade: increase build history retention to 200

### DIFF
--- a/jobs/kola-upgrade.Jenkinsfile
+++ b/jobs/kola-upgrade.Jenkinsfile
@@ -32,8 +32,8 @@ properties([
              trim: true),
     ]),
     buildDiscarder(logRotator(
-        numToKeepStr: '100',
-        artifactNumToKeepStr: '100'
+        numToKeepStr: '200',
+        artifactNumToKeepStr: '200'
     )),
     durabilityHint('PERFORMANCE_OPTIMIZED')
 ])


### PR DESCRIPTION
`kola-upgrade` runs per-stream per-architecture so builds roll off quickly. Increase retention so results are still available during release verification.