### PR TITLE
NO-JIRA: Fix bootimage bump job when doing multiple bumps

### DIFF
--- a/jobs/bootimagebump.Jenkinsfile
+++ b/jobs/bootimagebump.Jenkinsfile
@@ -66,7 +66,7 @@ node {
         throw new Exception("Missing BUILD_VERSION parameter!")
     }
 
-    PR_BRANCH = "bootimage-bump-${params.BUILD_VERSION}"
+    PR_BRANCH = "bootimage-bump-${params.RELEASE_BRANCH}-${params.BUILD_VERSION}"
     streamSplit = params.STREAM.split('-')
     if (params.RELEASE_BRANCH != '') {
         RELEASE_BRANCH = params.RELEASE_BRANCH


### PR DESCRIPTION
When doing multiple bumps at same time, like 4.20 and 4.19 the job create a branch based in the build version. In case of releases that share the same rhel stream, the branch is updated on the last job run causing a conflict in the PR opened by the job. This fixes that issue by adding the release branch name sa part of the temporary branch created by the job.

for example:
4.20 bump job creates the branch bootimage-bump-9.6.20260818-0 tracking release-4.20
4.19 bump job uses the same branch name as 4.20 but points the track to release-4.19.
That causes a conflict as the branch was updated with 4.19 data. 
That happens because 4.20 and 4.19 latest released version of OCP has the same coreos version (in this case, 9.6.20260818-0).

This fix just add the release name in the branch name, making the branch unique for each release, ie:
bootimage-bump-release-4.20-9.6.20260818-0
bootimage-bump-release-4.19-9.6.20260818-0