### PR TITLE
config: enable branched stream 2026-08

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,8 +13,8 @@ streams:
   rawhide:
     type: development
     konflux_driven: true
-  # branched:
-  #   type: development
+  branched:
+    type: development
 
 additional_arches: [aarch64, ppc64le, s390x]
 


### PR DESCRIPTION
Fedora 45 branched from rawhide. Enable the branched stream to build Fedora 45 CoreOS.

See https://github.com/coreos/fedora-coreos-tracker/issues/2127