### PR TITLE
utils: signImages(): stop specifying gpgkeypath

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -795,7 +795,7 @@ def signImages(stream, version, basearch, s3_stream_dir, verify_only=false) {
         robosignatory --s3 ${s3_stream_dir}/builds \
         --aws-config-file \${AWS_BUILD_UPLOAD_CONFIG} \
         --extra-fedmsg-keys stream=${stream} \
-        --images ${verify_arg} --gpgkeypath /etc/pki/rpm-gpg \
+        --images ${verify_arg} \
         --fedmsg-conf \${FEDORA_MESSAGING_CONF}
     """)
 }


### PR DESCRIPTION
Just let the default get used. The default was changed in [1] and let's just use that in case it ever changes again.

[1] https://github.com/coreos/coreos-assembler/commit/2a26517b5e53d82f8fe11b537bd497829e72306f