### PR TITLE
jobs/build: Support importing Konflux artifacts

### DIFF
--- a/jobs/build.Jenkinsfile
+++ b/jobs/build.Jenkinsfile
@@ -21,6 +21,11 @@ properties([
              description: 'Override import_oci_image image to use. If set, the STREAM parameter must match the image labels.',
              defaultValue: "",
              trim: true),
+      string(name: 'IMPORT_ARTIFACTS',
+             description: "Space-separated list of disk image artifacts to download from the OCI image (e.g. qemu metal)." +
+                        " Requires IMPORT_OCI_IMAGE to be set.',
+             defaultValue: "",
+             trim: true),
       string(name: 'VERSION',
              description: 'Override default versioning mechanism',
              defaultValue: '',
@@ -133,6 +138,12 @@ boolean import_oci = import_oci_image != ""
 if (!import_oci && pipeutils.is_stream_konflux_driven(pipecfg, params.STREAM)) {
     error("STREAMS that are driven by Konflux must import an OCI image")
 }
+
+def import_artifacts = params.IMPORT_ARTIFACTS ?: ""
+if (import_artifacts && !import_oci) {
+    error("IMPORT_ARTIFACTS requires a value in IMPORT_OCI_IMAGE")
+}
+def imported_artifacts = import_artifacts ? import_artifacts.split() as List : []
 
 echo "Waiting for build-${params.STREAM} lock"
 currentBuild.description = "${build_description} Waiting"
@@ -353,7 +364,8 @@ lock(resource: "build-${params.STREAM}") {
         } else {
             stage("Import OCI image") {
                 echo "Skipping build : Importing OCI : $import_oci_image"
-                shwrap("cosa import docker://${import_oci_image} --skip-prune ${parent_arg}")
+                def download_arg = imported_artifacts ? "--download ${imported_artifacts.join(',')}" : ""
+                shwrap("cosa import docker://${import_oci_image} --skip-prune ${parent_arg} ${download_arg}")
                 def build_meta = readJSON(text: shwrapCapture("cosa meta --dump"))
                 def oci_stream = build_meta['coreos-assembler.oci-imported-labels']['com.coreos.stream'] ?: ''
                 if (params.STREAM != oci_stream) {
@@ -384,7 +396,7 @@ lock(resource: "build-${params.STREAM}") {
 
         // Build artifacts (including QEMU)
         stage("Build Artifacts") {
-            pipeutils.build_artifacts(pipecfg, params.STREAM, basearch, skip_untested_artifacts)
+            pipeutils.build_artifacts(pipecfg, params.STREAM, basearch, skip_untested_artifacts, imported_artifacts)
 
             // Stop the build if the kernel + kernel-rt versions do not match.
             // This check runs on x86_64 RHCOS builds only.

--- a/utils.groovy
+++ b/utils.groovy
@@ -459,10 +459,17 @@ def get_artifacts_to_build(pipecfg, stream, basearch, skip_untested) {
 }
 
 // Build all the artifacts requested from the pipeline config for this arch.
-def build_artifacts(pipecfg, stream, basearch, skip_untested) {
+// imported_artifacts: list of artifacts already imported (e.g. from OCI),
+// which should be skipped during the build.
+def build_artifacts(pipecfg, stream, basearch, skip_untested, imported_artifacts=[]) {
 
     // First get the list of artifacts to build from the config
     def artifacts = get_artifacts_to_build(pipecfg, stream, basearch, skip_untested)
+
+    // Remove any artifacts that were already imported (e.g. via cosa import --download)
+    if (imported_artifacts) {
+        artifacts.removeAll(imported_artifacts)
+    }
 
     // If `cosa osbuild` is supported then let's build what we can using OSBuild
     if (shwrapRc("cosa shell -- test -e /usr/lib/coreos-assembler/cmd-osbuild") == 0) {


### PR DESCRIPTION
Leverage the new `--download` flag in `cosa import` [1] to pull artifacts that may have been already built by the Konflux pipeline.

This will allow us to do a smooth transition as we onboard more artifacts in the Konflux pipeline.
Any already existing artifacts won't be rebuilt and the pipeline will jump straight to testing.

[1] https://github.com/coreos/coreos-assembler/commit/b2d4323668cb8d5f60b729745dbdba38092261cd.

Assisted-by: Opencode.ai <Opus 4.6>